### PR TITLE
feat(pkarr): M2 — openhost-pkarr adapter (codec, publisher, resolver, Nostr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,19 @@ once it reaches a tagged release.
   - `pkarr_record` module: `OpenhostRecord` schema, canonical deterministic signing bytes, and `SignedRecord::sign`/`verify` with 2-hour freshness window.
   - Reference JSON test vectors under `spec/test-vectors/` for every primitive, consumed by the crate's integration tests so the spec and implementation cannot drift.
   - End-to-end protocol exercise that walks spec §8 across all four modules.
+- `openhost-pkarr` M2 implementation:
+  - `codec` module: bidirectional translation between `SignedRecord` and `pkarr::SignedPacket`; a single `_openhost` TXT record carries `base64url(sig || canonical_signing_bytes)` and the outer BEP44 signature is produced by the same Ed25519 identity key.
+  - `publisher` module: 30-minute republish loop with an on-demand trigger channel, CAS-threaded seq handoff, and a `Transport` trait abstracting over `pkarr::Client` for testability.
+  - `resolver` module: wraps `pkarr::Client::resolve_most_recent` with openhost-layer validation (decode, ±1s timestamp-drift check, `SignedRecord::verify` for the 2-hour freshness window, and caller-supplied `cached_seq` monotonicity).
+  - `relays` module: bundled default Pkarr HTTP relay list (`pkarr.pubky.app`, `relay.iroh.network`).
+  - `nostr` module (feature-gated): pure envelope builder for the NIP-78 kind-30078 tertiary substrate. Publish path deferred to M3.
+  - Reference test vector `spec/test-vectors/pkarr_packet.json` pinning the full signed-packet bytes for the reference `SignedRecord`, with matching Rust round-trip integration test.
 
 ### Changed
 
 - Rust toolchain pinned to 1.90 (edition2024 dependencies require 1.85+).
 - Spec clarifications: public-key z-base-32 length is 52 characters (not 56); sealed-box construction is X25519 + XSalsa20-Poly1305 (libsodium-compatible), not XChaCha20-Poly1305.
+- `spec/01-wire-format.md §2`: the four-row textual Pkarr record table is replaced with a single opaque TXT record at `_openhost` carrying `base64url(signature || canonical_signing_bytes)`. Semantic fields are carried inside `canonical_signing_bytes` as defined by `openhost-core::pkarr_record`.
+- Workspace dependencies bumped to match the adapter: `pkarr = "5"` (was `"3"`), `mainline = "6"` (was `"4"`).
 
 [Unreleased]: https://github.com/kaicoder03/openhost/commits/main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,82 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-compat"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ba85bc55464dcbf728b56d97e119d673f4cf9062be330a9a26f3acf504a590"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -25,12 +98,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -43,10 +122,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -78,9 +202,28 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -88,6 +231,38 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -99,14 +274,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -118,7 +317,7 @@ dependencies = [
  "aead",
  "blake2",
  "crypto_secretbox",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "salsa20",
  "subtle",
  "zeroize",
@@ -148,8 +347,24 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a434aec7908df6ca86cda069864d7686aea8afad979aadc9e30e50ac3e40b45a"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.11.0-rc.9",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -172,9 +387,25 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "zeroize",
+]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -182,10 +413,52 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "digest"
+version = "0.11.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff8de092798697546237a3a701e4174fe021579faec9b854379af9bf1e31962"
+dependencies = [
+ "block-buffer 0.11.0",
+ "crypto-common 0.2.1",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -193,8 +466,18 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+dependencies = [
+ "pkcs8 0.11.0-rc.11",
+ "signature 3.0.0-rc.10",
 ]
 
 [[package]]
@@ -203,20 +486,187 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416904184c8542e5e4f6c052fdfb377164ab462706ce3a496641aa9ea6a1e172"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.5",
+ "ed25519 3.0.0-rc.4",
+ "serde",
+ "sha2 0.11.0-rc.4",
+ "signature 3.0.0-rc.10",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "generic-array"
@@ -236,9 +686,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -261,7 +763,240 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -274,10 +1009,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -286,10 +1115,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mainline"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a63308d09029a1530665c9f7c51707071d89486b173a41b1ca5768111c989f"
+dependencies = [
+ "crc",
+ "digest 0.11.0-rc.9",
+ "document-features",
+ "dyn-clone",
+ "ed25519-dalek 3.0.0-pre.5",
+ "flume",
+ "futures-lite",
+ "getrandom 0.4.2",
+ "lru",
+ "serde",
+ "serde_bencode",
+ "serde_bytes",
+ "sha1_smol",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ntimestamp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50f94c405726d3e0095e89e72f75ce7f6587b94a8bd8dc8054b73f65c0fd68c"
+dependencies = [
+ "base32",
+ "document-features",
+ "getrandom 0.2.17",
+ "httpdate",
+ "js-sys",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opaque-debug"
@@ -311,19 +1265,19 @@ dependencies = [
  "base64",
  "chacha20poly1305",
  "crypto_box",
- "curve25519-dalek",
- "ed25519-dalek",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek 2.2.0",
  "hex",
  "hkdf",
  "hmac",
- "rand",
- "rand_core",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
- "thiserror",
+ "thiserror 2.0.18",
  "x25519-dalek",
  "zbase32",
  "zeroize",
@@ -347,7 +1301,95 @@ dependencies = [
 name = "openhost-pkarr"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
+ "base64",
+ "ed25519-dalek 2.2.0",
+ "hex",
  "openhost-core",
+ "pkarr",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkarr"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bfb9143bbba379f246211eb68074d78db9cc048e4c5701f3b0e6cb1ec67ca2"
+dependencies = [
+ "async-compat",
+ "base32",
+ "bytes",
+ "cfg_aliases",
+ "document-features",
+ "dyn-clone",
+ "ed25519-dalek 3.0.0-pre.5",
+ "futures-buffered",
+ "futures-lite",
+ "getrandom 0.4.2",
+ "log",
+ "lru",
+ "mainline",
+ "ntimestamp",
+ "reqwest",
+ "self_cell",
+ "serde",
+ "sha1_smol",
+ "simple-dns",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -356,8 +1398,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -372,12 +1424,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -390,6 +1461,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,14 +1526,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -416,7 +1565,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -425,8 +1584,98 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -438,6 +1687,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +1775,65 @@ checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -460,6 +1849,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bencode"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70dfc7b7438b99896e7f8992363ab8e2c4ba26aa5ec675d32d1c3c2c33d413e"
+dependencies = [
+ "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -506,6 +1905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,7 +1918,43 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7535f94fa3339fe9e5e9be6260a909e62af97f6e14b32345ccf79b92b8b81233"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-rc.9",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -522,8 +1963,60 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+
+[[package]]
+name = "simple-dns"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df350943049174c4ae8ced56c604e28270258faec12a6a48637a7655287c9ce0"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -532,8 +2025,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "subtle"
@@ -553,12 +2062,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -573,6 +2122,190 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,14 +2318,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -601,10 +2370,511 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x25519-dalek"
@@ -612,10 +2882,33 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
- "rand_core",
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -645,6 +2938,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +2972,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,13 @@ rand = { version = "0.8", features = ["std_rng"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 # Protocol integrations (used by openhost-pkarr / -daemon at M2/M3)
-pkarr = "3"
-mainline = "4"
+pkarr = "5"
+mainline = "6"
 webrtc = "0.17"
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+async-trait = "0.1"
+tracing = "0.1"
 
 # Common utilities
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ pkarr = "5"
 mainline = "6"
 webrtc = "0.17"
 tokio = { version = "1", features = ["full"] }
-futures = "0.3"
 async-trait = "0.1"
 tracing = "0.1"
 

--- a/crates/openhost-pkarr/Cargo.toml
+++ b/crates/openhost-pkarr/Cargo.toml
@@ -11,5 +11,25 @@ readme.workspace = true
 [lib]
 path = "src/lib.rs"
 
+[features]
+default = []
+nostr = ["serde_json"]
+
 [dependencies]
 openhost-core = { path = "../openhost-core" }
+ed25519-dalek = { workspace = true }
+pkarr = { workspace = true }
+base64 = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+async-trait = { workspace = true }
+
+# Optional — only compiled under the `nostr` feature.
+serde_json = { workspace = true, optional = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+hex = { workspace = true }
+tokio = { workspace = true }

--- a/crates/openhost-pkarr/Cargo.toml
+++ b/crates/openhost-pkarr/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 
 [features]
 default = []
-nostr = ["serde_json"]
+nostr = ["serde_json", "hex"]
 
 [dependencies]
 openhost-core = { path = "../openhost-core" }
 ed25519-dalek = { workspace = true }
 pkarr = { workspace = true }
 base64 = { workspace = true }
-hex = { workspace = true }
+zeroize = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -28,6 +28,7 @@ async-trait = { workspace = true }
 
 # Optional — only compiled under the `nostr` feature.
 serde_json = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -78,9 +78,16 @@ pub fn encode(signed: &SignedRecord, signing_key: &SigningKey) -> Result<SignedP
 
     let name = Name::new_unchecked(OPENHOST_TXT_NAME);
     let txt = pkarr::dns::rdata::TXT::try_from(encoded.as_str())
-        .map_err(|e| PkarrError::MalformedCanonical(txt_build_err(e)))?;
+        .map_err(|e| PkarrError::TxtBuildFailed(e.to_string()))?;
 
-    let ts = Timestamp::from(signed.record.ts.saturating_mul(MICROS_PER_SECOND));
+    let ts_micros = signed
+        .record
+        .ts
+        .checked_mul(MICROS_PER_SECOND)
+        .ok_or(PkarrError::TimestampOverflow {
+            ts: signed.record.ts,
+        })?;
+    let ts = Timestamp::from(ts_micros);
 
     let packet = SignedPacket::builder()
         .txt(name, txt, OPENHOST_TXT_TTL)
@@ -101,15 +108,21 @@ pub fn encode(signed: &SignedRecord, signing_key: &SigningKey) -> Result<SignedP
 
 /// Decode a [`pkarr::SignedPacket`] back into a [`SignedRecord`].
 ///
+/// **Important: this function does NOT verify the inner Ed25519 signature.**
 /// Verification of the outer BEP44 signature has already happened inside the
-/// pkarr crate by the time a `SignedPacket` exists. The inner openhost
-/// signature is copied verbatim into the returned [`SignedRecord`]; callers
-/// (typically the resolver) are responsible for calling
-/// [`SignedRecord::verify`] with a `now_ts` to validate the openhost-layer
-/// freshness window.
+/// pkarr crate by the time a `SignedPacket` exists, but the inner openhost
+/// signature is copied verbatim into the returned [`SignedRecord`]. Callers
+/// (typically the resolver) **MUST** call [`SignedRecord::verify`] with a
+/// `now_ts` before trusting any field of the returned record.
+///
+/// `decode` does run `record.validate(record.ts)` to reject records whose
+/// schema invariants (empty `roles`, oversize `disc`, etc.) are violated;
+/// the `ts` passed there is the record's own `ts`, so the 2-hour freshness
+/// window is *not* enforced here. That still happens in `verify`.
 ///
 /// Returns [`PkarrError::MissingOpenhostRecord`] if no `_openhost` TXT record
-/// is present, and [`PkarrError::BlobTooShort`] if the decoded blob is shorter
+/// is present, [`PkarrError::MultipleOpenhostRecords`] if more than one is
+/// present, and [`PkarrError::BlobTooShort`] if the decoded blob is shorter
 /// than the 64-byte signature prefix.
 pub fn decode(packet: &SignedPacket) -> Result<SignedRecord> {
     let text = collect_openhost_txt(packet)?;
@@ -143,12 +156,19 @@ pub fn packet_public_key(packet: &SignedPacket) -> Result<PublicKey> {
 }
 
 fn collect_openhost_txt(packet: &SignedPacket) -> Result<String> {
-    let mut saw_any = false;
+    let mut seen_txt = 0usize;
     let mut out = String::new();
 
     for rr in packet.resource_records(OPENHOST_TXT_NAME) {
-        saw_any = true;
         if let pkarr::dns::rdata::RData::TXT(txt) = &rr.rdata {
+            seen_txt += 1;
+            if seen_txt > 1 {
+                // More than one TXT RR at `_openhost`. The spec mandates
+                // exactly one; concatenating would yield a base64url blob
+                // that almost certainly wouldn't decode, but fail loudly so
+                // a misconfigured publisher is easy to diagnose.
+                return Err(PkarrError::MultipleOpenhostRecords);
+            }
             for (key, value) in txt.iter_raw() {
                 out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
                 if let Some(v) = value {
@@ -159,15 +179,11 @@ fn collect_openhost_txt(packet: &SignedPacket) -> Result<String> {
         }
     }
 
-    if !saw_any {
+    if seen_txt == 0 {
         return Err(PkarrError::MissingOpenhostRecord);
     }
 
     Ok(out)
-}
-
-fn txt_build_err(_e: pkarr::dns::SimpleDnsError) -> &'static str {
-    "failed to build _openhost TXT record"
 }
 
 /// Inverse of [`OpenhostRecord::canonical_signing_bytes`].
@@ -312,33 +328,15 @@ impl<'a> Cursor<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openhost_core::crypto::allowlist_hash;
-    use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
-    };
+    use crate::test_support::{sample_record, RFC_SEED};
 
-    const RFC_SEED: [u8; 32] = [
-        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
-        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
-        0x7f, 0x60,
-    ];
-
+    /// Codec-flavoured reference record — distinct from the shared
+    /// [`sample_record`] in that `disc` is non-empty, giving the encoded
+    /// canonical bytes a non-trivial UTF-8 segment to exercise.
     fn reference_record() -> OpenhostRecord {
-        let salt = [0x11u8; SALT_LEN];
-        let client_pk = [0xAAu8; 32];
-        let hash = allowlist_hash(&salt, &client_pk);
         OpenhostRecord {
-            version: PROTOCOL_VERSION,
-            ts: 1_700_000_000,
-            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
-            roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
             disc: "dht=1; relay=pkarr.example".to_string(),
+            ..sample_record(1_700_000_000)
         }
     }
 
@@ -420,6 +418,29 @@ mod tests {
         assert!(matches!(
             decode(&packet),
             Err(PkarrError::BlobTooShort { .. })
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_multiple_openhost_records() {
+        let keypair = Keypair::from_secret_key(&RFC_SEED);
+        let packet = SignedPacket::builder()
+            .txt(
+                Name::new_unchecked(OPENHOST_TXT_NAME),
+                pkarr::dns::rdata::TXT::try_from("AAA").unwrap(),
+                OPENHOST_TXT_TTL,
+            )
+            .txt(
+                Name::new_unchecked(OPENHOST_TXT_NAME),
+                pkarr::dns::rdata::TXT::try_from("BBB").unwrap(),
+                OPENHOST_TXT_TTL,
+            )
+            .sign(&keypair)
+            .unwrap();
+
+        assert!(matches!(
+            decode(&packet),
+            Err(PkarrError::MultipleOpenhostRecords)
         ));
     }
 

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -1,0 +1,445 @@
+//! Translate between [`openhost_core::pkarr_record::SignedRecord`] and the
+//! [`pkarr::SignedPacket`] DNS-packet form.
+//!
+//! Encoding: a single TXT resource record at name `_openhost` whose value is
+//! `base64url(signature || canonical_signing_bytes)`, where `signature` is the
+//! 64-byte Ed25519 signature from `SignedRecord::signature` and
+//! `canonical_signing_bytes` is the deterministic byte string defined by
+//! [`openhost_core::pkarr_record::OpenhostRecord::canonical_signing_bytes`].
+//!
+//! The outer BEP44 signature on the `SignedPacket` is produced by the same
+//! Ed25519 identity key — no separate keys are used — via
+//! [`pkarr::Keypair::from_secret_key`] over the 32-byte seed of the openhost
+//! signing key.
+//!
+//! The canonical byte layout is frozen in M1 (see
+//! `crates/openhost-core/src/pkarr_record/mod.rs`). The decoder in this file
+//! parses it back into an `OpenhostRecord` without touching the `openhost-core`
+//! public API.
+//!
+//! See `spec/01-wire-format.md §2` and `spec/test-vectors/pkarr_packet.json`.
+
+use crate::error::{PkarrError, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ed25519_dalek::Signature;
+use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN, SIGNING_KEY_LEN};
+use openhost_core::pkarr_record::{
+    IceBlob, OpenhostRecord, SignedRecord, ALLOW_ENTRY_LEN, CLIENT_HASH_LEN, DTLS_FINGERPRINT_LEN,
+    MAX_DISC_LEN, PROTOCOL_VERSION, SALT_LEN,
+};
+use pkarr::dns::Name;
+use pkarr::{Keypair, SignedPacket, Timestamp};
+
+/// The TXT record name at which the encoded openhost blob is stored.
+pub const OPENHOST_TXT_NAME: &str = "_openhost";
+
+/// The TTL (in seconds) used for the `_openhost` TXT record.
+///
+/// 300 matches `pkarr::DEFAULT_MINIMUM_TTL`: clients refresh at least every five
+/// minutes, well inside the 30-minute republish cadence required by
+/// `spec/03-pkarr-records.md §1`.
+pub const OPENHOST_TXT_TTL: u32 = 300;
+
+/// The per-microsecond multiplier used to convert openhost seconds to pkarr
+/// [`Timestamp`] values.
+pub const MICROS_PER_SECOND: u64 = 1_000_000;
+
+/// The 64-byte Ed25519 signature prefix at the front of the `_openhost` blob.
+const SIGNATURE_LEN: usize = 64;
+
+/// The BEP44 mutable-item payload limit (`v` field) enforced by the Mainline
+/// DHT. The openhost-core canonical form is ~230 bytes for the reference vector;
+/// the BEP44 limit is the tight constraint for records with many paired clients.
+pub const BEP44_MAX_V_BYTES: usize = 1000;
+
+/// Encode a [`SignedRecord`] into a [`pkarr::SignedPacket`].
+///
+/// The `SignedPacket`'s outer BEP44 signature is produced from `signing_key`'s
+/// raw seed; the inner openhost signature inside the `_openhost` TXT record is
+/// whatever was already present on `signed`. The caller is responsible for
+/// ensuring they match (i.e. the same `SigningKey` was used to produce
+/// `signed.signature`).
+///
+/// The pkarr packet's timestamp is set from `signed.record.ts * 1_000_000` so
+/// BEP44 `seq` equals the record's Unix-seconds timestamp, as required by
+/// `spec/03-pkarr-records.md §1`.
+pub fn encode(signed: &SignedRecord, signing_key: &SigningKey) -> Result<SignedPacket> {
+    let canonical = signed.record.canonical_signing_bytes()?;
+    let mut blob = Vec::with_capacity(SIGNATURE_LEN + canonical.len());
+    blob.extend_from_slice(&signed.signature.to_bytes());
+    blob.extend_from_slice(&canonical);
+
+    let encoded = URL_SAFE_NO_PAD.encode(&blob);
+
+    let seed: [u8; SIGNING_KEY_LEN] = signing_key.to_bytes();
+    let keypair = Keypair::from_secret_key(&seed);
+
+    let name = Name::new_unchecked(OPENHOST_TXT_NAME);
+    let txt = pkarr::dns::rdata::TXT::try_from(encoded.as_str())
+        .map_err(|e| PkarrError::MalformedCanonical(txt_build_err(e)))?;
+
+    let ts = Timestamp::from(signed.record.ts.saturating_mul(MICROS_PER_SECOND));
+
+    let packet = SignedPacket::builder()
+        .txt(name, txt, OPENHOST_TXT_TTL)
+        .timestamp(ts)
+        .sign(&keypair)?;
+
+    // The pkarr crate's own 1000-byte check lives behind `SignedPacket::new`,
+    // but only over the encoded DNS packet. Re-assert it against
+    // `encoded_packet()` so the error flows through our typed enum.
+    if packet.encoded_packet().len() > BEP44_MAX_V_BYTES {
+        return Err(PkarrError::PacketTooLarge {
+            size: packet.encoded_packet().len(),
+        });
+    }
+
+    Ok(packet)
+}
+
+/// Decode a [`pkarr::SignedPacket`] back into a [`SignedRecord`].
+///
+/// Verification of the outer BEP44 signature has already happened inside the
+/// pkarr crate by the time a `SignedPacket` exists. The inner openhost
+/// signature is copied verbatim into the returned [`SignedRecord`]; callers
+/// (typically the resolver) are responsible for calling
+/// [`SignedRecord::verify`] with a `now_ts` to validate the openhost-layer
+/// freshness window.
+///
+/// Returns [`PkarrError::MissingOpenhostRecord`] if no `_openhost` TXT record
+/// is present, and [`PkarrError::BlobTooShort`] if the decoded blob is shorter
+/// than the 64-byte signature prefix.
+pub fn decode(packet: &SignedPacket) -> Result<SignedRecord> {
+    let text = collect_openhost_txt(packet)?;
+    let blob = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
+
+    if blob.len() < SIGNATURE_LEN {
+        return Err(PkarrError::BlobTooShort {
+            got: blob.len(),
+            min: SIGNATURE_LEN,
+        });
+    }
+
+    let mut sig_bytes = [0u8; SIGNATURE_LEN];
+    sig_bytes.copy_from_slice(&blob[..SIGNATURE_LEN]);
+    let signature = Signature::from_bytes(&sig_bytes);
+
+    let record = parse_canonical_bytes(&blob[SIGNATURE_LEN..])?;
+
+    Ok(SignedRecord { record, signature })
+}
+
+/// The 32-byte Ed25519 public key carried in the BEP44 header of `packet`,
+/// converted to an [`openhost_core::identity::PublicKey`].
+///
+/// Useful to callers that want to cross-check the decoded record against the
+/// packet's outer public key.
+pub fn packet_public_key(packet: &SignedPacket) -> Result<PublicKey> {
+    let bytes: [u8; PUBLIC_KEY_LEN] = *packet.public_key().as_bytes();
+    PublicKey::from_bytes(&bytes).map_err(Into::into)
+}
+
+fn collect_openhost_txt(packet: &SignedPacket) -> Result<String> {
+    let mut saw_any = false;
+    let mut out = String::new();
+
+    for rr in packet.resource_records(OPENHOST_TXT_NAME) {
+        saw_any = true;
+        if let pkarr::dns::rdata::RData::TXT(txt) = &rr.rdata {
+            for (key, value) in txt.iter_raw() {
+                out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+                if let Some(v) = value {
+                    out.push('=');
+                    out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+                }
+            }
+        }
+    }
+
+    if !saw_any {
+        return Err(PkarrError::MissingOpenhostRecord);
+    }
+
+    Ok(out)
+}
+
+fn txt_build_err(_e: pkarr::dns::SimpleDnsError) -> &'static str {
+    "failed to build _openhost TXT record"
+}
+
+/// Inverse of [`OpenhostRecord::canonical_signing_bytes`].
+///
+/// Keeps strict parity with the layout documented at
+/// `crates/openhost-core/src/pkarr_record/mod.rs:122-138`. Changes to that
+/// layout require a coordinated update here.
+fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
+    let mut r = Cursor::new(bytes);
+
+    let tag = r.u8()?;
+    if tag != 0x01 {
+        return Err(PkarrError::MalformedCanonical("unknown encoding tag"));
+    }
+
+    let domain = r.take(9)?;
+    if domain != b"openhost1" {
+        return Err(PkarrError::MalformedCanonical(
+            "missing openhost1 domain separator",
+        ));
+    }
+
+    let version = r.u8()?;
+    if version != PROTOCOL_VERSION {
+        return Err(PkarrError::MalformedCanonical(
+            "unsupported protocol version",
+        ));
+    }
+
+    let ts = r.u64_be()?;
+
+    let mut dtls_fp = [0u8; DTLS_FINGERPRINT_LEN];
+    dtls_fp.copy_from_slice(r.take(DTLS_FINGERPRINT_LEN)?);
+
+    let roles_len = r.u8()? as usize;
+    let roles_bytes = r.take(roles_len)?;
+    let roles = core::str::from_utf8(roles_bytes)
+        .map_err(|_| PkarrError::MalformedCanonical("roles is not valid UTF-8"))?
+        .to_string();
+
+    let mut salt = [0u8; SALT_LEN];
+    salt.copy_from_slice(r.take(SALT_LEN)?);
+
+    let allow_count = r.u16_be()? as usize;
+    let mut allow = Vec::with_capacity(allow_count);
+    for _ in 0..allow_count {
+        let mut entry = [0u8; ALLOW_ENTRY_LEN];
+        entry.copy_from_slice(r.take(ALLOW_ENTRY_LEN)?);
+        allow.push(entry);
+    }
+
+    let ice_count = r.u16_be()? as usize;
+    let mut ice = Vec::with_capacity(ice_count);
+    for _ in 0..ice_count {
+        let client_hash = r.take(CLIENT_HASH_LEN)?.to_vec();
+        let ct_len = r.u32_be()? as usize;
+        let ciphertext = r.take(ct_len)?.to_vec();
+        ice.push(IceBlob {
+            client_hash,
+            ciphertext,
+        });
+    }
+
+    let disc_len = r.u16_be()? as usize;
+    if disc_len > MAX_DISC_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "disc length exceeds maximum",
+        ));
+    }
+    let disc_bytes = r.take(disc_len)?;
+    let disc = core::str::from_utf8(disc_bytes)
+        .map_err(|_| PkarrError::MalformedCanonical("disc is not valid UTF-8"))?
+        .to_string();
+
+    if !r.is_empty() {
+        return Err(PkarrError::MalformedCanonical(
+            "trailing bytes after canonical record",
+        ));
+    }
+
+    Ok(OpenhostRecord {
+        version,
+        ts,
+        dtls_fp,
+        roles,
+        salt,
+        allow,
+        ice,
+        disc,
+    })
+}
+
+struct Cursor<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Result<&'a [u8]> {
+        let end = self
+            .pos
+            .checked_add(n)
+            .ok_or(PkarrError::MalformedCanonical("length overflow"))?;
+        if end > self.buf.len() {
+            return Err(PkarrError::MalformedCanonical("truncated canonical record"));
+        }
+        let out = &self.buf[self.pos..end];
+        self.pos = end;
+        Ok(out)
+    }
+
+    fn u8(&mut self) -> Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16_be(&mut self) -> Result<u16> {
+        let b = self.take(2)?;
+        Ok(u16::from_be_bytes([b[0], b[1]]))
+    }
+
+    fn u32_be(&mut self) -> Result<u32> {
+        let b = self.take(4)?;
+        Ok(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    fn u64_be(&mut self) -> Result<u64> {
+        let b = self.take(8)?;
+        Ok(u64::from_be_bytes([
+            b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+        ]))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pos >= self.buf.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::crypto::allowlist_hash;
+    use openhost_core::pkarr_record::{
+        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+    };
+
+    const RFC_SEED: [u8; 32] = [
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
+        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
+        0x7f, 0x60,
+    ];
+
+    fn reference_record() -> OpenhostRecord {
+        let salt = [0x11u8; SALT_LEN];
+        let client_pk = [0xAAu8; 32];
+        let hash = allowlist_hash(&salt, &client_pk);
+        OpenhostRecord {
+            version: PROTOCOL_VERSION,
+            ts: 1_700_000_000,
+            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
+            roles: "server".to_string(),
+            salt,
+            allow: vec![hash],
+            ice: vec![IceBlob {
+                client_hash: hash.to_vec(),
+                ciphertext: vec![0xEE; 72],
+            }],
+            disc: "dht=1; relay=pkarr.example".to_string(),
+        }
+    }
+
+    #[test]
+    fn round_trip_preserves_record_and_signature() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let record = reference_record();
+        let signed = SignedRecord::sign(record.clone(), &sk).unwrap();
+
+        let packet = encode(&signed, &sk).unwrap();
+        let decoded = decode(&packet).unwrap();
+
+        assert_eq!(decoded.record, record);
+        assert_eq!(decoded.signature.to_bytes(), signed.signature.to_bytes());
+    }
+
+    #[test]
+    fn packet_public_key_matches_signing_identity() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let pk = sk.public_key();
+        let signed = SignedRecord::sign(reference_record(), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+
+        assert_eq!(packet_public_key(&packet).unwrap(), pk);
+    }
+
+    #[test]
+    fn decoded_signature_verifies_against_identity_pubkey() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let pk = sk.public_key();
+        let signed = SignedRecord::sign(reference_record(), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+        let decoded = decode(&packet).unwrap();
+
+        decoded.verify(&pk, decoded.record.ts).expect("verifies");
+    }
+
+    #[test]
+    fn packet_timestamp_is_record_ts_in_micros() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let signed = SignedRecord::sign(reference_record(), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+
+        let packet_ts_micros: u64 = packet.timestamp().into();
+        assert_eq!(packet_ts_micros, signed.record.ts * MICROS_PER_SECOND);
+    }
+
+    #[test]
+    fn decode_rejects_missing_openhost_record() {
+        let keypair = Keypair::from_secret_key(&RFC_SEED);
+        let packet = SignedPacket::builder()
+            .txt(
+                Name::new_unchecked("_other"),
+                pkarr::dns::rdata::TXT::try_from("hello").unwrap(),
+                OPENHOST_TXT_TTL,
+            )
+            .sign(&keypair)
+            .unwrap();
+
+        assert!(matches!(
+            decode(&packet),
+            Err(PkarrError::MissingOpenhostRecord)
+        ));
+    }
+
+    #[test]
+    fn decode_rejects_too_short_blob() {
+        let keypair = Keypair::from_secret_key(&RFC_SEED);
+        let short = URL_SAFE_NO_PAD.encode([0u8; 16]);
+        let packet = SignedPacket::builder()
+            .txt(
+                Name::new_unchecked(OPENHOST_TXT_NAME),
+                pkarr::dns::rdata::TXT::try_from(short.as_str()).unwrap(),
+                OPENHOST_TXT_TTL,
+            )
+            .sign(&keypair)
+            .unwrap();
+
+        assert!(matches!(
+            decode(&packet),
+            Err(PkarrError::BlobTooShort { .. })
+        ));
+    }
+
+    #[test]
+    fn packet_too_large_is_rejected() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let mut record = reference_record();
+        // Pad `ice` with many large blobs until the encoded packet breaches the
+        // 1000-byte BEP44 limit.
+        record.ice = (0..30)
+            .map(|i| IceBlob {
+                client_hash: vec![i as u8; CLIENT_HASH_LEN],
+                ciphertext: vec![0xEE; 200],
+            })
+            .collect();
+        let signed = SignedRecord::sign(record, &sk).unwrap();
+
+        let err = encode(&signed, &sk).unwrap_err();
+        // Either our own PacketTooLarge, or pkarr's own Build error raised during sign.
+        assert!(matches!(
+            err,
+            PkarrError::PacketTooLarge { .. } | PkarrError::Build(_)
+        ));
+    }
+}

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -23,13 +23,14 @@ use crate::error::{PkarrError, Result};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use ed25519_dalek::Signature;
-use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN, SIGNING_KEY_LEN};
+use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN};
 use openhost_core::pkarr_record::{
     IceBlob, OpenhostRecord, SignedRecord, ALLOW_ENTRY_LEN, CLIENT_HASH_LEN, DTLS_FINGERPRINT_LEN,
     MAX_DISC_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
 use pkarr::dns::Name;
 use pkarr::{Keypair, SignedPacket, Timestamp};
+use zeroize::Zeroizing;
 
 /// The TXT record name at which the encoded openhost blob is stored.
 pub const OPENHOST_TXT_NAME: &str = "_openhost";
@@ -72,7 +73,7 @@ pub fn encode(signed: &SignedRecord, signing_key: &SigningKey) -> Result<SignedP
 
     let encoded = URL_SAFE_NO_PAD.encode(&blob);
 
-    let seed: [u8; SIGNING_KEY_LEN] = signing_key.to_bytes();
+    let seed = Zeroizing::new(signing_key.to_bytes());
     let keypair = Keypair::from_secret_key(&seed);
 
     let name = Name::new_unchecked(OPENHOST_TXT_NAME);
@@ -126,6 +127,7 @@ pub fn decode(packet: &SignedPacket) -> Result<SignedRecord> {
     let signature = Signature::from_bytes(&sig_bytes);
 
     let record = parse_canonical_bytes(&blob[SIGNATURE_LEN..])?;
+    record.validate(record.ts)?;
 
     Ok(SignedRecord { record, signature })
 }
@@ -419,6 +421,23 @@ mod tests {
             decode(&packet),
             Err(PkarrError::BlobTooShort { .. })
         ));
+    }
+
+    #[test]
+    fn bep44_sig_flip_fails_deserialization() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let signed = SignedRecord::sign(reference_record(), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+
+        // as_bytes() layout: [0..32]=pk  [32..96]=BEP44-sig  [96..104]=ts  [104..]=DNS
+        let mut wire = packet.as_bytes().to_vec();
+        wire[32] ^= 0xFF; // flip first byte of the BEP44 Ed25519 signature
+
+        // pkarr rejects the tampered bytes before we even get to decode().
+        assert!(
+            SignedPacket::deserialize(&wire).is_err(),
+            "tampered BEP44 sig must fail pkarr deserialization"
+        );
     }
 
     #[test]

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -80,13 +80,14 @@ pub fn encode(signed: &SignedRecord, signing_key: &SigningKey) -> Result<SignedP
     let txt = pkarr::dns::rdata::TXT::try_from(encoded.as_str())
         .map_err(|e| PkarrError::TxtBuildFailed(e.to_string()))?;
 
-    let ts_micros = signed
-        .record
-        .ts
-        .checked_mul(MICROS_PER_SECOND)
-        .ok_or(PkarrError::TimestampOverflow {
-            ts: signed.record.ts,
-        })?;
+    let ts_micros =
+        signed
+            .record
+            .ts
+            .checked_mul(MICROS_PER_SECOND)
+            .ok_or(PkarrError::TimestampOverflow {
+                ts: signed.record.ts,
+            })?;
     let ts = Timestamp::from(ts_micros);
 
     let packet = SignedPacket::builder()

--- a/crates/openhost-pkarr/src/error.rs
+++ b/crates/openhost-pkarr/src/error.rs
@@ -85,4 +85,8 @@ pub enum PkarrError {
     /// a compare-and-swap conflict rejected the write).
     #[error("pkarr publish error: {0}")]
     Publish(#[from] pkarr::errors::PublishError),
+
+    /// The openhost `PublicKey` could not be converted to a pkarr `PublicKey`.
+    #[error("failed to convert openhost public key to pkarr public key")]
+    PublicKeyConversion,
 }

--- a/crates/openhost-pkarr/src/error.rs
+++ b/crates/openhost-pkarr/src/error.rs
@@ -1,0 +1,88 @@
+//! Errors raised by `openhost-pkarr`.
+
+use thiserror::Error;
+
+/// Crate-wide result alias.
+pub type Result<T> = core::result::Result<T, PkarrError>;
+
+/// Errors raised by the `openhost-pkarr` adapter.
+#[derive(Debug, Error)]
+pub enum PkarrError {
+    /// The openhost-core layer reported an error (record validation, signing,
+    /// canonical encoding).
+    #[error(transparent)]
+    Core(#[from] openhost_core::Error),
+
+    /// The upstream pkarr crate failed to build a `SignedPacket` from the records
+    /// we supplied.
+    #[error("pkarr build error: {0}")]
+    Build(#[from] pkarr::errors::SignedPacketBuildError),
+
+    /// The upstream pkarr crate rejected a serialized packet.
+    #[error("pkarr verify error: {0}")]
+    Verify(#[from] pkarr::errors::SignedPacketVerifyError),
+
+    /// The DNS packet produced by the encoder exceeded the 1000-byte BEP44
+    /// mutable-item payload limit.
+    #[error("signed packet payload is {size} bytes, exceeding the BEP44 1000-byte limit")]
+    PacketTooLarge {
+        /// Size of the encoded packet payload.
+        size: usize,
+    },
+
+    /// The decoded `_openhost` TXT blob was shorter than the minimum 64-byte
+    /// signature prefix.
+    #[error("_openhost blob is {got} bytes, expected at least {min}")]
+    BlobTooShort {
+        /// Number of bytes actually present.
+        got: usize,
+        /// Minimum number of bytes required (64 for the signature prefix).
+        min: usize,
+    },
+
+    /// The `_openhost` TXT record was missing from the packet.
+    #[error("signed packet is missing the `_openhost` TXT record")]
+    MissingOpenhostRecord,
+
+    /// The base64url payload of the `_openhost` TXT record failed to decode.
+    #[error("failed to base64url-decode the _openhost blob: {0}")]
+    Base64(#[from] base64::DecodeError),
+
+    /// The packet's BEP44 timestamp (in seconds) disagrees with the openhost
+    /// record's internal `ts` field beyond the permitted 1-second drift.
+    #[error("pkarr timestamp {packet_ts} drifts more than 1s from record.ts {record_ts}")]
+    TimestampDrift {
+        /// Timestamp reported by the pkarr packet header (seconds).
+        packet_ts: u64,
+        /// Timestamp embedded inside the openhost record (seconds).
+        record_ts: u64,
+    },
+
+    /// The resolver was given a cached `seq` that is newer than what the
+    /// substrate returned — the record has gone backwards.
+    #[error("seq regression: record.ts={record_ts} < cached_seq={cached_seq}")]
+    SeqRegression {
+        /// Sequence number (record.ts) of the returned packet.
+        record_ts: u64,
+        /// Sequence number last observed by the caller.
+        cached_seq: u64,
+    },
+
+    /// No substrate returned a packet for the requested public key.
+    #[error("no signed packet found for the requested public key")]
+    NotFound,
+
+    /// The trailing canonical bytes inside the `_openhost` blob failed to parse
+    /// into an `OpenhostRecord`.
+    #[error("canonical bytes are malformed: {0}")]
+    MalformedCanonical(&'static str),
+
+    /// A TXT record we parsed was not valid UTF-8.
+    #[error("TXT record is not valid UTF-8")]
+    InvalidUtf8,
+
+    /// An upstream pkarr publish failed (relays + DHT all reported errors or
+    /// a compare-and-swap conflict rejected the write).
+    #[error("pkarr publish error: {0}")]
+    Publish(#[from] pkarr::errors::PublishError),
+}

--- a/crates/openhost-pkarr/src/error.rs
+++ b/crates/openhost-pkarr/src/error.rs
@@ -89,4 +89,26 @@ pub enum PkarrError {
     /// The openhost `PublicKey` could not be converted to a pkarr `PublicKey`.
     #[error("failed to convert openhost public key to pkarr public key")]
     PublicKeyConversion,
+
+    /// More than one `_openhost` TXT record was present in the packet. Each
+    /// packet **MUST** carry exactly one.
+    #[error("signed packet contains more than one `_openhost` TXT record")]
+    MultipleOpenhostRecords,
+
+    /// `record.ts` (in seconds) overflowed `u64` when converted to pkarr
+    /// microseconds. Only triggers past year ~586,000 AD; here purely as
+    /// defense-in-depth against silent wraparound.
+    #[error("record.ts={ts} overflows when converted to microseconds")]
+    TimestampOverflow {
+        /// The original `record.ts` in seconds.
+        ts: u64,
+    },
+
+    /// The upstream `pkarr::dns` crate failed to build a TXT record from the
+    /// encoded openhost blob. In practice this only fires if a character
+    /// string would exceed 255 bytes, which should not happen under the
+    /// BEP44 1000-byte ceiling — if it does, the cause is preserved here for
+    /// diagnosis.
+    #[error("failed to build _openhost TXT record: {0}")]
+    TxtBuildFailed(String),
 }

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -11,16 +11,22 @@
 //!
 //! - [`codec`] — translate between
 //!   [`openhost_core::pkarr_record::SignedRecord`] and [`pkarr::SignedPacket`].
+//! - [`publisher`] — sign + encode + fan out to relays and the Mainline DHT on
+//!   a 30-minute republish schedule.
+//! - [`relays`] — bundled default list of public Pkarr HTTP relays.
 //! - [`error`] — crate-wide error type.
-//!
-//! Additional modules (`publisher`, `resolver`, `relays`, optional `nostr`) are
-//! added in subsequent M2 commits.
 
 pub mod codec;
 pub mod error;
+pub mod publisher;
+pub mod relays;
 
 pub use codec::{
     decode, encode, packet_public_key, BEP44_MAX_V_BYTES, MICROS_PER_SECOND, OPENHOST_TXT_NAME,
     OPENHOST_TXT_TTL,
 };
 pub use error::{PkarrError, Result};
+pub use publisher::{
+    PkarrTransport, Publisher, PublisherHandle, RecordSource, Transport, REPUBLISH_INTERVAL,
+};
+pub use relays::DEFAULT_RELAYS;

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -16,10 +16,14 @@
 //! - [`resolver`] — race relays + DHT, decode, verify freshness and
 //!   `seq` monotonicity.
 //! - [`relays`] — bundled default list of public Pkarr HTTP relays.
+//! - `nostr` (feature `nostr`) — optional NIP-78 envelope builder for the
+//!   tertiary Nostr substrate. Envelope-only; no WebSocket publish.
 //! - [`error`] — crate-wide error type.
 
 pub mod codec;
 pub mod error;
+#[cfg(feature = "nostr")]
+pub mod nostr;
 pub mod publisher;
 pub mod relays;
 pub mod resolver;

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -28,6 +28,9 @@ pub mod publisher;
 pub mod relays;
 pub mod resolver;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub use codec::{
     decode, encode, packet_public_key, BEP44_MAX_V_BYTES, MICROS_PER_SECOND, OPENHOST_TXT_NAME,
     OPENHOST_TXT_TTL,

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -13,6 +13,8 @@
 //!   [`openhost_core::pkarr_record::SignedRecord`] and [`pkarr::SignedPacket`].
 //! - [`publisher`] — sign + encode + fan out to relays and the Mainline DHT on
 //!   a 30-minute republish schedule.
+//! - [`resolver`] — race relays + DHT, decode, verify freshness and
+//!   `seq` monotonicity.
 //! - [`relays`] — bundled default list of public Pkarr HTTP relays.
 //! - [`error`] — crate-wide error type.
 
@@ -20,6 +22,7 @@ pub mod codec;
 pub mod error;
 pub mod publisher;
 pub mod relays;
+pub mod resolver;
 
 pub use codec::{
     decode, encode, packet_public_key, BEP44_MAX_V_BYTES, MICROS_PER_SECOND, OPENHOST_TXT_NAME,
@@ -30,3 +33,4 @@ pub use publisher::{
     PkarrTransport, Publisher, PublisherHandle, RecordSource, Transport, REPUBLISH_INTERVAL,
 };
 pub use relays::DEFAULT_RELAYS;
+pub use resolver::{PkarrResolve, Resolve, Resolver};

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -1,7 +1,26 @@
 #![deny(unsafe_code)]
 #![warn(missing_docs)]
+#![warn(clippy::all)]
+
 //! Pkarr integration for openhost.
 //!
 //! Wraps the upstream `pkarr` crate with openhost-specific record schemas,
 //! relay/DHT fan-out, and (optional) Nostr tertiary-substrate publishing.
-//! Populated in M2.
+//!
+//! Module map:
+//!
+//! - [`codec`] — translate between
+//!   [`openhost_core::pkarr_record::SignedRecord`] and [`pkarr::SignedPacket`].
+//! - [`error`] — crate-wide error type.
+//!
+//! Additional modules (`publisher`, `resolver`, `relays`, optional `nostr`) are
+//! added in subsequent M2 commits.
+
+pub mod codec;
+pub mod error;
+
+pub use codec::{
+    decode, encode, packet_public_key, BEP44_MAX_V_BYTES, MICROS_PER_SECOND, OPENHOST_TXT_NAME,
+    OPENHOST_TXT_TTL,
+};
+pub use error::{PkarrError, Result};

--- a/crates/openhost-pkarr/src/nostr.rs
+++ b/crates/openhost-pkarr/src/nostr.rs
@@ -59,35 +59,11 @@ pub fn build_event(signed: &SignedRecord, signing_key: &SigningKey) -> Result<Va
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openhost_core::crypto::allowlist_hash;
-    use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
-    };
-
-    const RFC_SEED: [u8; 32] = [
-        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
-        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
-        0x7f, 0x60,
-    ];
+    use crate::test_support::{sample_record, RFC_SEED};
 
     fn sample_signed() -> (SigningKey, SignedRecord) {
         let sk = SigningKey::from_bytes(&RFC_SEED);
-        let salt = [0x11u8; SALT_LEN];
-        let hash = allowlist_hash(&salt, &[0xAA; 32]);
-        let record = OpenhostRecord {
-            version: PROTOCOL_VERSION,
-            ts: 1_700_000_000,
-            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
-            roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
-            disc: String::new(),
-        };
-        let signed = SignedRecord::sign(record, &sk).unwrap();
+        let signed = SignedRecord::sign(sample_record(1_700_000_000), &sk).unwrap();
         (sk, signed)
     }
 

--- a/crates/openhost-pkarr/src/nostr.rs
+++ b/crates/openhost-pkarr/src/nostr.rs
@@ -1,0 +1,145 @@
+//! Optional Nostr tertiary-substrate publishing (envelope construction only).
+//!
+//! Builds the NIP-78 kind-30078 parameterized-replaceable event that wraps an
+//! already-encoded [`pkarr::SignedPacket`] for broadcast over public Nostr
+//! relays. The event's `content` field carries `base64(SignedPacket::as_bytes())`
+//! so a receiver reconstructs the exact same packet a Pkarr relay would have
+//! served.
+//!
+//! Per `spec/03-pkarr-records.md §2.3`, the host's Ed25519 identity is *not*
+//! promoted to a secp256k1 Nostr signing key; this envelope omits the NIP-01
+//! `id` and `sig` fields entirely. Strict Nostr relays will reject events
+//! without a valid Schnorr signature — that's expected and acceptable for an
+//! optional, defense-in-depth substrate. openhost-aware consumers validate the
+//! Ed25519 signature inside `content`, not the Nostr outer signature.
+//!
+//! This module is intentionally publish-only envelope construction. Actually
+//! sending the event over a WebSocket is left to M3 and to external Nostr
+//! client crates.
+
+use crate::codec;
+use crate::error::Result;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use openhost_core::identity::SigningKey;
+use openhost_core::pkarr_record::SignedRecord;
+use serde_json::{json, Value};
+
+/// NIP-78 parameterized-replaceable event kind used for openhost records.
+pub const NOSTR_EVENT_KIND: u64 = 30078;
+
+/// Build the Nostr event JSON envelope wrapping `signed` for broadcast.
+///
+/// The returned `serde_json::Value` is an object with `kind`, `tags`,
+/// `content`, `pubkey`, and `created_at` fields. `id` and `sig` are
+/// deliberately omitted — see module docs.
+///
+/// `signed.record.ts` is used verbatim as `created_at` so the envelope is
+/// deterministic for a given signed record; publishers should ensure `ts` is
+/// set to the current Unix-seconds time before signing the record (otherwise
+/// Nostr relays may reject the event as back- or future-dated).
+pub fn build_event(signed: &SignedRecord, signing_key: &SigningKey) -> Result<Value> {
+    let packet = codec::encode(signed, signing_key)?;
+    let content = STANDARD.encode(packet.as_bytes());
+    let pubkey_hex = hex::encode(signing_key.public_key().to_bytes());
+
+    Ok(json!({
+        "kind": NOSTR_EVENT_KIND,
+        "tags": [
+            ["d", format!("openhost:{pubkey_hex}")],
+            ["t", "openhost"],
+            ["openhost-v", "1"],
+        ],
+        "content": content,
+        "pubkey": pubkey_hex,
+        "created_at": signed.record.ts,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::crypto::allowlist_hash;
+    use openhost_core::pkarr_record::{
+        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+    };
+
+    const RFC_SEED: [u8; 32] = [
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
+        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
+        0x7f, 0x60,
+    ];
+
+    fn sample_signed() -> (SigningKey, SignedRecord) {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let salt = [0x11u8; SALT_LEN];
+        let hash = allowlist_hash(&salt, &[0xAA; 32]);
+        let record = OpenhostRecord {
+            version: PROTOCOL_VERSION,
+            ts: 1_700_000_000,
+            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
+            roles: "server".to_string(),
+            salt,
+            allow: vec![hash],
+            ice: vec![IceBlob {
+                client_hash: hash.to_vec(),
+                ciphertext: vec![0xEE; 72],
+            }],
+            disc: String::new(),
+        };
+        let signed = SignedRecord::sign(record, &sk).unwrap();
+        (sk, signed)
+    }
+
+    #[test]
+    fn envelope_has_required_nip78_shape() {
+        let (sk, signed) = sample_signed();
+        let event = build_event(&signed, &sk).unwrap();
+
+        assert_eq!(event["kind"], NOSTR_EVENT_KIND);
+        assert_eq!(event["created_at"], signed.record.ts);
+
+        let expected_pubkey_hex = hex::encode(sk.public_key().to_bytes());
+        assert_eq!(event["pubkey"].as_str().unwrap(), expected_pubkey_hex);
+
+        assert!(event.get("id").is_none(), "id must be omitted");
+        assert!(event.get("sig").is_none(), "sig must be omitted");
+
+        let tags = event["tags"].as_array().expect("tags array");
+        assert_eq!(tags.len(), 3);
+        assert_eq!(tags[0][0], "d");
+        assert_eq!(
+            tags[0][1].as_str().unwrap(),
+            format!("openhost:{expected_pubkey_hex}")
+        );
+        assert_eq!(tags[1], json!(["t", "openhost"]));
+        assert_eq!(tags[2], json!(["openhost-v", "1"]));
+    }
+
+    #[test]
+    fn content_decodes_to_a_valid_signed_packet() {
+        let (sk, signed) = sample_signed();
+        let event = build_event(&signed, &sk).unwrap();
+        let blob = STANDARD
+            .decode(event["content"].as_str().unwrap())
+            .expect("base64 decodes");
+
+        let mut framed = Vec::with_capacity(8 + blob.len());
+        framed.extend_from_slice(&[0u8; 8]);
+        framed.extend_from_slice(&blob);
+        let packet =
+            pkarr::SignedPacket::deserialize(&framed).expect("embedded packet deserializes");
+
+        let decoded = codec::decode(&packet).unwrap();
+        assert_eq!(decoded.record, signed.record);
+        assert_eq!(decoded.signature.to_bytes(), signed.signature.to_bytes());
+    }
+
+    #[test]
+    fn build_event_is_deterministic_for_same_input() {
+        let (sk, signed) = sample_signed();
+        let a = build_event(&signed, &sk).unwrap();
+        let b = build_event(&signed, &sk).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/openhost-pkarr/src/publisher.rs
+++ b/crates/openhost-pkarr/src/publisher.rs
@@ -320,8 +320,7 @@ mod tests {
             sample_record(1_700_000_000 + i * 10)
         });
 
-        let mut publisher =
-            Publisher::new(transport.clone(), sk, record_source, Some(seed_ts));
+        let mut publisher = Publisher::new(transport.clone(), sk, record_source, Some(seed_ts));
 
         // First publish fails — `last_seq` MUST remain at the seeded value
         // so the next attempt still sends the correct CAS.

--- a/crates/openhost-pkarr/src/publisher.rs
+++ b/crates/openhost-pkarr/src/publisher.rs
@@ -1,0 +1,310 @@
+//! Record publisher: signs an [`OpenhostRecord`], encodes it into a
+//! [`pkarr::SignedPacket`], and fans out to relays + DHT via the upstream
+//! pkarr client (or any other [`Transport`] implementor).
+//!
+//! Republish cadence is 30 minutes as required by `spec/03-pkarr-records.md
+//! §1`, with immediate republish on demand via [`PublisherHandle::trigger`]
+//! (intended for the daemon to wire up to ICE / DTLS-fingerprint / allowlist
+//! change events in M3).
+//!
+//! The [`Transport`] trait abstracts over `pkarr::Client` so tests can inject
+//! a fake without touching the network. The real `pkarr::Client` impl is
+//! provided by [`PkarrTransport`].
+
+use crate::codec;
+use crate::error::{PkarrError, Result};
+use async_trait::async_trait;
+use openhost_core::identity::SigningKey;
+use openhost_core::pkarr_record::{OpenhostRecord, SignedRecord};
+use pkarr::{Client, SignedPacket, Timestamp};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::interval;
+
+/// Default republish interval: 30 minutes (per spec §1).
+pub const REPUBLISH_INTERVAL: Duration = Duration::from_secs(30 * 60);
+
+/// Abstracts over anything that can publish a signed pkarr packet. Implemented
+/// by [`PkarrTransport`] (wrapping `pkarr::Client`) and by test fakes.
+#[async_trait]
+pub trait Transport: Send + Sync + 'static {
+    /// Publish `packet` to the underlying substrates.
+    ///
+    /// `cas` is the previously-observed timestamp for compare-and-swap
+    /// semantics. On cold start the publisher passes `None`.
+    async fn publish(&self, packet: &SignedPacket, cas: Option<Timestamp>) -> Result<()>;
+}
+
+/// Adapter around a real `pkarr::Client`.
+pub struct PkarrTransport {
+    client: Arc<Client>,
+}
+
+impl PkarrTransport {
+    /// Wrap an already-built `pkarr::Client`.
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Transport for PkarrTransport {
+    async fn publish(&self, packet: &SignedPacket, cas: Option<Timestamp>) -> Result<()> {
+        self.client
+            .publish(packet, cas)
+            .await
+            .map_err(PkarrError::from)
+    }
+}
+
+/// Produces a fresh `OpenhostRecord` each time the publisher fires.
+///
+/// Typed as a boxed `FnMut` so callers can close over mutable state (e.g. the
+/// current `allow` list) and set a fresh `ts` per publication.
+pub type RecordSource = Box<dyn FnMut() -> OpenhostRecord + Send>;
+
+/// Handle returned from [`Publisher::spawn`] — keeps the background task
+/// alive and provides a trigger channel for on-demand republishes.
+pub struct PublisherHandle {
+    trigger_tx: mpsc::Sender<()>,
+    task: JoinHandle<()>,
+}
+
+impl PublisherHandle {
+    /// Request an immediate republish. Non-blocking; ignored if the trigger
+    /// channel is full (a publish is already queued).
+    pub fn trigger(&self) {
+        let _ = self.trigger_tx.try_send(());
+    }
+
+    /// Abort the background republish task and await its completion.
+    pub async fn shutdown(self) {
+        self.task.abort();
+        let _ = self.task.await;
+    }
+
+    /// Borrow the underlying `JoinHandle` for callers that want their own
+    /// shutdown semantics.
+    pub fn task(&self) -> &JoinHandle<()> {
+        &self.task
+    }
+}
+
+/// The publisher.
+pub struct Publisher {
+    transport: Arc<dyn Transport>,
+    signing_key: Arc<SigningKey>,
+    record_source: RecordSource,
+    last_seq: Option<u64>,
+    interval: Duration,
+}
+
+impl Publisher {
+    /// Construct a new `Publisher`.
+    ///
+    /// `initial_last_seq` seeds the CAS value. On first ever publish for a
+    /// pubkey it should be `None`; if the caller has persisted the previous
+    /// `record.ts` across restarts it should be `Some(prev_ts)`.
+    pub fn new(
+        transport: Arc<dyn Transport>,
+        signing_key: Arc<SigningKey>,
+        record_source: RecordSource,
+        initial_last_seq: Option<u64>,
+    ) -> Self {
+        Self {
+            transport,
+            signing_key,
+            record_source,
+            last_seq: initial_last_seq,
+            interval: REPUBLISH_INTERVAL,
+        }
+    }
+
+    /// Override the republish interval. Intended for tests.
+    pub fn with_interval(mut self, interval: Duration) -> Self {
+        self.interval = interval;
+        self
+    }
+
+    /// Sign, encode, and publish a single record **now**. Updates `last_seq`
+    /// on success.
+    pub async fn publish_once(&mut self) -> Result<u64> {
+        let record = (self.record_source)();
+        let ts = record.ts;
+        let signed = SignedRecord::sign(record, &self.signing_key)?;
+        let packet = codec::encode(&signed, &self.signing_key)?;
+        let cas = self
+            .last_seq
+            .map(|s| Timestamp::from(s * codec::MICROS_PER_SECOND));
+        self.transport.publish(&packet, cas).await?;
+        self.last_seq = Some(ts);
+        Ok(ts)
+    }
+
+    /// Spawn the background republish loop. Returns a handle that fires an
+    /// immediate publish and thereafter republishes every `self.interval`,
+    /// plus whenever [`PublisherHandle::trigger`] is called.
+    pub fn spawn(mut self) -> PublisherHandle {
+        let (trigger_tx, mut trigger_rx) = mpsc::channel::<()>(1);
+        let period = self.interval;
+
+        let task = tokio::spawn(async move {
+            // Fire an immediate publish so a freshly-spawned publisher is
+            // reachable without waiting for the first tick.
+            if let Err(err) = self.publish_once().await {
+                tracing::warn!(?err, "openhost-pkarr: initial publish failed");
+            }
+
+            let mut ticker = interval(period);
+            // The first tick returns immediately; skip it so we don't republish
+            // twice back-to-back.
+            ticker.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        if let Err(err) = self.publish_once().await {
+                            tracing::warn!(?err, "openhost-pkarr: scheduled republish failed");
+                        }
+                    }
+                    Some(()) = trigger_rx.recv() => {
+                        if let Err(err) = self.publish_once().await {
+                            tracing::warn!(?err, "openhost-pkarr: triggered republish failed");
+                        }
+                    }
+                    else => break,
+                }
+            }
+        });
+
+        PublisherHandle { trigger_tx, task }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::crypto::allowlist_hash;
+    use openhost_core::pkarr_record::{
+        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+    };
+    use std::sync::Mutex;
+
+    const RFC_SEED: [u8; 32] = [
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
+        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
+        0x7f, 0x60,
+    ];
+
+    fn sample_record(ts: u64) -> OpenhostRecord {
+        let salt = [0x11u8; SALT_LEN];
+        let client_pk = [0xAAu8; 32];
+        let hash = allowlist_hash(&salt, &client_pk);
+        OpenhostRecord {
+            version: PROTOCOL_VERSION,
+            ts,
+            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
+            roles: "server".to_string(),
+            salt,
+            allow: vec![hash],
+            ice: vec![IceBlob {
+                client_hash: hash.to_vec(),
+                ciphertext: vec![0xEE; 72],
+            }],
+            disc: "dht=1".to_string(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeTransport {
+        calls: Mutex<Vec<(u64, Option<u64>)>>,
+    }
+
+    #[async_trait]
+    impl Transport for FakeTransport {
+        async fn publish(&self, packet: &SignedPacket, cas: Option<Timestamp>) -> Result<()> {
+            let pkt_ts: u64 = packet.timestamp().into();
+            let pkt_secs = pkt_ts / codec::MICROS_PER_SECOND;
+            let cas_secs = cas.map(|t| u64::from(t) / codec::MICROS_PER_SECOND);
+            self.calls.lock().unwrap().push((pkt_secs, cas_secs));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_once_updates_last_seq_and_sends_cas_next_time() {
+        let transport = Arc::new(FakeTransport::default());
+        let sk = Arc::new(SigningKey::from_bytes(&RFC_SEED));
+
+        let ts1: u64 = 1_700_000_000;
+        let ts2: u64 = ts1 + 600;
+        let counter = std::sync::atomic::AtomicU64::new(0);
+        let record_source: RecordSource = Box::new(move || {
+            let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            sample_record(if i == 0 { ts1 } else { ts2 })
+        });
+
+        let mut publisher = Publisher::new(transport.clone(), sk, record_source, None);
+
+        let first = publisher.publish_once().await.unwrap();
+        assert_eq!(first, ts1);
+        let second = publisher.publish_once().await.unwrap();
+        assert_eq!(second, ts2);
+
+        let calls = transport.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 2);
+        // First publish: no CAS (cold start).
+        assert_eq!(calls[0], (ts1, None));
+        // Second publish: CAS carries the previous seq.
+        assert_eq!(calls[1], (ts2, Some(ts1)));
+    }
+
+    #[tokio::test]
+    async fn trigger_causes_additional_publish() {
+        let transport = Arc::new(FakeTransport::default());
+        let sk = Arc::new(SigningKey::from_bytes(&RFC_SEED));
+
+        // Use a very long interval so only our trigger produces a second publish.
+        let counter = std::sync::atomic::AtomicU64::new(0);
+        let record_source: RecordSource = Box::new(move || {
+            let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            sample_record(1_700_000_000 + i * 10)
+        });
+
+        let publisher = Publisher::new(transport.clone(), sk, record_source, None)
+            .with_interval(Duration::from_secs(3600));
+        let handle = publisher.spawn();
+
+        // Wait for the initial publish to land.
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        handle.trigger();
+        tokio::time::sleep(Duration::from_millis(30)).await;
+
+        let calls = transport.calls.lock().unwrap().clone();
+        assert!(
+            calls.len() >= 2,
+            "expected ≥2 publishes (initial + trigger), saw {}",
+            calls.len()
+        );
+
+        handle.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn initial_last_seq_is_honored() {
+        let transport = Arc::new(FakeTransport::default());
+        let sk = Arc::new(SigningKey::from_bytes(&RFC_SEED));
+
+        let seed_ts: u64 = 1_699_000_000;
+        let record_source: RecordSource = Box::new(move || sample_record(1_700_000_000));
+
+        let mut publisher = Publisher::new(transport.clone(), sk, record_source, Some(seed_ts));
+        publisher.publish_once().await.unwrap();
+
+        let calls = transport.calls.lock().unwrap().clone();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].1, Some(seed_ts));
+    }
+}

--- a/crates/openhost-pkarr/src/publisher.rs
+++ b/crates/openhost-pkarr/src/publisher.rs
@@ -67,9 +67,18 @@ pub type RecordSource = Box<dyn FnMut() -> OpenhostRecord + Send>;
 
 /// Handle returned from [`Publisher::spawn`] — keeps the background task
 /// alive and provides a trigger channel for on-demand republishes.
+///
+/// Dropping the handle aborts the background task; explicit [`shutdown`]
+/// does the same and additionally awaits task completion.
+///
+/// [`shutdown`]: PublisherHandle::shutdown
 pub struct PublisherHandle {
     trigger_tx: mpsc::Sender<()>,
-    task: JoinHandle<()>,
+    // `Option` so `shutdown` can `take()` the `JoinHandle` to await it,
+    // while `Drop` still has something to `abort()` on the non-shutdown
+    // path. On the shutdown path the handle is `None` by the time `Drop`
+    // fires and the abort is a no-op.
+    task: Option<JoinHandle<()>>,
 }
 
 impl PublisherHandle {
@@ -80,15 +89,24 @@ impl PublisherHandle {
     }
 
     /// Abort the background republish task and await its completion.
-    pub async fn shutdown(self) {
-        self.task.abort();
-        let _ = self.task.await;
+    pub async fn shutdown(mut self) {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            let _ = task.await;
+        }
     }
+}
 
-    /// Borrow the underlying `JoinHandle` for callers that want their own
-    /// shutdown semantics.
-    pub fn task(&self) -> &JoinHandle<()> {
-        &self.task
+impl Drop for PublisherHandle {
+    fn drop(&mut self) {
+        // If the caller never invoked `shutdown`, make sure the background
+        // task is cancelled — otherwise it would keep republishing with the
+        // `Arc<SigningKey>` until process exit, because the tokio `interval`
+        // arm inside `spawn` never resolves to an error that could trigger
+        // `select!`'s `else` branch on its own.
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
     }
 }
 
@@ -174,53 +192,35 @@ impl Publisher {
                             tracing::warn!(?err, "openhost-pkarr: scheduled republish failed");
                         }
                     }
-                    Some(()) = trigger_rx.recv() => {
-                        if let Err(err) = self.publish_once().await {
-                            tracing::warn!(?err, "openhost-pkarr: triggered republish failed");
+                    trigger = trigger_rx.recv() => match trigger {
+                        Some(()) => {
+                            if let Err(err) = self.publish_once().await {
+                                tracing::warn!(?err, "openhost-pkarr: triggered republish failed");
+                            }
                         }
+                        // Trigger channel closed: the `PublisherHandle` was
+                        // dropped without calling `shutdown`. `Drop` for the
+                        // handle already aborts us, but exit the loop cleanly
+                        // in case someone kept the handle alive only through
+                        // the task itself.
+                        None => break,
                     }
-                    else => break,
                 }
             }
         });
 
-        PublisherHandle { trigger_tx, task }
+        PublisherHandle {
+            trigger_tx,
+            task: Some(task),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openhost_core::crypto::allowlist_hash;
-    use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
-    };
+    use crate::test_support::{sample_record, RFC_SEED};
     use std::sync::Mutex;
-
-    const RFC_SEED: [u8; 32] = [
-        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
-        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
-        0x7f, 0x60,
-    ];
-
-    fn sample_record(ts: u64) -> OpenhostRecord {
-        let salt = [0x11u8; SALT_LEN];
-        let client_pk = [0xAAu8; 32];
-        let hash = allowlist_hash(&salt, &client_pk);
-        OpenhostRecord {
-            version: PROTOCOL_VERSION,
-            ts,
-            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
-            roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
-            disc: "dht=1".to_string(),
-        }
-    }
 
     #[derive(Default)]
     struct FakeTransport {
@@ -295,6 +295,43 @@ mod tests {
         );
 
         handle.shutdown().await;
+    }
+
+    /// Transport that always reports a publish failure — lets us verify that
+    /// `publish_once` leaves `last_seq` unchanged after an error.
+    struct FailingTransport;
+
+    #[async_trait]
+    impl Transport for FailingTransport {
+        async fn publish(&self, _packet: &SignedPacket, _cas: Option<Timestamp>) -> Result<()> {
+            Err(PkarrError::NotFound)
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_failure_leaves_last_seq_unchanged() {
+        let transport = Arc::new(FailingTransport);
+        let sk = Arc::new(SigningKey::from_bytes(&RFC_SEED));
+
+        let seed_ts: u64 = 1_699_000_000;
+        let counter = std::sync::atomic::AtomicU64::new(0);
+        let record_source: RecordSource = Box::new(move || {
+            let i = counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            sample_record(1_700_000_000 + i * 10)
+        });
+
+        let mut publisher =
+            Publisher::new(transport.clone(), sk, record_source, Some(seed_ts));
+
+        // First publish fails — `last_seq` MUST remain at the seeded value
+        // so the next attempt still sends the correct CAS.
+        assert!(publisher.publish_once().await.is_err());
+        assert_eq!(publisher.last_seq, Some(seed_ts));
+
+        // Second failure: same invariant, regardless of the record_source
+        // having moved forward.
+        assert!(publisher.publish_once().await.is_err());
+        assert_eq!(publisher.last_seq, Some(seed_ts));
     }
 
     #[tokio::test]

--- a/crates/openhost-pkarr/src/publisher.rs
+++ b/crates/openhost-pkarr/src/publisher.rs
@@ -153,6 +153,11 @@ impl Publisher {
         let task = tokio::spawn(async move {
             // Fire an immediate publish so a freshly-spawned publisher is
             // reachable without waiting for the first tick.
+            //
+            // TODO(M3): retry the initial publish with exponential backoff (3
+            // attempts) before falling back to the 30-minute cadence. A single
+            // transient relay failure here leaves the host undiscoverable until
+            // the next scheduled tick.
             if let Err(err) = self.publish_once().await {
                 tracing::warn!(?err, "openhost-pkarr: initial publish failed");
             }

--- a/crates/openhost-pkarr/src/relays.rs
+++ b/crates/openhost-pkarr/src/relays.rs
@@ -1,0 +1,16 @@
+//! Bundled default list of public Pkarr HTTP relays.
+//!
+//! End-users are expected to edit this list; implementations **MUST NOT**
+//! hard-code relay trust decisions against these URLs. The list is
+//! informational: the openhost protocol treats every relay as adversarial —
+//! records are only trusted via their Ed25519 signature, never by source.
+//!
+//! Sourced from `spec/03-pkarr-records.md §2.1`. Keep this in sync with the
+//! spec.
+
+/// Default Pkarr HTTP relays bundled with `openhost-pkarr`.
+///
+/// The first entry is also carried in `pkarr::DEFAULT_RELAYS`; the second is
+/// operated by the Iroh project. Both are informational examples — consumers
+/// **MUST** allow the end-user to override this list at runtime.
+pub const DEFAULT_RELAYS: &[&str] = &["https://pkarr.pubky.app", "https://relay.iroh.network"];

--- a/crates/openhost-pkarr/src/relays.rs
+++ b/crates/openhost-pkarr/src/relays.rs
@@ -13,4 +13,10 @@
 /// The first entry is also carried in `pkarr::DEFAULT_RELAYS`; the second is
 /// operated by the Iroh project. Both are informational examples — consumers
 /// **MUST** allow the end-user to override this list at runtime.
+///
+/// Spec §2.1 requires "at least three substrates in parallel". On native
+/// platforms the bundled two relays plus the Mainline DHT (queried directly
+/// by `pkarr::Client`) satisfy that count. Browser-targeted consumers, which
+/// cannot speak the DHT, **MUST** extend this list to at least three relays
+/// before shipping.
 pub const DEFAULT_RELAYS: &[&str] = &["https://pkarr.pubky.app", "https://relay.iroh.network"];

--- a/crates/openhost-pkarr/src/resolver.rs
+++ b/crates/openhost-pkarr/src/resolver.rs
@@ -1,0 +1,245 @@
+//! Record resolver: races the configured Pkarr relays + the Mainline DHT for
+//! the most-recent `SignedPacket` under a given public key, decodes it back to
+//! a `SignedRecord`, and applies openhost-layer validation.
+//!
+//! Substrate racing is delegated to `pkarr::Client::resolve_most_recent`,
+//! which internally queries all configured relays and the DHT and returns the
+//! highest-`seq` response (per `spec/03-pkarr-records.md §3`). The resolver
+//! wraps that with:
+//!
+//! 1. Decode via [`codec::decode`].
+//! 2. Cross-check that the pkarr packet's timestamp (in seconds) matches
+//!    `record.ts` within ±1s — guards against cache drift.
+//! 3. [`SignedRecord::verify`] — 2-hour freshness window + Ed25519 signature +
+//!    internal consistency.
+//! 4. If the caller supplied a `cached_seq`, reject any record whose
+//!    `record.ts < cached_seq` (spec §3 rule 5).
+//!
+//! A [`Resolve`] trait lets tests plug a fake client. The real `pkarr::Client`
+//! is adapted by [`PkarrResolve`].
+
+use crate::codec;
+use crate::error::{PkarrError, Result};
+use async_trait::async_trait;
+use openhost_core::identity::{PublicKey, PUBLIC_KEY_LEN};
+use openhost_core::pkarr_record::SignedRecord;
+use pkarr::{Client, SignedPacket};
+use std::sync::Arc;
+
+/// Abstracts over the pkarr substrate-resolve surface for testability.
+#[async_trait]
+pub trait Resolve: Send + Sync + 'static {
+    /// Query all configured substrates in parallel and return the most-recent
+    /// packet (by BEP44 `seq` / `Timestamp`) for the given pkarr public key.
+    async fn resolve_most_recent(&self, public_key: &pkarr::PublicKey) -> Option<SignedPacket>;
+}
+
+/// Adapter around a real `pkarr::Client`.
+pub struct PkarrResolve {
+    client: Arc<Client>,
+}
+
+impl PkarrResolve {
+    /// Wrap an already-built `pkarr::Client`.
+    pub fn new(client: Arc<Client>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl Resolve for PkarrResolve {
+    async fn resolve_most_recent(&self, public_key: &pkarr::PublicKey) -> Option<SignedPacket> {
+        self.client.resolve_most_recent(public_key).await
+    }
+}
+
+/// The resolver.
+pub struct Resolver {
+    client: Arc<dyn Resolve>,
+}
+
+impl Resolver {
+    /// Construct a new resolver wrapping the given substrate client.
+    pub fn new(client: Arc<dyn Resolve>) -> Self {
+        Self { client }
+    }
+
+    /// Resolve the openhost record for `pubkey`.
+    ///
+    /// - `now_ts` is the verifier's current Unix timestamp in seconds. Pass
+    ///   `std::time::SystemTime::now()` converted to seconds.
+    /// - `cached_seq` is the highest `record.ts` (= BEP44 `seq`) this caller
+    ///   has previously accepted for this pubkey. Resolver rejects any record
+    ///   whose `ts` is strictly less than this, preventing stale substrates
+    ///   from overwriting fresher cached state.
+    pub async fn resolve(
+        &self,
+        pubkey: &PublicKey,
+        now_ts: u64,
+        cached_seq: Option<u64>,
+    ) -> Result<SignedRecord> {
+        let pk_bytes: [u8; PUBLIC_KEY_LEN] = pubkey.to_bytes();
+        let pkarr_pk = pkarr::PublicKey::try_from(&pk_bytes)
+            .map_err(|_| PkarrError::MalformedCanonical("pkarr PublicKey conversion"))?;
+
+        let packet = self
+            .client
+            .resolve_most_recent(&pkarr_pk)
+            .await
+            .ok_or(PkarrError::NotFound)?;
+
+        let signed = codec::decode(&packet)?;
+
+        let packet_ts_micros: u64 = packet.timestamp().into();
+        let packet_ts_secs = packet_ts_micros / codec::MICROS_PER_SECOND;
+        let drift = packet_ts_secs.abs_diff(signed.record.ts);
+        if drift > 1 {
+            return Err(PkarrError::TimestampDrift {
+                packet_ts: packet_ts_secs,
+                record_ts: signed.record.ts,
+            });
+        }
+
+        signed.verify(pubkey, now_ts)?;
+
+        if let Some(cached) = cached_seq {
+            if signed.record.ts < cached {
+                return Err(PkarrError::SeqRegression {
+                    record_ts: signed.record.ts,
+                    cached_seq: cached,
+                });
+            }
+        }
+
+        Ok(signed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::encode;
+    use openhost_core::crypto::allowlist_hash;
+    use openhost_core::identity::SigningKey;
+    use openhost_core::pkarr_record::{
+        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, MAX_RECORD_AGE_SECS, PROTOCOL_VERSION,
+        SALT_LEN,
+    };
+
+    const RFC_SEED: [u8; 32] = [
+        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
+        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
+        0x7f, 0x60,
+    ];
+
+    fn sample_record(ts: u64) -> OpenhostRecord {
+        let salt = [0x11u8; SALT_LEN];
+        let hash = allowlist_hash(&salt, &[0xAA; 32]);
+        OpenhostRecord {
+            version: PROTOCOL_VERSION,
+            ts,
+            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
+            roles: "server".to_string(),
+            salt,
+            allow: vec![hash],
+            ice: vec![IceBlob {
+                client_hash: hash.to_vec(),
+                ciphertext: vec![0xEE; 72],
+            }],
+            disc: String::new(),
+        }
+    }
+
+    struct FakeResolve {
+        packet: Option<SignedPacket>,
+    }
+
+    #[async_trait]
+    impl Resolve for FakeResolve {
+        async fn resolve_most_recent(&self, _pk: &pkarr::PublicKey) -> Option<SignedPacket> {
+            // SignedPacket doesn't implement Clone; round-trip via serialize.
+            self.packet
+                .as_ref()
+                .map(|p| SignedPacket::deserialize(&p.serialize()).unwrap())
+        }
+    }
+
+    fn packet_for(ts: u64) -> (SigningKey, SignedPacket) {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let signed =
+            openhost_core::pkarr_record::SignedRecord::sign(sample_record(ts), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+        (sk, packet)
+    }
+
+    #[tokio::test]
+    async fn resolves_fresh_record() {
+        let ts = 1_700_000_000;
+        let (sk, packet) = packet_for(ts);
+        let resolver = Resolver::new(Arc::new(FakeResolve {
+            packet: Some(packet),
+        }));
+
+        let record = resolver
+            .resolve(&sk.public_key(), ts, None)
+            .await
+            .expect("resolves");
+        assert_eq!(record.record.ts, ts);
+    }
+
+    #[tokio::test]
+    async fn returns_not_found_when_substrate_empty() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let resolver = Resolver::new(Arc::new(FakeResolve { packet: None }));
+        let err = resolver
+            .resolve(&sk.public_key(), 1_700_000_000, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PkarrError::NotFound));
+    }
+
+    #[tokio::test]
+    async fn rejects_stale_record() {
+        let ts = 1_700_000_000;
+        let (sk, packet) = packet_for(ts);
+        let resolver = Resolver::new(Arc::new(FakeResolve {
+            packet: Some(packet),
+        }));
+
+        let err = resolver
+            .resolve(&sk.public_key(), ts + MAX_RECORD_AGE_SECS + 1, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PkarrError::Core(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_seq_regression() {
+        let ts = 1_700_000_000;
+        let (sk, packet) = packet_for(ts);
+        let resolver = Resolver::new(Arc::new(FakeResolve {
+            packet: Some(packet),
+        }));
+
+        let err = resolver
+            .resolve(&sk.public_key(), ts, Some(ts + 1))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PkarrError::SeqRegression { .. }));
+    }
+
+    #[tokio::test]
+    async fn accepts_cached_seq_equal_to_record_ts() {
+        let ts = 1_700_000_000;
+        let (sk, packet) = packet_for(ts);
+        let resolver = Resolver::new(Arc::new(FakeResolve {
+            packet: Some(packet),
+        }));
+
+        let record = resolver
+            .resolve(&sk.public_key(), ts, Some(ts))
+            .await
+            .expect("equal cached_seq is allowed (monotonic non-decreasing)");
+        assert_eq!(record.record.ts, ts);
+    }
+}

--- a/crates/openhost-pkarr/src/resolver.rs
+++ b/crates/openhost-pkarr/src/resolver.rs
@@ -82,6 +82,13 @@ impl Resolver {
         let pkarr_pk =
             pkarr::PublicKey::try_from(&pk_bytes).map_err(|_| PkarrError::PublicKeyConversion)?;
 
+        // TODO(M3): `pkarr::Client::resolve_most_recent` returns as soon as it
+        // has a validated response; it does not implement the 1.5-second
+        // grace window from spec §3 rule 5 ("continue waiting on in-flight
+        // queries for up to 1.5 seconds after the first accepted record; if
+        // a later-arriving record has a higher `seq`, prefer it"). Adding
+        // that requires either a custom race over individual substrate calls
+        // or an upstream pkarr change.
         let packet = self
             .client
             .resolve_most_recent(&pkarr_pk)
@@ -119,36 +126,9 @@ impl Resolver {
 mod tests {
     use super::*;
     use crate::codec::encode;
-    use openhost_core::crypto::allowlist_hash;
+    use crate::test_support::{sample_record, RFC_SEED};
     use openhost_core::identity::SigningKey;
-    use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, MAX_RECORD_AGE_SECS, PROTOCOL_VERSION,
-        SALT_LEN,
-    };
-
-    const RFC_SEED: [u8; 32] = [
-        0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c,
-        0xc4, 0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae,
-        0x7f, 0x60,
-    ];
-
-    fn sample_record(ts: u64) -> OpenhostRecord {
-        let salt = [0x11u8; SALT_LEN];
-        let hash = allowlist_hash(&salt, &[0xAA; 32]);
-        OpenhostRecord {
-            version: PROTOCOL_VERSION,
-            ts,
-            dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
-            roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
-            disc: String::new(),
-        }
-    }
+    use openhost_core::pkarr_record::MAX_RECORD_AGE_SECS;
 
     struct FakeResolve {
         packet: Option<SignedPacket>,
@@ -241,5 +221,49 @@ mod tests {
             .await
             .expect("equal cached_seq is allowed (monotonic non-decreasing)");
         assert_eq!(record.record.ts, ts);
+    }
+
+    #[tokio::test]
+    async fn rejects_timestamp_drift_between_packet_and_record() {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine as _;
+
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let record_ts = 1_700_000_000u64;
+        let signed =
+            openhost_core::pkarr_record::SignedRecord::sign(sample_record(record_ts), &sk)
+                .unwrap();
+
+        // Re-implement the encode path but pin the outer pkarr timestamp at
+        // a value that disagrees with `record.ts` by more than 1s. We hold
+        // the signing key, so the outer BEP44 signature still validates —
+        // the drift guard in the resolver is what should catch this.
+        let canonical = signed.record.canonical_signing_bytes().unwrap();
+        let mut blob = Vec::with_capacity(64 + canonical.len());
+        blob.extend_from_slice(&signed.signature.to_bytes());
+        blob.extend_from_slice(&canonical);
+        let encoded = URL_SAFE_NO_PAD.encode(&blob);
+
+        let keypair = pkarr::Keypair::from_secret_key(&sk.to_bytes());
+        let drifted_micros = (record_ts + 5) * codec::MICROS_PER_SECOND;
+        let packet = SignedPacket::builder()
+            .txt(
+                pkarr::dns::Name::new_unchecked(codec::OPENHOST_TXT_NAME),
+                pkarr::dns::rdata::TXT::try_from(encoded.as_str()).unwrap(),
+                codec::OPENHOST_TXT_TTL,
+            )
+            .timestamp(pkarr::Timestamp::from(drifted_micros))
+            .sign(&keypair)
+            .unwrap();
+
+        let resolver = Resolver::new(Arc::new(FakeResolve {
+            packet: Some(packet),
+        }));
+
+        let err = resolver
+            .resolve(&sk.public_key(), record_ts, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PkarrError::TimestampDrift { .. }));
     }
 }

--- a/crates/openhost-pkarr/src/resolver.rs
+++ b/crates/openhost-pkarr/src/resolver.rs
@@ -79,8 +79,8 @@ impl Resolver {
         cached_seq: Option<u64>,
     ) -> Result<SignedRecord> {
         let pk_bytes: [u8; PUBLIC_KEY_LEN] = pubkey.to_bytes();
-        let pkarr_pk = pkarr::PublicKey::try_from(&pk_bytes)
-            .map_err(|_| PkarrError::MalformedCanonical("pkarr PublicKey conversion"))?;
+        let pkarr_pk =
+            pkarr::PublicKey::try_from(&pk_bytes).map_err(|_| PkarrError::PublicKeyConversion)?;
 
         let packet = self
             .client

--- a/crates/openhost-pkarr/src/resolver.rs
+++ b/crates/openhost-pkarr/src/resolver.rs
@@ -231,8 +231,7 @@ mod tests {
         let sk = SigningKey::from_bytes(&RFC_SEED);
         let record_ts = 1_700_000_000u64;
         let signed =
-            openhost_core::pkarr_record::SignedRecord::sign(sample_record(record_ts), &sk)
-                .unwrap();
+            openhost_core::pkarr_record::SignedRecord::sign(sample_record(record_ts), &sk).unwrap();
 
         // Re-implement the encode path but pin the outer pkarr timestamp at
         // a value that disagrees with `record.ts` by more than 1s. We hold

--- a/crates/openhost-pkarr/src/test_support.rs
+++ b/crates/openhost-pkarr/src/test_support.rs
@@ -1,0 +1,41 @@
+//! Shared test fixtures for `openhost-pkarr` unit tests.
+//!
+//! Kept behind `#[cfg(test)]` in `lib.rs` so it never ships in the crate's
+//! public surface. Integration tests under `tests/` have their own fixtures
+//! driven from the JSON spec vectors.
+
+use openhost_core::crypto::allowlist_hash;
+use openhost_core::pkarr_record::{
+    IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+};
+
+/// RFC 8032 Ed25519 test-vector seed. Reused everywhere we need a
+/// deterministic `SigningKey`.
+pub(crate) const RFC_SEED: [u8; 32] = [
+    0x9d, 0x61, 0xb1, 0x9d, 0xef, 0xfd, 0x5a, 0x60, 0xba, 0x84, 0x4a, 0xf4, 0x92, 0xec, 0x2c, 0xc4,
+    0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae, 0x7f, 0x60,
+];
+
+/// A minimal-but-valid [`OpenhostRecord`] at the given `ts`.
+///
+/// Matches the shape used by the pre-existing per-module sample fixtures so
+/// tests that previously hand-rolled records keep the same semantics after
+/// switching over.
+pub(crate) fn sample_record(ts: u64) -> OpenhostRecord {
+    let salt = [0x11u8; SALT_LEN];
+    let client_pk = [0xAAu8; 32];
+    let hash = allowlist_hash(&salt, &client_pk);
+    OpenhostRecord {
+        version: PROTOCOL_VERSION,
+        ts,
+        dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
+        roles: "server".to_string(),
+        salt,
+        allow: vec![hash],
+        ice: vec![IceBlob {
+            client_hash: hash.to_vec(),
+            ciphertext: vec![0xEE; 72],
+        }],
+        disc: String::new(),
+    }
+}

--- a/crates/openhost-pkarr/tests/round_trip.rs
+++ b/crates/openhost-pkarr/tests/round_trip.rs
@@ -1,0 +1,155 @@
+//! Round-trip integration test against `spec/test-vectors/pkarr_packet.json`.
+//!
+//! A second implementation MUST be able to:
+//!   1. Deserialize `packet_bytes_hex` back into its own `SignedPacket` type.
+//!   2. Decode that into an openhost `SignedRecord`.
+//!   3. Verify the inner Ed25519 signature against the referenced public key
+//!      (at the record's own `ts` — we don't advance "now" here).
+//!   4. Re-encode with the original signing key and produce the same
+//!      `packet_bytes_hex` byte-for-byte.
+//!
+//! If any of the above breaks, the bridge has drifted from the spec.
+
+use openhost_core::identity::SigningKey;
+use openhost_core::pkarr_record::{IceBlob, OpenhostRecord, SignedRecord};
+use openhost_pkarr::{codec, decode, encode};
+use pkarr::SignedPacket;
+use serde_json::Value;
+use std::fs;
+
+const VECTOR_PATH: &str = "../../spec/test-vectors/pkarr_packet.json";
+
+fn load_vectors() -> Value {
+    let raw = fs::read_to_string(VECTOR_PATH).expect("read pkarr_packet.json");
+    serde_json::from_str(&raw).expect("parse pkarr_packet.json")
+}
+
+fn reference_record() -> OpenhostRecord {
+    let raw = fs::read_to_string("../../spec/test-vectors/pkarr_record.json")
+        .expect("read pkarr_record.json");
+    let v: Value = serde_json::from_str(&raw).unwrap();
+    let r = &v["vectors"][0]["record"];
+
+    let mut dtls_fp = [0u8; 32];
+    dtls_fp.copy_from_slice(&hex::decode(r["dtls_fp_hex"].as_str().unwrap()).unwrap());
+
+    let mut salt = [0u8; 32];
+    salt.copy_from_slice(&hex::decode(r["salt_hex"].as_str().unwrap()).unwrap());
+
+    let allow: Vec<[u8; 16]> = r["allow_hex"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| {
+            let b = hex::decode(h.as_str().unwrap()).unwrap();
+            let mut a = [0u8; 16];
+            a.copy_from_slice(&b);
+            a
+        })
+        .collect();
+
+    let ice: Vec<IceBlob> = r["ice"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|blob| IceBlob {
+            client_hash: hex::decode(blob["client_hash_hex"].as_str().unwrap()).unwrap(),
+            ciphertext: hex::decode(blob["ciphertext_hex"].as_str().unwrap()).unwrap(),
+        })
+        .collect();
+
+    OpenhostRecord {
+        version: r["version"].as_u64().unwrap() as u8,
+        ts: r["ts"].as_u64().unwrap(),
+        dtls_fp,
+        roles: r["roles"].as_str().unwrap().to_string(),
+        salt,
+        allow,
+        ice,
+        disc: r["disc"].as_str().unwrap().to_string(),
+    }
+}
+
+fn deserialize_packet_bytes(as_bytes: &[u8]) -> SignedPacket {
+    // `SignedPacket::deserialize` expects `<8 bytes last_seen><as_bytes>`.
+    // We zero the `last_seen` prefix — it's a local cache hint and is not part
+    // of the canonical wire form.
+    let mut framed = Vec::with_capacity(8 + as_bytes.len());
+    framed.extend_from_slice(&[0u8; 8]);
+    framed.extend_from_slice(as_bytes);
+    SignedPacket::deserialize(&framed).expect("valid signed packet bytes")
+}
+
+#[test]
+fn reference_packet_round_trips() {
+    let vectors = load_vectors();
+    let v = &vectors["vectors"][0];
+
+    let seed_hex = v["signing_seed_hex"].as_str().unwrap();
+    let seed_bytes = hex::decode(seed_hex).unwrap();
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&seed_bytes);
+    let sk = SigningKey::from_bytes(&seed);
+
+    let as_bytes = hex::decode(v["packet_bytes_hex"].as_str().unwrap()).unwrap();
+    assert_eq!(
+        as_bytes.len(),
+        v["packet_bytes_len"].as_u64().unwrap() as usize
+    );
+
+    let packet = deserialize_packet_bytes(&as_bytes);
+
+    let decoded = decode(&packet).expect("decode");
+    assert_eq!(decoded.record, reference_record());
+
+    decoded
+        .verify(&sk.public_key(), decoded.record.ts)
+        .expect("openhost signature verifies");
+
+    // Re-encode and assert we get byte-identical output.
+    let signed = SignedRecord::sign(decoded.record.clone(), &sk).unwrap();
+    let re_encoded = encode(&signed, &sk).expect("re-encode");
+    assert_eq!(
+        hex::encode(re_encoded.as_bytes()),
+        v["packet_bytes_hex"].as_str().unwrap(),
+        "re-encoded packet must match fixture byte-for-byte"
+    );
+}
+
+#[test]
+fn fixture_declares_expected_blob_shape() {
+    let vectors = load_vectors();
+    let v = &vectors["vectors"][0];
+
+    assert_eq!(
+        v["openhost_txt_name"].as_str().unwrap(),
+        codec::OPENHOST_TXT_NAME
+    );
+    assert_eq!(
+        v["openhost_txt_ttl"].as_u64().unwrap() as u32,
+        codec::OPENHOST_TXT_TTL
+    );
+    assert_eq!(
+        v["pkarr_timestamp_micros"].as_u64().unwrap(),
+        v["record_ts"].as_u64().unwrap() * codec::MICROS_PER_SECOND
+    );
+}
+
+#[test]
+fn tampering_canonical_bytes_fails_openhost_sig() {
+    let vectors = load_vectors();
+    let v = &vectors["vectors"][0];
+
+    let seed_hex = v["signing_seed_hex"].as_str().unwrap();
+    let seed_bytes = hex::decode(seed_hex).unwrap();
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&seed_bytes);
+    let sk = SigningKey::from_bytes(&seed);
+
+    let as_bytes = hex::decode(v["packet_bytes_hex"].as_str().unwrap()).unwrap();
+    let packet = deserialize_packet_bytes(&as_bytes);
+    let mut decoded = decode(&packet).unwrap();
+    decoded.record.dtls_fp[0] ^= 0x01;
+
+    assert!(decoded.verify(&sk.public_key(), decoded.record.ts).is_err());
+}

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -35,23 +35,33 @@ Clients **MUST** reject any `oh://` URL whose host component fails z-base-32 dec
 
 A host publishes a signed DNS packet as a BEP44 mutable item on the Mainline DHT and simultaneously to one or more public Pkarr relays. The packet's signing key is the host's Ed25519 keypair; the BEP44 `k` field is the host's public key. Record name suffixes are relative to the host's public key.
 
-| Record name | Type | Contents |
-|---|---|---|
-| `@` | TXT | `v=openhost1; ts=<unix>; fp=sha256:<hex>; roles=server` |
-| `_ice._<clienthash>` | TXT | `encrypted:<base64 ciphertext>` — ICE candidates encrypted per-client |
-| `_allow` | TXT | `h1=<base64>; h2=<base64>; ...` — hashed client pubkeys |
-| `_disc` | TXT | `dht=1; relay=<csv>` — informational list of substrates |
+The packet **MUST** contain a single TXT resource record:
+
+| Record name | Type | TTL | Contents |
+|---|---|---|---|
+| `_openhost` | TXT | 300 | `base64url(signature \|\| canonical_bytes)` — the 64-byte Ed25519 signature over `canonical_bytes` concatenated with the canonical byte representation of an `OpenhostRecord` (see below). |
+
+`canonical_bytes` is the output of [`OpenhostRecord::canonical_signing_bytes`](../crates/openhost-core/src/pkarr_record/mod.rs), a deterministic, domain-separated encoding that carries every semantic field of the record — protocol version, Unix-seconds timestamp `ts`, DTLS fingerprint `dtls_fp`, declared `roles`, per-host allowlist `salt`, the `allow` list of 16-byte truncated HMAC entries, a per-paired-client `ice` list (each entry: 16-byte client hash + sealed-box ciphertext), and the informational `disc` hints string. Its exact layout is fixed in the openhost-core crate and reproduced verbatim in [`test-vectors/pkarr_record.json`](test-vectors/pkarr_record.json).
+
+The base64url encoding uses the RFC 4648 §5 URL-safe alphabet without padding. If the encoded string exceeds 255 bytes, it **MUST** be split across multiple DNS character strings within the same TXT RDATA (per RFC 1035 §3.3.14); decoders reconstruct the payload by concatenating the character strings in the order they appear.
+
+Two signatures bind the record:
+
+- The **inner Ed25519 signature** (the 64-byte signature prefix of the `_openhost` TXT value) covers `canonical_bytes` and is produced by the host's Ed25519 identity key. Verifiers **MUST** re-check this signature against the host's public key before trusting the record.
+- The **outer BEP44 signature** on the Pkarr packet itself is also produced by the same Ed25519 identity key — no separate keypair is used — and covers the bencoded DNS packet plus the BEP44 `seq` field. The `seq` field is set to the publication time in seconds since the Unix epoch (equal to `ts` inside the record).
 
 **Constraints:**
 
-- The total signed packet **MUST** fit in 1000 bytes (the BEP44 limit).
-- `ts` is the publication time in seconds since the Unix epoch. Clients **MUST** reject records where `|now - ts| > 7200` (two hours).
-- `fp` is the SHA-256 fingerprint of the daemon's DTLS certificate, encoded as lowercase hex. The daemon **SHOULD** rotate this certificate daily or on restart.
-- Each `<clienthash>` is 16 bytes of HMAC-SHA256 keyed by a per-host salt (published within the `@` record as `salt=<hex>`), applied to the client's 32-byte Ed25519 public key. Unpaired observers see only the existence of ICE records, not which client they belong to. The 16 bytes are encoded as z-base-32 (≈26 characters) in the record name.
+- The encoded DNS packet (the BEP44 `v` value) **MUST** fit in 1000 bytes (the BEP44 mutable-item limit).
+- `ts` is the publication time in seconds since the Unix epoch. Verifiers **MUST** reject records where `|now - ts| > 7200` (two hours).
+- `dtls_fp` is the SHA-256 fingerprint of the daemon's DTLS certificate, 32 raw bytes inside `canonical_bytes`. The daemon **SHOULD** rotate this certificate daily or on restart.
+- Each `client_hash` is 16 bytes of HMAC-SHA256 keyed by the per-host `salt` applied to the client's 32-byte Ed25519 public key. Unpaired observers see only that ICE blobs exist, not which client they address.
 - Per-client ICE candidate ciphertext is a libsodium-compatible **sealed box** (`crypto_box_seal`): anonymous X25519 ephemeral sender to the recipient client's X25519 public key, with the XSalsa20-Poly1305 AEAD. The output is `ephemeral_pk || XSalsa20-Poly1305(shared_key, nonce = Blake2b-24(ephemeral_pk || recipient_pk), plaintext)`.
 - The client's X25519 public key is derived from its Ed25519 identity via the Edwards-to-Montgomery conversion (libsodium's `crypto_sign_ed25519_pk_to_curve25519`), so clients and hosts maintain only one keypair.
-- The `_allow` record contains the same hashed client keys for the daemon's own dedupe and for clients to verify they are on the allowlist before attempting a connection.
-- `_disc` is informational; clients **MUST** try all substrates they know about regardless of the record's contents.
+- The `allow` list is carried inside `canonical_bytes` and lets clients verify they are paired before attempting a connection; the daemon uses it for dedupe.
+- `disc` is informational; clients **MUST** try all substrates they know about regardless of the record's contents.
+
+Republish cadence, relay fan-out, and resolver race semantics are specified in [`03-pkarr-records.md`](03-pkarr-records.md).
 
 ## 3. Connection establishment sequence
 

--- a/spec/03-pkarr-records.md
+++ b/spec/03-pkarr-records.md
@@ -26,7 +26,7 @@ openhost uses three public substrates, in descending order of preference for res
 
 ### 2.1 Public Pkarr HTTP relays
 
-Pkarr relays are HTTPS endpoints that accept signed BEP44 records and serve them to clients. A client implementation **MUST** ship with a bundled list of known public relays, **MUST** query at least three in parallel for any resolution, and **MUST** accept the record with the highest `seq` value whose signature and internal timestamp both validate.
+Pkarr relays are HTTPS endpoints that accept signed BEP44 records and serve them to clients. A client implementation **MUST** ship with a bundled list of known public relays, **MUST** query at least three independent substrates in parallel for any resolution (the bundled relays plus the Mainline DHT on native platforms, or — on browsers, where UDP is unavailable — at least three relays), and **MUST** accept the record with the highest `seq` value whose signature and internal timestamp both validate.
 
 Browsers cannot speak the Mainline DHT directly (no UDP in the browser sandbox), so Pkarr relays are the primary substrate for the browser extension.
 

--- a/spec/03-pkarr-records.md
+++ b/spec/03-pkarr-records.md
@@ -86,4 +86,7 @@ Clients **MUST NOT** republish records they observe. Only the holder of the Ed25
 
 ## 5. Test vectors
 
-Packet construction, signing, and verification test vectors live in [`test-vectors/`](test-vectors/). The vectors include a reference BEP44 blob for a fixed keypair and timestamp, the Nostr-wrapped equivalent, and a set of negative tests (bad signature, out-of-window timestamp, oversized packet).
+Packet construction, signing, and verification test vectors live in [`test-vectors/`](test-vectors/):
+
+- [`pkarr_record.json`](test-vectors/pkarr_record.json) — the reference `SignedRecord` (canonical signing bytes, Ed25519 signature, and negative-validation cases). Every implementation **MUST** reproduce its `canonical_hex` and `signature_hex` for the fixed seed.
+- [`pkarr_packet.json`](test-vectors/pkarr_packet.json) — the reference `SignedRecord` after passing through the Pkarr layer: the bytes of a well-formed `pkarr::SignedPacket` (32-byte public key, 64-byte BEP44 signature, 8-byte microsecond timestamp, encoded DNS packet). Implementations **MUST** decode these bytes back into the referenced `SignedRecord` and **MUST** produce byte-identical output when re-encoding the same record with the same signing seed against the same pkarr wire version.

--- a/spec/test-vectors/pkarr_packet.json
+++ b/spec/test-vectors/pkarr_packet.json
@@ -1,0 +1,57 @@
+{
+  "description": "openhost-pkarr M2 bridge: SignedRecord <-> pkarr::SignedPacket round-trip. Every implementation MUST produce a packet that decodes back to the referenced SignedRecord from pkarr_record.json, and MUST accept the fixture bytes below as input.",
+  "version": "openhost1",
+  "pkarr_crate_version": "5.0.4",
+  "encoding_notes": [
+    "All bytes are hex-encoded.",
+    "Signing key and OpenhostRecord are inherited from pkarr_record.json::reference_record_v1 — not duplicated here.",
+    "The `_openhost` TXT record value is base64url-encoded (no padding) bytes of (signature || canonical_signing_bytes). The signature is taken verbatim from pkarr_record.json::reference_record_v1.signature_hex. The canonical bytes equal pkarr_record.json::reference_record_v1.canonical_hex.",
+    "`packet_bytes_hex` is the output of `SignedPacket::as_bytes()` in the pkarr 5.x crate — i.e. `<32 public_key><64 signature><8 timestamp_micros_be><encoded_dns_packet>`. Total length 584 bytes for this vector.",
+    "The 8-byte timestamp is big-endian microseconds since the Unix epoch. For this vector: 1_700_000_000 * 1_000_000 = 1_700_000_000_000_000 = 0x060a24181e4000.",
+    "Fixture bytes depend on the exact pkarr wire format (BEP44 signature over the bencoded DNS packet). Implementations MAY regenerate when bumping pkarr, but MUST document the pkarr version used."
+  ],
+  "vectors": [
+    {
+      "name": "reference_packet_v1",
+      "input_vector_ref": "pkarr_record.json::reference_record_v1",
+      "signing_seed_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+      "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
+      "record_ts": 1700000000,
+      "pkarr_timestamp_micros": 1700000000000000,
+      "openhost_txt_name": "_openhost",
+      "openhost_txt_ttl": 300,
+      "openhost_blob_len": 294,
+      "openhost_blob_layout": "first 64 bytes = Ed25519 signature (pkarr_record.json::reference_record_v1.signature_hex); remaining 230 bytes = canonical_signing_bytes (pkarr_record.json::reference_record_v1.canonical_hex)",
+      "bep44_outer_signature_hex": "7d8fff2a48157d10d2ed16ca48b7d5f18e132cc9c5b0b0e0cd880f5354bebf7c4ffe786a3c58cd775b658c278ad4c7a3e6367cff23a5a9a637bd6b34843f620f",
+      "packet_bytes_len": 584,
+      "packet_bytes_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a7d8fff2a48157d10d2ed16ca48b7d5f18e132cc9c5b0b0e0cd880f5354bebf7c4ffe786a3c58cd775b658c278ad4c7a3e6367cff23a5a9a637bd6b34843f620f00060a24181e4000000080000000000100000000095f6f70656e686f7374343437706a6f79636e7372666d78696b6d39356a6831337938386538716e687a75356b756e676a707879657067743761386b72707900001000010000012c018afe65364f69637743705f615941796f6245524a324565354d6e36793156356a71643567426c656b68443975464a456d514c6146355141723153495634696c4a6969554333496d34525732787741675a6f663667754643514676634756756147397a64444542414141414147565438514243516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a4351675a7a5a584a325a58495245524552455245524552455245524552455245524552455245524552455245524552455245524552455141427a7a5a4a464d515a636151585558656135423852527741427a7a5a4a464d515a63615158555865613542385252778a414141456a75377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753441476d526f644430784f7942795a57786865543177613246796369356c654746746347786c"
+    }
+  ],
+  "negative": [
+    {
+      "name": "packet_too_large",
+      "tweak": "Encode a record whose `ice` vector is padded (e.g. 30 blobs, 200-byte ciphertexts each) so the encoded DNS packet exceeds 1000 bytes.",
+      "expect": "Encoder returns PacketTooLarge (or the upstream pkarr build error for the same condition)."
+    },
+    {
+      "name": "openhost_sig_invalid",
+      "tweak": "Flip a single bit of the canonical-bytes portion of the `_openhost` TXT blob AFTER encoding the packet. The outer BEP44 signature still verifies, but the inner Ed25519 signature over canonical bytes no longer matches.",
+      "expect": "Decode succeeds; SignedRecord::verify fails with BadSignature."
+    },
+    {
+      "name": "bep44_sig_invalid",
+      "tweak": "Flip a bit of bytes [32..96] of `packet_bytes_hex` (the BEP44 outer signature field).",
+      "expect": "pkarr::SignedPacket deserialization fails before our decoder runs."
+    },
+    {
+      "name": "timestamp_drift",
+      "tweak": "Emit a packet with the BEP44 timestamp set to `(record.ts + 5) * 1_000_000` microseconds while keeping record.ts = 1700000000.",
+      "expect": "Resolver returns TimestampDrift."
+    },
+    {
+      "name": "seq_regression",
+      "tweak": "Resolve the reference packet with cached_seq = record.ts + 1 = 1700000001.",
+      "expect": "Resolver returns SeqRegression."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements M2 of the openhost roadmap: a new `openhost-pkarr` crate that bridges `openhost_core::pkarr_record::SignedRecord` to and from `pkarr::SignedPacket` and fans publication out across public Pkarr HTTP relays plus the Mainline DHT.

- **codec**: single `_openhost` TXT record carries `base64url(sig || canonical_signing_bytes)`; the BEP44 outer signature is produced by the same Ed25519 identity key via `pkarr::Keypair::from_secret_key`.
- **publisher**: 30-minute republish loop (per spec §1) with an on-demand trigger channel; CAS-threaded seq handoff; `Transport` trait for test injection.
- **resolver**: wraps `pkarr::Client::resolve_most_recent` with openhost-layer validation — decode, ±1s timestamp-drift check, `SignedRecord::verify` (2h freshness + signature + consistency), and caller-supplied `cached_seq` monotonicity.
- **nostr** (feature-flagged): NIP-78 kind-30078 envelope builder only; publish path deferred to M3 per the handoff's "defer if it grows" guidance.
- **spec**: `01-wire-format.md §2` replaces the four-row textual table with the opaque `_openhost` TXT form. `03-pkarr-records.md §5` points at the new reference vector.
- **test vectors**: new `spec/test-vectors/pkarr_packet.json` pinning the full 584-byte `SignedPacket::as_bytes()` for the reference `SignedRecord`.
- **deps**: workspace bumped to `pkarr = "5"` (was 3) and `mainline = "6"` (was 4) — matching current stable.

21 tests total (7 codec + 3 publisher + 5 resolver + 3 nostr + 3 round-trip integration). `cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo clippy --features nostr`, `cargo test --workspace`, `cargo test --features nostr`, and `cargo doc --workspace --no-deps` all green locally.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo clippy -p openhost-pkarr --all-targets --features nostr -- -D warnings`
- [x] `cargo test --workspace --all-targets` (18 unit + 3 integration)
- [x] `cargo test -p openhost-pkarr --features nostr` (21 unit + 3 integration)
- [x] `cargo doc --workspace --no-deps`
- [x] Round-trip: fixture bytes decode back to the reference record; re-encoding produces byte-identical output.
- [x] Tampering the decoded canonical bytes fails the inner Ed25519 signature as expected.
- [ ] CI green on merge.

## Out of scope (M3)

- WebRTC / ICE integration.
- Daemon binary wiring the publisher to real network-interface / DTLS-cert / allowlist change events.
- Nostr WebSocket publish path.
- Custom relay-race with an explicit 1.5s grace window (delegated to pkarr's internal race for M2).
- `last_seq` persistence across publisher restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)