### PR TITLE
⚡ Bolt: Optimize response head encoding in forwarder

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-18 - [Optimization of HTTP Header Encoding]
+**Learning:** Using `format!` to construct strings that are immediately converted to bytes and appended to a buffer causes an unnecessary heap allocation and a copy.
+**Action:** Use the `write!` macro directly on types that implement `std::io::Write` (like `Vec<u8>`) to avoid intermediate allocations in hot paths.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -31,6 +31,7 @@ use http_body_util::{BodyExt, Full, Limited};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -367,7 +368,10 @@ fn encode_response_head(
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Bolt: Use write! to append directly to the Vec buffer, avoiding an
+    // intermediate String allocation from format!.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to a Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What: The optimization replaces a `format!` macro call with `write!` directly into a `Vec<u8>` buffer.
🎯 Why: `format!` creates an intermediate heap-allocated `String`, which is then copied to the buffer and discarded. Using `write!` on the `Vec<u8>` (which implements `std::io::Write`) avoids this allocation.
📊 Impact: Reduces heap allocations by 1 per HTTP response. While small, this is in the hot path of the localhost forwarder.
🔬 Measurement: Verified with existing tests in `crates/openhost-daemon/src/forward.rs` ensuring identical output format.

---
*PR created automatically by Jules for task [14670973996923878571](https://jules.google.com/task/14670973996923878571) started by @vamzi*