### PR TITLE
feat(daemon): allowlist enforcement + per-client rate limit (M7b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,23 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Breaking changes
+
+- **Allowlist enforcement is on by default** (`pkarr.offer_poll.enforce_allowlist = true`). Upgraders running PR #7a configurations will see every inbound offer rejected until they either (a) pair their clients via `openhostd pair add <pubkey>`, or (b) explicitly set `enforce_allowlist = false` in the config. The daemon logs a startup `warn!` when enforcement is on, the pair DB is empty, and `watched_clients` is non-empty — operators see the misconfiguration in the first line of the boot log. The escape-hatch (`false`) preserves PR #7a's permissive behavior unchanged.
+
 ### Added
 
+- `openhost-daemon` M7b allowlist enforcement + per-client rate limit:
+  - New `openhost-daemon::pairing` module: plaintext TOML pair DB at `~/.config/openhost/allow.toml` (overridable via `pairing.db_path`), atomic write with mode 0600 on Unix, `PairingDb::compute_hashes` projects entries into the `_allow` HMAC hashes already published in the `_openhost` record. Missing file = empty list (first-run ergonomics); malformed file or duplicate entries = hard error.
+  - New `openhost-daemon::rate_limit::TokenBucket` — pure synchronous token-bucket keyed per `client_pk`. Caller threads `now: Instant` in, keeping the poller's existing `now_instant` reuse clean and making unit tests deterministic.
+  - `SharedState` gets `replace_allow`, `is_client_allowed`, `add_client_hash`, `remove_client_hash` helpers; `allow` now mutates at runtime via SIGHUP.
+  - `OfferPoller` gains two new gates, evaluated after unseal + cross-check: (1) `is_client_allowed` when `enforce_allowlist = true` (default); (2) `TokenBucket::try_consume` per `client_pk`. Both failure paths advance the dedup cursor so a bypass flood can't drive the daemon into a decrypt-every-tick workload. Allowlist runs before rate-limit so unauthorised peers can't drain legitimate peers' buckets.
+  - `signal::reload_signal()` awaits SIGHUP on Unix (returns `Pending` on Windows — pairing changes require a daemon restart there). `App::run` now drives `tokio::select! { biased; shutdown => break; reload => reload_pair_db + publisher.trigger(); }`, hot-swapping the allow list without tearing down live sessions.
+  - New CLI subcommand tree `openhostd pair {add <pubkey> [--nickname <str>], remove <pubkey>, list}`. Each mutation rewrites the TOML atomically and prints a reminder to SIGHUP the running daemon.
+  - Config surface: new `[pairing] db_path` top-level section + `pkarr.offer_poll.{enforce_allowlist, rate_limit_burst, rate_limit_refill_secs}`. `Config::validate` rejects zero burst, non-finite / non-positive refill.
+  - New `DaemonError::Pairing(PairingError)` variant. `PairingError::{Io, Toml, TomlSer, InvalidPubkey, Duplicate, AlreadyPresent, NotPresent}`.
+  - 4 new integration tests in `tests/pairing_enforcement.rs`: authorized client processed, unauthorized client rejected, `enforce_allowlist = false` preserves PR #7a behavior, and `rate_limit_burst = 2` caps a 5-offer burst to exactly 2 `handle_offer` calls. 15 new unit tests across `pairing` + `rate_limit` + `publish` (allowlist helpers).
+  - **Out of scope for this PR:** mid-session revocation of an already-authenticated DC (the binding-time cross-check of the allow list is a PR #7c item — today an authenticated session survives until the client naturally disconnects or the daemon shuts down). The offer-poll gate is the primary line of defense.
 - `openhost-daemon` M7a offer-record polling + per-client answer publishing:
   - New `openhost-pkarr::offer` module: `OfferRecord`/`OfferPlaintext`/`AnswerEntry`/`AnswerPlaintext` types, domain-separated inner-plaintext codec (`openhost-offer-inner1` / `openhost-answer-inner1`), sealed-box wrappers over libsodium `crypto_box_seal`, `host_hash_label` + `client_hash_label` helpers (z-base-32 of a 16-byte hash), and `encode_with_answers` which emits a single `SignedPacket` carrying the main `_openhost` TXT PLUS one extra `_answer-<client-hash>` TXT per queued answer. The encoder auto-evicts the oldest answers when the packet would exceed BEP44's 1000-byte `v` limit. 15 unit tests covering roundtrip, tamper, encoding invariance (with-empty-answers packets are byte-identical to `encode()`), and eviction.
   - New `openhost-pkarr::AnswerSource` hook on `Publisher` — a `FnMut() -> Vec<AnswerEntry>` the publisher calls each tick, folding the snapshot into the outgoing packet via `encode_with_answers`. Daemons that don't need it pass `None` and the bytes match the plain codec exactly.

--- a/crates/openhost-daemon/README.md
+++ b/crates/openhost-daemon/README.md
@@ -79,6 +79,56 @@ callers can drive the listener directly for tests or custom signalling.
   is pinned in the daemon's published record (`openhost-resolve` prints
   it if you want to verify).
 
+## Pairing (PR #7b)
+
+The daemon will only process offers from clients you've explicitly
+paired with it. The pair DB is a plaintext TOML file at
+`~/.config/openhost/allow.toml` (path overridable via
+`pairing.db_path`). Each entry carries the client's z-base-32 pubkey
+and an optional nickname:
+
+```toml
+[[pair]]
+pubkey   = "yRyanemyt4kh9s51tt51mbe8zf88w73fnoh4q4zz7zs68x6d3a9o"
+nickname = "my laptop"
+```
+
+Manage entries via the CLI:
+
+```bash
+openhostd pair list
+openhostd pair add <zbase32-pubkey> --nickname "my laptop"
+openhostd pair remove <zbase32-pubkey>
+```
+
+On Unix, `openhostd pair add/remove` edits the file atomically and
+prints a reminder to SIGHUP the running daemon to apply the change
+without a restart. On Windows, restart the daemon to reload.
+
+Enforcement is on by default (`pkarr.offer_poll.enforce_allowlist =
+true`). Unpaired clients' offers are dropped at poll time with a
+`warn!` pointing at the CLI command. For isolated networks where the
+risk model doesn't require pairing, set `enforce_allowlist = false`
+to preserve the permissive PR #7a behavior.
+
+Abuse control: each paired client has a token-bucket rate limit (3
+burst, one refill per 5 seconds by default). Beyond the bucket the
+offer is dropped + logged without tearing down the poller.
+
+```toml
+[pkarr.offer_poll]
+enforce_allowlist        = true
+rate_limit_burst         = 3
+rate_limit_refill_secs   = 5.0
+watched_clients          = [ ... ]          # see below
+```
+
+**Relationship to `watched_clients`.** `watched_clients` is the set
+of pubkey zones the daemon polls; the pair DB is the set of pubkeys
+allowed to connect. Typically they overlap 1:1, but the two knobs are
+kept separate so operators can continue watching a zone after
+revoking a pair (useful for debugging pkarr-side outages).
+
 ## Offer-record polling (spec §3.3, PR #7a)
 
 The daemon picks up inbound WebRTC offers by polling pkarr for

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -207,6 +207,10 @@ impl App {
 
         // Drive the event loop: shutdown wins over concurrent SIGHUP
         // (`biased;` makes the select poll the shutdown arm first).
+        // Rapid SIGHUP bursts coalesce at the tokio-signal layer and
+        // at the loop boundary — we reload at most once per iteration.
+        // Reload is idempotent: a later SIGHUP just runs the load +
+        // replace_allow again, so coalescing is acceptable.
         loop {
             tokio::select! {
                 biased;

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -20,10 +20,12 @@ use crate::forward::Forwarder;
 use crate::identity_store::{load_or_create, FsKeyStore, KeyStore};
 use crate::listener::PassivePeer;
 use crate::offer_poller::{OfferPoller, OfferPollerConfig};
+use crate::pairing;
 use crate::publish::{self, PublishService, SharedState};
-use crate::signal::shutdown_signal;
+use crate::signal::{reload_signal, shutdown_signal};
 use openhost_core::identity::SigningKey;
 use openhost_pkarr::{InitialPublishOutcome, Resolve, Transport};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -48,12 +50,17 @@ pub struct App {
     /// on the `build_with_transport` test path that doesn't provide a
     /// resolver, keeping pre-PR #7a tests working without changes.
     poller: Option<OfferPoller>,
+    /// Resolved path to the pairing DB. Consulted on SIGHUP to reload
+    /// the allow list + trigger a republish.
+    pair_db_path: PathBuf,
 }
 
 impl App {
     /// Build the daemon against the real pkarr network.
     pub async fn build(cfg: Config) -> Result<Self> {
         let (identity, cert, state) = init_common(&cfg).await?;
+        let pair_db_path = resolve_pair_db_path(&cfg);
+        load_pair_db_into_state(&pair_db_path, &state, &cfg)?;
         let forwarder = build_forwarder(&cfg)?;
         let listener =
             build_listener(&cert, identity.clone(), state.clone(), forwarder.clone()).await?;
@@ -74,6 +81,7 @@ impl App {
             publisher,
             listener,
             poller,
+            pair_db_path,
         })
     }
 
@@ -82,6 +90,8 @@ impl App {
     /// offer-polling path.
     pub async fn build_with_transport(cfg: Config, transport: Arc<dyn Transport>) -> Result<Self> {
         let (identity, cert, state) = init_common(&cfg).await?;
+        let pair_db_path = resolve_pair_db_path(&cfg);
+        load_pair_db_into_state(&pair_db_path, &state, &cfg)?;
         let forwarder = build_forwarder(&cfg)?;
         let listener =
             build_listener(&cert, identity.clone(), state.clone(), forwarder.clone()).await?;
@@ -94,6 +104,7 @@ impl App {
             publisher,
             listener,
             poller: None,
+            pair_db_path,
         })
     }
 
@@ -107,6 +118,8 @@ impl App {
         resolver: Arc<dyn Resolve>,
     ) -> Result<Self> {
         let (identity, cert, state) = init_common(&cfg).await?;
+        let pair_db_path = resolve_pair_db_path(&cfg);
+        load_pair_db_into_state(&pair_db_path, &state, &cfg)?;
         let forwarder = build_forwarder(&cfg)?;
         let listener =
             build_listener(&cert, identity.clone(), state.clone(), forwarder.clone()).await?;
@@ -127,7 +140,14 @@ impl App {
             publisher,
             listener,
             poller,
+            pair_db_path,
         })
+    }
+
+    /// Path to the pairing DB this daemon is using. Exposed for
+    /// integration tests that want to mutate the DB and send SIGHUP.
+    pub fn pair_db_path(&self) -> &Path {
+        &self.pair_db_path
     }
 
     /// The host's Ed25519 identity.
@@ -184,7 +204,35 @@ impl App {
             dtls_fp = %self.cert.fingerprint_colon_hex(),
             "openhostd: up",
         );
-        shutdown_signal().await;
+
+        // Drive the event loop: shutdown wins over concurrent SIGHUP
+        // (`biased;` makes the select poll the shutdown arm first).
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_signal() => {
+                    break;
+                }
+                _ = reload_signal() => {
+                    match reload_pair_db(&self.pair_db_path, &self.state) {
+                        Ok(count) => {
+                            tracing::info!(
+                                count,
+                                "openhostd: pairing DB reloaded; republishing",
+                            );
+                            self.publisher.trigger();
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                ?err,
+                                "openhostd: pairing DB reload failed; keeping previous allow list",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!("openhostd: shutdown signal received, stopping publisher");
         // Order: listener first (tears down in-flight DTLS); poller
         // next (stops the loop that might otherwise push a late answer
@@ -316,6 +364,9 @@ fn build_offer_poller(
             poll_interval: Duration::from_secs(cfg_poll.poll_secs),
             watched_clients: watched,
             per_client_throttle: Duration::from_secs(cfg_poll.per_client_throttle_secs),
+            enforce_allowlist: cfg_poll.enforce_allowlist,
+            rate_limit_burst: cfg_poll.rate_limit_burst,
+            rate_limit_refill_per_sec: 1.0 / cfg_poll.rate_limit_refill_secs,
         },
     ))
 }
@@ -337,6 +388,55 @@ fn build_forwarder(cfg: &Config) -> Result<Option<Arc<Forwarder>>> {
         }
         None => Ok(None),
     }
+}
+
+/// Resolve the pairing DB path from config, falling back to the
+/// platform default.
+fn resolve_pair_db_path(cfg: &Config) -> PathBuf {
+    cfg.pairing
+        .db_path
+        .clone()
+        .unwrap_or_else(pairing::default_db_path)
+}
+
+/// Load the pairing DB into `state.allow`. Missing file = empty allow
+/// list (not an error). Malformed file IS an error.
+fn load_pair_db_into_state(path: &Path, state: &SharedState, cfg: &Config) -> Result<()> {
+    let db = pairing::load(path)?;
+    let hashes = db.compute_hashes(&state.salt());
+    let count = hashes.len();
+    state.replace_allow(hashes);
+    tracing::info!(
+        count,
+        path = %path.display(),
+        "openhostd: loaded pairing DB",
+    );
+    // Startup warn: enforce_allowlist=on + empty DB + non-empty
+    // watched_clients is almost always a misconfiguration — operators
+    // upgrading from PR #7a will otherwise see every connection
+    // rejected without a clear explanation in the log.
+    if cfg.pkarr.offer_poll.enforce_allowlist
+        && count == 0
+        && !cfg.pkarr.offer_poll.watched_clients.is_empty()
+    {
+        tracing::warn!(
+            "openhostd: allowlist enforcement is on but the pair DB is empty; \
+             no client offer will be accepted. Add clients with \
+             `openhostd pair add <pubkey>` or set \
+             `pkarr.offer_poll.enforce_allowlist = false` in the config.",
+        );
+    }
+    Ok(())
+}
+
+/// Re-read the pairing DB + swap the allow list atomically. Used by
+/// the SIGHUP handler. Returns the new entry count on success.
+fn reload_pair_db(path: &Path, state: &SharedState) -> Result<usize> {
+    let db = pairing::load(path)?;
+    let hashes = db.compute_hashes(&state.salt());
+    let count = hashes.len();
+    state.replace_allow(hashes);
+    Ok(count)
 }
 
 /// Install a global `tracing_subscriber` with the configured level filter.

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -34,6 +34,9 @@ pub struct Config {
     /// Logging.
     #[serde(default)]
     pub log: LogConfig,
+    /// Pairing-database configuration.
+    #[serde(default)]
+    pub pairing: PairingConfig,
 }
 
 /// Identity keystore configuration.
@@ -94,6 +97,21 @@ pub struct OfferPollConfig {
     /// this many seconds per watched client, dropping floods without
     /// killing the loop. Defaults to 5.
     pub per_client_throttle_secs: u64,
+    /// Whether to require the client pubkey to be in the allowlist
+    /// (pairing DB) before processing its offer. Defaults to `true`.
+    /// Setting this to `false` preserves the permissive PR #7a
+    /// behavior; do so only on isolated networks.
+    #[serde(default = "default_enforce_allowlist")]
+    pub enforce_allowlist: bool,
+    /// Token-bucket burst capacity per client pubkey. At most this
+    /// many offers per client are processed back-to-back before the
+    /// refill rate kicks in. Defaults to 3.
+    #[serde(default = "default_rate_limit_burst")]
+    pub rate_limit_burst: u32,
+    /// Token-bucket refill rate in seconds per token. Defaults to 5.0
+    /// (one token per 5 s).
+    #[serde(default = "default_rate_limit_refill_secs")]
+    pub rate_limit_refill_secs: f64,
 }
 
 impl Default for OfferPollConfig {
@@ -102,8 +120,32 @@ impl Default for OfferPollConfig {
             poll_secs: 1,
             watched_clients: Vec::new(),
             per_client_throttle_secs: 5,
+            enforce_allowlist: default_enforce_allowlist(),
+            rate_limit_burst: default_rate_limit_burst(),
+            rate_limit_refill_secs: default_rate_limit_refill_secs(),
         }
     }
+}
+
+/// Pairing-database configuration.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct PairingConfig {
+    /// Path to the pairing TOML database. `None` resolves to the
+    /// platform-default path under the openhost config directory.
+    pub db_path: Option<PathBuf>,
+}
+
+fn default_enforce_allowlist() -> bool {
+    true
+}
+
+fn default_rate_limit_burst() -> u32 {
+    3
+}
+
+fn default_rate_limit_refill_secs() -> f64 {
+    5.0
 }
 
 /// DTLS certificate configuration.
@@ -210,6 +252,18 @@ impl Config {
         if self.pkarr.offer_poll.poll_secs == 0 {
             return Err(ConfigError::Invalid("pkarr.offer_poll.poll_secs must be > 0").into());
         }
+        if self.pkarr.offer_poll.rate_limit_burst == 0 {
+            return Err(
+                ConfigError::Invalid("pkarr.offer_poll.rate_limit_burst must be > 0").into(),
+            );
+        }
+        let refill = self.pkarr.offer_poll.rate_limit_refill_secs;
+        if !refill.is_finite() || refill <= 0.0 {
+            return Err(ConfigError::Invalid(
+                "pkarr.offer_poll.rate_limit_refill_secs must be finite and > 0",
+            )
+            .into());
+        }
         // Validate each watched-client pubkey parses as z-base-32 at
         // load time so a typo fails loudly rather than silently
         // producing a poller that never finds anything.
@@ -286,6 +340,7 @@ pub fn seed_config(data_dir: &Path) -> Config {
         },
         forward: None,
         log: LogConfig::default(),
+        pairing: PairingConfig::default(),
     }
 }
 

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -40,6 +40,10 @@ pub enum DaemonError {
     #[error(transparent)]
     OfferPoll(#[from] OfferPollError),
 
+    /// Pairing-database operation failed.
+    #[error(transparent)]
+    Pairing(#[from] crate::pairing::PairingError),
+
     /// Low-level I/O failure not caught by a more specific variant.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/crates/openhost-daemon/src/lib.rs
+++ b/crates/openhost-daemon/src/lib.rs
@@ -28,7 +28,9 @@ pub mod forward;
 pub mod identity_store;
 pub mod listener;
 pub mod offer_poller;
+pub mod pairing;
 pub mod publish;
+pub mod rate_limit;
 pub mod signal;
 
 pub use app::{init_tracing, App};
@@ -38,3 +40,4 @@ pub use error::{DaemonError, OfferPollError, Result};
 pub use forward::{ForwardResponse, Forwarder};
 pub use listener::PassivePeer;
 pub use offer_poller::{OfferPoller, OfferPollerConfig};
+pub use pairing::{PairEntry, PairingDb, PairingError};

--- a/crates/openhost-daemon/src/main.rs
+++ b/crates/openhost-daemon/src/main.rs
@@ -12,8 +12,10 @@
 //! tokio runtime.
 
 use clap::{Parser, Subcommand};
+use openhost_core::identity::PublicKey;
 use openhost_daemon::config::{self, Config};
 use openhost_daemon::identity_store::{load_or_create, FsKeyStore, KeyStore};
+use openhost_daemon::pairing;
 use openhost_daemon::{dtls_cert, init_tracing, App};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -38,6 +40,10 @@ enum Command {
     /// Identity management.
     #[command(subcommand)]
     Identity(IdentityCmd),
+
+    /// Pairing database management (authorized clients).
+    #[command(subcommand)]
+    Pair(PairCmd),
 }
 
 #[derive(Debug, Subcommand)]
@@ -47,6 +53,26 @@ enum IdentityCmd {
 
     /// Regenerate the DTLS certificate (keeps the Ed25519 identity).
     Rotate,
+}
+
+#[derive(Debug, Subcommand)]
+enum PairCmd {
+    /// Add a client to the pairing database.
+    Add {
+        /// z-base-32 client pubkey (52 chars).
+        pubkey: String,
+        /// Optional human-readable nickname for the operator's sanity.
+        /// Stays local; never enters the published pkarr record.
+        #[arg(long)]
+        nickname: Option<String>,
+    },
+    /// Remove a client from the pairing database.
+    Remove {
+        /// z-base-32 client pubkey (52 chars).
+        pubkey: String,
+    },
+    /// List the currently-paired clients.
+    List,
 }
 
 fn main() -> ExitCode {
@@ -106,8 +132,58 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 so the new fingerprint lands in the next signed record."
             );
         }
+        Command::Pair(pair_cmd) => run_pair(&cfg, pair_cmd)?,
     }
 
+    Ok(())
+}
+
+fn run_pair(cfg: &Config, cmd: PairCmd) -> anyhow::Result<()> {
+    let db_path = cfg
+        .pairing
+        .db_path
+        .clone()
+        .unwrap_or_else(pairing::default_db_path);
+    match cmd {
+        PairCmd::Add { pubkey, nickname } => {
+            let pk = PublicKey::from_zbase32(&pubkey)
+                .map_err(|e| anyhow::anyhow!("invalid pubkey {pubkey:?}: {e}"))?;
+            pairing::add(&db_path, &pk, nickname.clone())?;
+            println!("added {pk}");
+            if let Some(n) = nickname {
+                println!("  nickname: {n}");
+            }
+            eprintln!(
+                "openhostd: pair DB updated at {}. Send SIGHUP to the running daemon \
+                 (or restart) to apply.",
+                db_path.display(),
+            );
+        }
+        PairCmd::Remove { pubkey } => {
+            let pk = PublicKey::from_zbase32(&pubkey)
+                .map_err(|e| anyhow::anyhow!("invalid pubkey {pubkey:?}: {e}"))?;
+            pairing::remove(&db_path, &pk)?;
+            println!("removed {pk}");
+            eprintln!(
+                "openhostd: pair DB updated at {}. Send SIGHUP to the running daemon \
+                 (or restart) to apply.",
+                db_path.display(),
+            );
+        }
+        PairCmd::List => {
+            let db = pairing::load(&db_path)?;
+            if db.pairs.is_empty() {
+                eprintln!("openhostd: pair DB at {} is empty", db_path.display());
+            } else {
+                for entry in &db.pairs {
+                    match &entry.nickname {
+                        Some(n) => println!("{}  # {n}", entry.pubkey),
+                        None => println!("{}", entry.pubkey),
+                    }
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/offer_poller.rs
+++ b/crates/openhost-daemon/src/offer_poller.rs
@@ -334,6 +334,13 @@ async fn process_client_packet(
     // Runs BEFORE the rate-limit consume so an unpaired flood can't
     // drain a legitimate client's bucket (each pk has its own entry
     // anyway, but the ordering is also cheap and readable).
+    //
+    // Note on log severity: the FIRST rejection for an unpaired pk
+    // logs at `warn!` so operators see the actionable message. Any
+    // subsequent tick from the same unpaired pk falls into the
+    // per-client throttle branch above and logs at `debug!` instead
+    // — preventing a single misconfigured client from flooding the
+    // daemon's `warn!` stream.
     if cfg.enforce_allowlist && !state.is_client_allowed(client_pk) {
         tracing::warn!(
             client = %client_pk,

--- a/crates/openhost-daemon/src/offer_poller.rs
+++ b/crates/openhost-daemon/src/offer_poller.rs
@@ -25,6 +25,7 @@
 
 use crate::listener::PassivePeer;
 use crate::publish::SharedState;
+use crate::rate_limit::TokenBucket;
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_pkarr::{
     decode_offer_from_packet, hash_offer_sdp, AnswerEntry, AnswerPlaintext, Resolve,
@@ -45,6 +46,14 @@ pub struct OfferPollerConfig {
     pub watched_clients: Vec<PublicKey>,
     /// At most one offer per client per this duration is processed.
     pub per_client_throttle: Duration,
+    /// Whether to require the unsealed client pubkey to be in the
+    /// allow list before running `handle_offer`. See PR #7b.
+    pub enforce_allowlist: bool,
+    /// Token-bucket burst capacity per client pubkey.
+    pub rate_limit_burst: u32,
+    /// Token-bucket refill rate in tokens per second (= 1.0 /
+    /// `rate_limit_refill_secs` in the config).
+    pub rate_limit_refill_per_sec: f64,
 }
 
 impl Default for OfferPollerConfig {
@@ -53,6 +62,9 @@ impl Default for OfferPollerConfig {
             poll_interval: Duration::from_secs(1),
             watched_clients: Vec::new(),
             per_client_throttle: Duration::from_secs(5),
+            enforce_allowlist: true,
+            rate_limit_burst: 3,
+            rate_limit_refill_per_sec: 1.0 / 5.0,
         }
     }
 }
@@ -127,13 +139,17 @@ impl Drop for OfferPoller {
     }
 }
 
-/// Seen-cache entry: the highest `ts` we've already processed for this
-/// client, plus when we last touched the entry (for TTL eviction).
-#[derive(Debug, Clone, Copy)]
-struct Seen {
+/// Per-client cache entry. Bundles:
+/// - Seen-cache: the highest `ts` we've processed + last-touch time
+///   (for TTL eviction).
+/// - Token bucket: abuse-control gate on how often we'll spend CPU
+///   running `handle_offer` for this client.
+#[derive(Debug, Clone)]
+struct ClientState {
     last_ts: u64,
     last_touched: Instant,
     last_processed: Option<Instant>,
+    bucket: TokenBucket,
 }
 
 const SEEN_TTL: Duration = Duration::from_secs(600);
@@ -147,7 +163,7 @@ async fn run_poll_loop(
     cfg: OfferPollerConfig,
     mut shutdown_rx: watch::Receiver<bool>,
 ) {
-    let mut seen: HashMap<PublicKey, Seen> = HashMap::new();
+    let mut seen: HashMap<PublicKey, ClientState> = HashMap::new();
     let mut ticker = tokio::time::interval(cfg.poll_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // `interval(..)` fires immediately on the first tick; that's exactly
@@ -185,7 +201,7 @@ async fn poll_one_cycle(
     state: &SharedState,
     publisher_trigger: &Arc<dyn Fn() + Send + Sync>,
     cfg: &OfferPollerConfig,
-    seen: &mut HashMap<PublicKey, Seen>,
+    seen: &mut HashMap<PublicKey, ClientState>,
 ) {
     let now_instant = Instant::now();
     let daemon_pk = identity.public_key();
@@ -230,7 +246,7 @@ async fn process_client_packet(
     state: &SharedState,
     publisher_trigger: &Arc<dyn Fn() + Send + Sync>,
     cfg: &OfferPollerConfig,
-    seen: &mut HashMap<PublicKey, Seen>,
+    seen: &mut HashMap<PublicKey, ClientState>,
     now_instant: Instant,
 ) {
     let offer_record = match decode_offer_from_packet(packet, daemon_pk) {
@@ -255,11 +271,16 @@ async fn process_client_packet(
     let packet_ts: u64 = packet.timestamp().into();
     let packet_ts_secs = packet_ts / openhost_pkarr::MICROS_PER_SECOND;
 
-    // Dedup + throttle.
-    let entry = seen.entry(*client_pk).or_insert(Seen {
+    // Dedup + throttle. Entry construction seeds a fresh token bucket.
+    let entry = seen.entry(*client_pk).or_insert_with(|| ClientState {
         last_ts: 0,
         last_touched: now_instant,
         last_processed: None,
+        bucket: TokenBucket::new(
+            cfg.rate_limit_burst,
+            cfg.rate_limit_refill_per_sec,
+            now_instant,
+        ),
     });
     entry.last_touched = now_instant;
     if packet_ts_secs <= entry.last_ts {
@@ -303,6 +324,31 @@ async fn process_client_packet(
             outer = %client_pk,
             inner = %plaintext.client_pk,
             "offer poll: inner client_pk mismatch; tearing down",
+        );
+        entry.last_ts = packet_ts_secs;
+        entry.last_processed = Some(now_instant);
+        return;
+    }
+
+    // PR #7b allowlist gate: reject offers from unpaired clients.
+    // Runs BEFORE the rate-limit consume so an unpaired flood can't
+    // drain a legitimate client's bucket (each pk has its own entry
+    // anyway, but the ordering is also cheap and readable).
+    if cfg.enforce_allowlist && !state.is_client_allowed(client_pk) {
+        tracing::warn!(
+            client = %client_pk,
+            "offer poll: client is not in allowlist; skipping. Add via 'openhostd pair add'.",
+        );
+        entry.last_ts = packet_ts_secs;
+        entry.last_processed = Some(now_instant);
+        return;
+    }
+
+    // PR #7b rate-limit gate: consume a token. On empty bucket, skip.
+    if !entry.bucket.try_consume(now_instant) {
+        tracing::warn!(
+            client = %client_pk,
+            "offer poll: client rate-limited; skipping",
         );
         entry.last_ts = packet_ts_secs;
         entry.last_processed = Some(now_instant);

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -56,15 +56,17 @@ pub struct PairingDb {
 impl PairingDb {
     /// Parsed entries as `(PublicKey, Option<nickname>)`. Invalid
     /// z-base-32 entries are rejected up-front by [`load`]; this method
-    /// cannot fail.
+    /// cannot fail when the DB was produced by [`load`].
     ///
     /// # Panics
     ///
     /// Panics if any `pubkey` fails `PublicKey::from_zbase32`. `load`
-    /// enforces the invariant; direct mutators outside this module
-    /// must uphold it.
+    /// enforces the invariant; because `PairingDb` is `Deserialize`,
+    /// callers who bypass `load` (e.g. `toml::from_str` directly)
+    /// must re-validate before using `parsed` / `compute_hashes`.
+    /// `pub(crate)` to keep the panic-boundary narrow.
     #[must_use]
-    pub fn parsed(&self) -> Vec<(PublicKey, Option<String>)> {
+    pub(crate) fn parsed(&self) -> Vec<(PublicKey, Option<String>)> {
         self.pairs
             .iter()
             .map(|p| {

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -1,0 +1,333 @@
+//! Pairing database — the operator's allowlist of authorized clients.
+//!
+//! Format: TOML at `~/.config/openhost/allow.toml` (overridable via
+//! `Config.pairing.db_path`). One `[[pair]]` array entry per paired
+//! client. Each entry carries the client's z-base-32 pubkey and an
+//! optional human-readable nickname.
+//!
+//! ```toml
+//! [[pair]]
+//! pubkey = "yRyanemyt4kh9s51tt51mbe8zf88w73fnoh4q4zz7zs68x6d3a9o"
+//! nickname = "my laptop"
+//! added_at = 1_700_000_000
+//! ```
+//!
+//! Mutations: `openhostd pair add <pubkey> [--nickname <str>]` /
+//! `openhostd pair remove <pubkey>` write the file atomically and then
+//! send SIGHUP to the running daemon so it reloads without a restart.
+//! Missing file is treated as an empty list, not an error — first-run
+//! ergonomics matter.
+//!
+//! Permissions: 0600 on Unix (same atomic write-tmp-then-rename pattern
+//! as `identity_store`). On Windows the file inherits the default ACL
+//! from its parent directory.
+
+use openhost_core::crypto::allowlist_hash;
+use openhost_core::identity::PublicKey;
+use openhost_core::pkarr_record::SALT_LEN;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// One paired client.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PairEntry {
+    /// z-base-32 Ed25519 pubkey.
+    pub pubkey: String,
+    /// Operator-chosen nickname. Never leaves the local file; never
+    /// enters the published `_openhost` zone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    /// Unix seconds when the entry was added. Informational only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub added_at: Option<u64>,
+}
+
+/// The on-disk pairing database.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct PairingDb {
+    /// Ordered list of paired clients. Order is preservation-only; the
+    /// file is rewritten on every mutation so operators can hand-edit.
+    #[serde(default, rename = "pair")]
+    pub pairs: Vec<PairEntry>,
+}
+
+impl PairingDb {
+    /// Parsed entries as `(PublicKey, Option<nickname>)`. Invalid
+    /// z-base-32 entries are rejected up-front by [`load`]; this method
+    /// cannot fail.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any `pubkey` fails `PublicKey::from_zbase32`. `load`
+    /// enforces the invariant; direct mutators outside this module
+    /// must uphold it.
+    #[must_use]
+    pub fn parsed(&self) -> Vec<(PublicKey, Option<String>)> {
+        self.pairs
+            .iter()
+            .map(|p| {
+                let pk = PublicKey::from_zbase32(&p.pubkey)
+                    .expect("PairingDb invariant: every stored pubkey parses");
+                (pk, p.nickname.clone())
+            })
+            .collect()
+    }
+
+    /// Compute the set of `_allow` hashes this DB projects into the
+    /// published `_openhost` record under `salt`.
+    #[must_use]
+    pub fn compute_hashes(&self, salt: &[u8; SALT_LEN]) -> Vec<[u8; 16]> {
+        self.parsed()
+            .into_iter()
+            .map(|(pk, _)| allowlist_hash(salt, &pk.to_bytes()))
+            .collect()
+    }
+
+    /// Whether the DB contains the given pubkey.
+    #[must_use]
+    pub fn contains(&self, pk: &PublicKey) -> bool {
+        self.pairs.iter().any(|p| {
+            PublicKey::from_zbase32(&p.pubkey)
+                .map(|k| &k == pk)
+                .unwrap_or(false)
+        })
+    }
+}
+
+/// Pairing-DB error surface.
+#[derive(Debug, Error)]
+pub enum PairingError {
+    /// I/O failure reading or writing the DB file.
+    #[error("pairing db io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// TOML parse failure.
+    #[error("pairing db parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+
+    /// TOML serialisation failure. In practice only fires on
+    /// implementation bugs; retained for completeness.
+    #[error("pairing db serialise error: {0}")]
+    TomlSer(#[from] toml::ser::Error),
+
+    /// A stored `pubkey` is not a valid z-base-32 Ed25519 key.
+    #[error("pairing db contains invalid pubkey entry: {pubkey:?}")]
+    InvalidPubkey {
+        /// The offending entry.
+        pubkey: String,
+    },
+
+    /// Duplicate pubkey in the loaded file.
+    #[error("pairing db contains duplicate pubkey: {0}")]
+    Duplicate(String),
+
+    /// `add` called for a pubkey that's already present.
+    #[error("pubkey already paired: {0}")]
+    AlreadyPresent(String),
+
+    /// `remove` called for a pubkey that's not present.
+    #[error("pubkey is not paired: {0}")]
+    NotPresent(String),
+}
+
+/// Load the DB from `path`. A missing file returns `Ok(PairingDb::default())`;
+/// a malformed file is a hard error.
+pub fn load(path: &Path) -> Result<PairingDb, PairingError> {
+    let bytes = match std::fs::read_to_string(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(PairingDb::default()),
+        Err(e) => return Err(e.into()),
+    };
+    let db: PairingDb = toml::from_str(&bytes)?;
+
+    // Validate every entry: z-base-32 parses + no duplicates.
+    let mut seen = std::collections::HashSet::new();
+    for entry in &db.pairs {
+        let pk =
+            PublicKey::from_zbase32(&entry.pubkey).map_err(|_| PairingError::InvalidPubkey {
+                pubkey: entry.pubkey.clone(),
+            })?;
+        if !seen.insert(pk.to_bytes()) {
+            return Err(PairingError::Duplicate(entry.pubkey.clone()));
+        }
+    }
+    Ok(db)
+}
+
+/// Atomically overwrite the DB at `path`. On Unix the final file mode
+/// is 0600; on Windows the parent directory's ACL applies.
+pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let body = toml::to_string_pretty(db)?;
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, body.as_bytes())?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(&tmp, perms)?;
+    }
+
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Add a new pair entry. Errors on duplicate.
+pub fn add(path: &Path, pubkey: &PublicKey, nickname: Option<String>) -> Result<(), PairingError> {
+    let mut db = load(path)?;
+    if db.contains(pubkey) {
+        return Err(PairingError::AlreadyPresent(pubkey.to_zbase32()));
+    }
+    let added_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .ok();
+    db.pairs.push(PairEntry {
+        pubkey: pubkey.to_zbase32(),
+        nickname,
+        added_at,
+    });
+    save_atomic(path, &db)
+}
+
+/// Remove a pair entry. Errors if the pubkey isn't present.
+pub fn remove(path: &Path, pubkey: &PublicKey) -> Result<(), PairingError> {
+    let mut db = load(path)?;
+    let zb = pubkey.to_zbase32();
+    let before = db.pairs.len();
+    db.pairs.retain(|p| {
+        PublicKey::from_zbase32(&p.pubkey)
+            .map(|k| k != *pubkey)
+            .unwrap_or(true)
+    });
+    if db.pairs.len() == before {
+        return Err(PairingError::NotPresent(zb));
+    }
+    save_atomic(path, &db)
+}
+
+/// Default DB path: `<config_dir>/openhost/allow.toml`. Matches the
+/// convention used by [`crate::config::default_path`].
+#[must_use]
+pub fn default_db_path() -> PathBuf {
+    directories::ProjectDirs::from("", "", "openhost")
+        .map(|dirs| dirs.config_dir().join("allow.toml"))
+        .unwrap_or_else(|| PathBuf::from("openhost/allow.toml"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::identity::SigningKey;
+    use tempfile::TempDir;
+
+    fn fresh_pk(seed: u8) -> PublicKey {
+        SigningKey::from_bytes(&[seed; 32]).public_key()
+    }
+
+    #[test]
+    fn load_missing_file_returns_empty_db() {
+        let tmp = TempDir::new().unwrap();
+        let db = load(&tmp.path().join("nope.toml")).unwrap();
+        assert!(db.pairs.is_empty());
+    }
+
+    #[test]
+    fn add_then_load_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let pk = fresh_pk(0x11);
+        add(&path, &pk, Some("nick".into())).unwrap();
+        let db = load(&path).unwrap();
+        assert_eq!(db.pairs.len(), 1);
+        assert_eq!(db.pairs[0].pubkey, pk.to_zbase32());
+        assert_eq!(db.pairs[0].nickname.as_deref(), Some("nick"));
+        assert!(db.pairs[0].added_at.is_some());
+    }
+
+    #[test]
+    fn add_rejects_duplicate() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let pk = fresh_pk(0x22);
+        add(&path, &pk, None).unwrap();
+        let err = add(&path, &pk, None).unwrap_err();
+        assert!(matches!(err, PairingError::AlreadyPresent(_)));
+    }
+
+    #[test]
+    fn remove_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let pk_a = fresh_pk(0x33);
+        let pk_b = fresh_pk(0x44);
+        add(&path, &pk_a, None).unwrap();
+        add(&path, &pk_b, None).unwrap();
+        remove(&path, &pk_a).unwrap();
+        let db = load(&path).unwrap();
+        assert_eq!(db.pairs.len(), 1);
+        assert_eq!(db.pairs[0].pubkey, pk_b.to_zbase32());
+    }
+
+    #[test]
+    fn remove_rejects_missing() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let pk = fresh_pk(0x55);
+        let err = remove(&path, &pk).unwrap_err();
+        assert!(matches!(err, PairingError::NotPresent(_)));
+    }
+
+    #[test]
+    fn load_rejects_invalid_pubkey() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        std::fs::write(&path, "[[pair]]\npubkey = \"not-a-real-pubkey-value\"\n").unwrap();
+        let err = load(&path).unwrap_err();
+        assert!(matches!(err, PairingError::InvalidPubkey { .. }));
+    }
+
+    #[test]
+    fn load_rejects_duplicate() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let pk = fresh_pk(0x66).to_zbase32();
+        let body = format!("[[pair]]\npubkey = \"{pk}\"\n[[pair]]\npubkey = \"{pk}\"\n");
+        std::fs::write(&path, body).unwrap();
+        let err = load(&path).unwrap_err();
+        assert!(matches!(err, PairingError::Duplicate(_)));
+    }
+
+    #[test]
+    fn compute_hashes_matches_allowlist_hash() {
+        let salt = [0x11u8; SALT_LEN];
+        let pk = fresh_pk(0x77);
+        let mut db = PairingDb::default();
+        db.pairs.push(PairEntry {
+            pubkey: pk.to_zbase32(),
+            nickname: None,
+            added_at: None,
+        });
+        let hashes = db.compute_hashes(&salt);
+        assert_eq!(hashes.len(), 1);
+        assert_eq!(hashes[0], allowlist_hash(&salt, &pk.to_bytes()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn saved_file_is_mode_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("allow.toml");
+        add(&path, &fresh_pk(0x88), None).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -16,7 +16,8 @@
 use crate::config::PkarrConfig;
 use crate::error::{PublishError, Result as DaemonResult};
 use hkdf::Hkdf;
-use openhost_core::identity::SigningKey;
+use openhost_core::crypto::allowlist_hash;
+use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::pkarr_record::{
     IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
@@ -129,6 +130,47 @@ impl SharedState {
     /// Snapshot of the current allow list.
     pub fn allow(&self) -> Vec<[u8; 16]> {
         self.allow.read().expect("allow lock poisoned").clone()
+    }
+
+    /// Replace the entire allow list. Used by `App::run`'s SIGHUP
+    /// reload path to swap in a freshly-loaded pairing DB without
+    /// tearing down live sessions.
+    pub fn replace_allow(&self, hashes: Vec<[u8; 16]>) {
+        *self.allow.write().expect("allow lock poisoned") = hashes;
+    }
+
+    /// Whether a client pubkey's HMAC projection is currently in the
+    /// allow list. Recomputes `allowlist_hash(salt, client_pk)` and
+    /// consults the current snapshot.
+    #[must_use]
+    pub fn is_client_allowed(&self, client_pk: &PublicKey) -> bool {
+        let hash = allowlist_hash(&self.salt, &client_pk.to_bytes());
+        self.allow
+            .read()
+            .expect("allow lock poisoned")
+            .contains(&hash)
+    }
+
+    /// Insert a single precomputed hash into the allow list. Idempotent
+    /// (duplicate entries are dropped). Most callers use
+    /// [`replace_allow`] instead; this is exposed for mutation-style
+    /// tests and for a future TOFU-pairing flow.
+    ///
+    /// [`replace_allow`]: SharedState::replace_allow
+    pub fn add_client_hash(&self, hash: [u8; 16]) {
+        let mut guard = self.allow.write().expect("allow lock poisoned");
+        if !guard.contains(&hash) {
+            guard.push(hash);
+        }
+    }
+
+    /// Remove a single hash from the allow list. Returns whether the
+    /// hash was present before the call.
+    pub fn remove_client_hash(&self, hash: [u8; 16]) -> bool {
+        let mut guard = self.allow.write().expect("allow lock poisoned");
+        let before = guard.len();
+        guard.retain(|e| *e != hash);
+        before != guard.len()
     }
 
     /// Snapshot of the current ICE blob set.
@@ -390,6 +432,45 @@ mod tests {
         let sk_b = SigningKey::from_bytes(&other_seed);
         let s_other = SharedState::new(&sk_b, [0; DTLS_FINGERPRINT_LEN]).salt();
         assert_ne!(s1, s_other, "distinct identities must yield distinct salts");
+    }
+
+    #[test]
+    fn is_client_allowed_rehashes_and_checks() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let state = SharedState::new(&sk, [0; DTLS_FINGERPRINT_LEN]);
+        let client_pk = SigningKey::from_bytes(&[0x22; 32]).public_key();
+        assert!(!state.is_client_allowed(&client_pk));
+        let hash = allowlist_hash(&state.salt(), &client_pk.to_bytes());
+        state.add_client_hash(hash);
+        assert!(state.is_client_allowed(&client_pk));
+    }
+
+    #[test]
+    fn replace_allow_overwrites() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let state = SharedState::new(&sk, [0; DTLS_FINGERPRINT_LEN]);
+        state.add_client_hash([0x11; 16]);
+        state.replace_allow(vec![[0x22; 16], [0x33; 16]]);
+        let snap = state.allow();
+        assert_eq!(snap, vec![[0x22; 16], [0x33; 16]]);
+    }
+
+    #[test]
+    fn add_client_hash_is_idempotent() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let state = SharedState::new(&sk, [0; DTLS_FINGERPRINT_LEN]);
+        state.add_client_hash([0x11; 16]);
+        state.add_client_hash([0x11; 16]);
+        assert_eq!(state.allow().len(), 1);
+    }
+
+    #[test]
+    fn remove_client_hash_returns_presence() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let state = SharedState::new(&sk, [0; DTLS_FINGERPRINT_LEN]);
+        state.add_client_hash([0x11; 16]);
+        assert!(state.remove_client_hash([0x11; 16]));
+        assert!(!state.remove_client_hash([0x11; 16]));
     }
 
     #[test]

--- a/crates/openhost-daemon/src/rate_limit.rs
+++ b/crates/openhost-daemon/src/rate_limit.rs
@@ -1,0 +1,147 @@
+//! Per-client token-bucket rate limiter.
+//!
+//! Used by the offer poller to cap how often a single client's
+//! offer-ingest path consumes CPU. Semantics:
+//!
+//! - Each bucket holds up to `burst_cap` tokens.
+//! - On `try_consume`, the bucket is refilled proportional to the
+//!   elapsed time since the last refill at `refill_per_sec` tokens per
+//!   second, capped at `burst_cap`.
+//! - If at least one token is available, one is consumed and the call
+//!   returns `true`; otherwise the bucket is untouched and the call
+//!   returns `false`.
+//!
+//! The implementation is deliberately synchronous and tokio-free: the
+//! caller threads an explicit `now: Instant` in. That lets the offer
+//! poller reuse its per-cycle `Instant::now()` and makes unit tests
+//! deterministic without `tokio::time::pause`.
+
+use std::time::Instant;
+
+/// One per-client token bucket.
+#[derive(Debug, Clone)]
+pub struct TokenBucket {
+    /// Current token count. Fractional so refill math is exact.
+    tokens: f64,
+    /// When `tokens` was last refilled.
+    last_refill: Instant,
+    /// Maximum token count. `tokens` is clamped to this on every refill.
+    burst_cap: f64,
+    /// Refill rate in tokens per second.
+    refill_per_sec: f64,
+}
+
+impl TokenBucket {
+    /// Build a new bucket starting full (`tokens = burst_cap`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `burst_cap <= 0.0`, `refill_per_sec <= 0.0`, or either
+    /// argument is not finite. Callers are expected to validate config
+    /// values before construction.
+    #[must_use]
+    pub fn new(burst_cap: u32, refill_per_sec: f64, now: Instant) -> Self {
+        assert!(
+            burst_cap > 0 && refill_per_sec.is_finite() && refill_per_sec > 0.0,
+            "TokenBucket requires burst_cap > 0 and finite, positive refill_per_sec",
+        );
+        let cap = f64::from(burst_cap);
+        Self {
+            tokens: cap,
+            last_refill: now,
+            burst_cap: cap,
+            refill_per_sec,
+        }
+    }
+
+    /// Attempt to consume one token. Returns `true` on success.
+    ///
+    /// Refills the bucket first based on elapsed wall time since the
+    /// previous refill, clamped to `burst_cap`.
+    pub fn try_consume(&mut self, now: Instant) -> bool {
+        let elapsed = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.burst_cap);
+        self.last_refill = now;
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn starts_full_burst_cap_then_empties() {
+        let t0 = Instant::now();
+        let mut b = TokenBucket::new(3, 1.0, t0);
+        assert!(b.try_consume(t0));
+        assert!(b.try_consume(t0));
+        assert!(b.try_consume(t0));
+        // Fourth consume in the same instant is rejected.
+        assert!(!b.try_consume(t0));
+    }
+
+    #[test]
+    fn refills_on_elapsed_time() {
+        let t0 = Instant::now();
+        let mut b = TokenBucket::new(2, 1.0, t0);
+        assert!(b.try_consume(t0));
+        assert!(b.try_consume(t0));
+        assert!(!b.try_consume(t0));
+        // 2 seconds later, two tokens' worth have refilled.
+        let t1 = t0 + Duration::from_secs(2);
+        assert!(b.try_consume(t1));
+        assert!(b.try_consume(t1));
+        assert!(!b.try_consume(t1));
+    }
+
+    #[test]
+    fn refill_caps_at_burst() {
+        let t0 = Instant::now();
+        let mut b = TokenBucket::new(3, 1.0, t0);
+        // Drain.
+        for _ in 0..3 {
+            assert!(b.try_consume(t0));
+        }
+        // A huge gap refills but caps at burst.
+        let t_far = t0 + Duration::from_secs(10_000);
+        for _ in 0..3 {
+            assert!(b.try_consume(t_far));
+        }
+        assert!(!b.try_consume(t_far));
+    }
+
+    #[test]
+    fn fractional_refill_accumulates() {
+        let t0 = Instant::now();
+        let mut b = TokenBucket::new(1, 1.0, t0);
+        // Drain.
+        assert!(b.try_consume(t0));
+        // 0.4 s → 0.4 tokens — not enough.
+        let t_half = t0 + Duration::from_millis(400);
+        assert!(!b.try_consume(t_half));
+        // Another 0.7 s on top → 1.1 accumulated, enough.
+        let t_full = t_half + Duration::from_millis(700);
+        assert!(b.try_consume(t_full));
+    }
+
+    #[test]
+    #[should_panic]
+    fn rejects_zero_burst() {
+        let _ = TokenBucket::new(0, 1.0, Instant::now());
+    }
+
+    #[test]
+    #[should_panic]
+    fn rejects_non_finite_refill() {
+        let _ = TokenBucket::new(3, f64::NAN, Instant::now());
+    }
+}

--- a/crates/openhost-daemon/src/signal.rs
+++ b/crates/openhost-daemon/src/signal.rs
@@ -1,7 +1,9 @@
-//! Cross-platform shutdown signal handling.
+//! Cross-platform shutdown + reload signal handling.
 //!
-//! Resolves the returned future when the daemon should begin a graceful
-//! shutdown: SIGINT (Ctrl-C) or SIGTERM on Unix, Ctrl-C on Windows.
+//! `shutdown_signal` resolves on SIGINT/SIGTERM (Unix) or Ctrl-C
+//! (Windows). `reload_signal` resolves on SIGHUP (Unix) and never
+//! resolves on Windows — which matches the daemon's Windows posture:
+//! pairing changes require a daemon restart there.
 
 /// Await a shutdown signal. Returns as soon as one lands.
 pub async fn shutdown_signal() {
@@ -19,5 +21,23 @@ pub async fn shutdown_signal() {
     #[cfg(windows)]
     {
         let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+/// Await a reload signal (SIGHUP on Unix). On Windows the returned
+/// future never resolves — pairing-DB changes require a daemon restart.
+/// Callers typically drive this in a loop with `shutdown_signal` in a
+/// `tokio::select!`.
+pub async fn reload_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut sighup = signal(SignalKind::hangup()).expect("register SIGHUP handler");
+        let _ = sighup.recv().await;
+    }
+
+    #[cfg(windows)]
+    {
+        std::future::pending::<()>().await;
     }
 }

--- a/crates/openhost-daemon/tests/bootstrap.rs
+++ b/crates/openhost-daemon/tests/bootstrap.rs
@@ -50,6 +50,7 @@ fn test_config(dir: &TempDir) -> Config {
         },
         forward: None,
         log: LogConfig::default(),
+        pairing: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -48,6 +48,7 @@ fn test_config(dir: &TempDir, upstream_port: u16) -> Config {
             max_body_bytes: 1024 * 1024,
         }),
         log: LogConfig::default(),
+        pairing: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/offer_poll.rs
+++ b/crates/openhost-daemon/tests/offer_poll.rs
@@ -51,6 +51,13 @@ fn daemon_config(
                 poll_secs: 1,
                 watched_clients: watched.iter().map(|pk| pk.to_zbase32()).collect(),
                 per_client_throttle_secs: 5,
+                // PR #7a semantics: tests here predate PR #7b's
+                // allowlist gate. The PR #7b integration tests in
+                // `tests/pairing_enforcement.rs` cover the enforced
+                // path explicitly.
+                enforce_allowlist: false,
+                rate_limit_burst: 3,
+                rate_limit_refill_secs: 5.0,
             },
         },
         dtls: DtlsConfig {
@@ -59,6 +66,7 @@ fn daemon_config(
         },
         forward: None,
         log: LogConfig::default(),
+        pairing: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -1,0 +1,317 @@
+//! Integration tests for the PR #7b allowlist + rate-limit gates on
+//! the offer poller.
+//!
+//! Reuses `support::ScriptedResolve` / `CaptureTransport` from PR #7a.
+//! The setup pattern: stage a sealed offer under the client's zone;
+//! tick the poller; assert whether the offer reached `handle_offer`
+//! (observable via `app.listener().active_count()`) or was rejected.
+
+mod support;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use openhost_core::identity::{PublicKey, SigningKey};
+use openhost_daemon::config::{
+    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, OfferPollConfig, PairingConfig,
+    PkarrConfig,
+};
+use openhost_daemon::{pairing, App, Result as DaemonResult};
+use openhost_pkarr::{OfferPlaintext, OfferRecord, OFFER_TXT_PREFIX, OFFER_TXT_TTL};
+use pkarr::dns::rdata::TXT;
+use pkarr::dns::Name;
+use pkarr::{Keypair, SignedPacket, Timestamp};
+use rand::rngs::OsRng;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use support::{CaptureTransport, ScriptedResolve};
+use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+/// Build a daemon `Config` with the PR #7b knobs set explicitly. The
+/// caller controls which clients are watched and whether the allowlist
+/// is enforced; the pair-DB path is a tmpfile the test can pre-populate.
+fn build_config(
+    tmp: &TempDir,
+    watched: &[PublicKey],
+    enforce_allowlist: bool,
+    rate_limit_burst: u32,
+    rate_limit_refill_secs: f64,
+    per_client_throttle_secs: u64,
+    pair_db_path: Option<PathBuf>,
+) -> Config {
+    Config {
+        identity: IdentityConfig {
+            store: IdentityStore::Fs {
+                path: tmp.path().join("identity.key"),
+            },
+        },
+        pkarr: PkarrConfig {
+            relays: vec![],
+            republish_secs: 3600,
+            offer_poll: OfferPollConfig {
+                poll_secs: 1,
+                watched_clients: watched.iter().map(|pk| pk.to_zbase32()).collect(),
+                per_client_throttle_secs,
+                enforce_allowlist,
+                rate_limit_burst,
+                rate_limit_refill_secs,
+            },
+        },
+        dtls: DtlsConfig {
+            cert_path: tmp.path().join("dtls.pem"),
+            rotate_secs: 3600,
+        },
+        forward: None,
+        log: LogConfig::default(),
+        pairing: PairingConfig {
+            db_path: pair_db_path,
+        },
+    }
+}
+
+/// Build a pkarr `SignedPacket` under the client's key containing an
+/// `_offer-<host-hash>` TXT sealed to the daemon.
+async fn build_offer_packet(
+    client_sk: &SigningKey,
+    daemon_pk: &PublicKey,
+    offer_sdp: &str,
+    ts_secs: u64,
+) -> SignedPacket {
+    let plaintext = OfferPlaintext {
+        client_pk: client_sk.public_key(),
+        offer_sdp: offer_sdp.to_string(),
+    };
+    let mut rng = OsRng;
+    let offer = OfferRecord::seal(&mut rng, daemon_pk, &plaintext).unwrap();
+    let txt_value = URL_SAFE_NO_PAD.encode(&offer.sealed);
+    let label = openhost_pkarr::host_hash_label(daemon_pk);
+    let name = format!("{OFFER_TXT_PREFIX}{label}");
+
+    let seed = Zeroizing::new(client_sk.to_bytes());
+    let keypair = Keypair::from_secret_key(&seed);
+    SignedPacket::builder()
+        .txt(
+            Name::new_unchecked(&name),
+            TXT::try_from(txt_value.as_str()).unwrap(),
+            OFFER_TXT_TTL,
+        )
+        .timestamp(Timestamp::from(ts_secs * 1_000_000))
+        .sign(&keypair)
+        .unwrap()
+}
+
+async fn real_client_offer_sdp() -> String {
+    use webrtc::api::APIBuilder;
+    use webrtc::data_channel::data_channel_init::RTCDataChannelInit;
+    use webrtc::peer_connection::configuration::RTCConfiguration;
+
+    let api = APIBuilder::new().build();
+    let pc = api
+        .new_peer_connection(RTCConfiguration::default())
+        .await
+        .expect("client pc builds");
+    let _dc = pc
+        .create_data_channel("openhost", Some(RTCDataChannelInit::default()))
+        .await
+        .expect("create DC");
+    let offer = pc.create_offer(None).await.expect("create_offer");
+    pc.set_local_description(offer).await.expect("set local");
+    // No `gathering_complete` wait — keeps the SDP small enough to fit.
+    let sdp = pc.local_description().await.unwrap().sdp;
+    let _ = pc.close().await;
+    sdp
+}
+
+#[tokio::test]
+async fn authorized_client_offer_is_processed() -> DaemonResult<()> {
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db = tmp.path().join("allow.toml");
+    pairing::add(&pair_db, &client_pk, Some("test".into())).unwrap();
+
+    let cfg = build_config(&tmp, &[client_pk], true, 3, 5.0, 5, Some(pair_db));
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    let daemon_pk = app.identity().public_key();
+    let offer_sdp = real_client_offer_sdp().await;
+    let packet = build_offer_packet(&client_sk, &daemon_pk, &offer_sdp, 1_700_000_000).await;
+    resolver.set_packet(&client_pk, &packet);
+
+    // Wait until an answer lands in SharedState. (The BEP44 encoder may
+    // evict it from the wire packet — documented in PR #7a — so we
+    // assert against the queue, not the captured bytes.)
+    let expected_hash =
+        openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if app
+            .state()
+            .snapshot_answers()
+            .iter()
+            .any(|e| e.client_hash == expected_hash)
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("authorised client offer did not yield an answer");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn unauthorized_client_offer_is_skipped() -> DaemonResult<()> {
+    // No pair added; enforce=on. Offer must be skipped.
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db = tmp.path().join("allow.toml");
+    let cfg = build_config(&tmp, &[client_pk], true, 3, 5.0, 5, Some(pair_db));
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    let daemon_pk = app.identity().public_key();
+    let offer_sdp = "v=0\r\na=setup:active\r\n";
+    let packet = build_offer_packet(&client_sk, &daemon_pk, offer_sdp, 1_700_000_000).await;
+    resolver.set_packet(&client_pk, &packet);
+
+    // Wait a few poll cycles. No answer should ever be queued.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let expected_hash =
+        openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
+    assert!(
+        !app.state()
+            .snapshot_answers()
+            .iter()
+            .any(|e| e.client_hash == expected_hash),
+        "unauthorised client MUST NOT have an answer queued"
+    );
+    assert_eq!(
+        app.listener().active_count().await,
+        0,
+        "unauthorised client MUST NOT trigger handle_offer"
+    );
+
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn enforce_disabled_preserves_pr7a_behavior() -> DaemonResult<()> {
+    // enforce=off + empty pair DB: offer still gets processed (PR #7a
+    // semantics preserved under the escape-hatch knob).
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let cfg = build_config(&tmp, &[client_pk], false, 3, 5.0, 5, None);
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    let daemon_pk = app.identity().public_key();
+    let offer_sdp = real_client_offer_sdp().await;
+    let packet = build_offer_packet(&client_sk, &daemon_pk, &offer_sdp, 1_700_000_000).await;
+    resolver.set_packet(&client_pk, &packet);
+
+    let expected_hash =
+        openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if app
+            .state()
+            .snapshot_answers()
+            .iter()
+            .any(|e| e.client_hash == expected_hash)
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("enforce=false should have let the offer through");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn rate_limit_caps_burst_of_distinct_offers() -> DaemonResult<()> {
+    // Set burst = 2, refill = 3600s (effectively none over the test
+    // window), per-client throttle = 0 so dedup doesn't gate. Publish
+    // 5 distinct-ts offers across 6 poll ticks; only `burst` = 2
+    // should reach handle_offer — the remaining 3 hit an empty bucket.
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db = tmp.path().join("allow.toml");
+    pairing::add(&pair_db, &client_pk, None).unwrap();
+
+    let cfg = build_config(&tmp, &[client_pk], true, 2, 3600.0, 0, Some(pair_db));
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    let daemon_pk = app.identity().public_key();
+    let base_ts: u64 = 1_700_000_000;
+
+    // Publish 5 offers with strictly-increasing ts values, ~1.2s
+    // apart (slightly longer than the 1 Hz poll tick so each tick
+    // sees a distinct packet).
+    for i in 0..5 {
+        let offer_sdp = real_client_offer_sdp().await;
+        let pkt = build_offer_packet(&client_sk, &daemon_pk, &offer_sdp, base_ts + i).await;
+        resolver.set_packet(&client_pk, &pkt);
+        tokio::time::sleep(Duration::from_millis(1200)).await;
+    }
+
+    let count = app.listener().active_count().await;
+    assert_eq!(
+        count, 2,
+        "rate limit should cap to burst=2 handle_offer calls, saw {count}",
+    );
+
+    app.shutdown().await;
+    Ok(())
+}

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -41,6 +41,7 @@ fn real_config(dir: &TempDir) -> Config {
         },
         forward: None,
         log: LogConfig::default(),
+        pairing: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -201,6 +201,7 @@ pub fn test_config_noforward(dir: &tempfile::TempDir) -> openhost_daemon::Config
         },
         forward: None,
         log: LogConfig::default(),
+        pairing: Default::default(),
     }
 }
 


### PR DESCRIPTION
## Summary

- Closes PR #7a's authorization hole. Any sealed offer that unsealed was de-facto authorized; PR #7b requires the `client_pk` to be in the operator's pair DB AND to have a token available in its per-client rate-limit bucket.
- New `openhost-daemon::pairing` module (TOML DB, atomic 0600 write, SIGHUP reload) + `rate_limit::TokenBucket` (pure sync, caller-threaded `Instant`).
- New CLI subcommand tree `openhostd pair {add, remove, list}`.
- ⚠️ **Breaking:** `pkarr.offer_poll.enforce_allowlist = true` is the default. PR #7a users must pair their clients or opt out (`enforce_allowlist = false`). The daemon logs a startup `warn!` when the pair DB is empty + enforcement is on — misconfigurations are loud.

## Scope

**In:**
- `SharedState::{replace_allow, is_client_allowed, add/remove_client_hash}`.
- OfferPoller gates: allowlist first, rate-limit second, both BEFORE `handle_offer`.
- `signal::reload_signal()` awaits SIGHUP on Unix (`Pending` on Windows). `App::run` drives a biased select loop that hot-swaps the allow list on SIGHUP + triggers a republish.
- Config surface: new `[pairing] db_path` + three new `OfferPollConfig` fields.
- `DaemonError::Pairing` + full `PairingError` enum.
- 4 integration tests + 15 unit tests + 5 new tests in `publish` for the allowlist helpers.

**Out (deferred):**
- Mid-session revocation of authenticated DCs — PR #7c.
- Windows SIGHUP equivalent — restart required.
- Auto-SIGHUP from `openhostd pair` via a PID file — CLI prints a reminder; operator sends the signal manually.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test -p openhost-daemon --lib` (76 passing, 29 new)
- [x] `cargo test -p openhost-daemon --test pairing_enforcement` (4 new)
- [x] `cargo test -p openhost-daemon --test offer_poll` (5, regression)
- [x] `cargo test -p openhost-daemon --test channel_binding` (5, regression)
- [x] `cargo test -p openhost-daemon --test listener` (5, regression)
- [x] `cargo test -p openhost-daemon --test forward` (7, regression)
- [x] `cargo test -p openhost-daemon --test bootstrap` (3, regression)
- [x] `cargo test --workspace` — full green

🤖 Generated with [Claude Code](https://claude.com/claude-code)