### PR TITLE
docs: add ROADMAP.md for post-v0.1 direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ openhost lets you reach services running on your own computers — from any pair
 
 ## Status
 
-**Pre-alpha.** The protocol is being specified. No user-facing builds are shipping yet. Watch the repo for the first M1 tag.
+**`v0.1.0` shipped** — the daemon, client library, WebRTC listener, channel binding, and HTTP forwarder are all in `main` and tagged. No binary releases yet; build from source (see below). openhost is pre-audit software — do not expose services you can't afford to have compromised. See [`CHANGELOG.md`](CHANGELOG.md) for what landed and [`ROADMAP.md`](ROADMAP.md) for what's next.
 
 ## How it works
 
@@ -39,6 +39,10 @@ cargo check --workspace
 # Docs site (uses pnpm)
 cd site && pnpm install && pnpm dev
 ```
+
+## Roadmap
+
+Post-v0.1 work is sequenced in [`ROADMAP.md`](ROADMAP.md): close the three known limitations from the `v0.1.0` release notes, then land operator-facing docs (quickstart, install, troubleshoot, worked examples for Jellyfin and Home Assistant), then the Phase 3 backlog (distributable binaries, observability, keychain backends, the `webrtc-rs` sans-I/O migration, browser extension, and native apps).
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ openhost lets you reach services running on your own computers — from any pair
 
 ## Status
 
-**`v0.1.0` shipped** — the daemon, client library, WebRTC listener, channel binding, and HTTP forwarder are all in `main` and tagged. No binary releases yet; build from source (see below). openhost is pre-audit software — do not expose services you can't afford to have compromised. See [`CHANGELOG.md`](CHANGELOG.md) for what landed and [`ROADMAP.md`](ROADMAP.md) for what's next.
+**`v0.1.0` shipped** — the daemon, client library, WebRTC listener, channel binding, and HTTP forwarder are all in `main` and tagged. No binary releases yet; build from source. See [`CHANGELOG.md`](CHANGELOG.md) for what landed, [`ROADMAP.md`](ROADMAP.md) for what's next, and [`SECURITY.md`](SECURITY.md) before exposing a service.
 
 ## How it works
 
@@ -42,13 +42,13 @@ cd site && pnpm install && pnpm dev
 
 ## Roadmap
 
-Post-v0.1 work is sequenced in [`ROADMAP.md`](ROADMAP.md): close the three known limitations from the `v0.1.0` release notes, then land operator-facing docs (quickstart, install, troubleshoot, worked examples for Jellyfin and Home Assistant), then the Phase 3 backlog (distributable binaries, observability, keychain backends, the `webrtc-rs` sans-I/O migration, browser extension, and native apps).
+Post-v0.1 work is sequenced in [`ROADMAP.md`](ROADMAP.md). Phase 1 closes the three known limitations from the `v0.1.0` release notes and Phase 2 lands operator-facing docs (quickstart, install, troubleshoot, worked examples for Jellyfin and Home Assistant). Phase 3+ tracks longer-horizon work: distributable binaries, observability, keychain backends, the `webrtc-rs` sans-I/O migration, browser extension, and native apps.
 
 ## Security
 
 Reports of vulnerabilities: **please use GitHub's private Security Advisories** rather than filing a public issue. See [`SECURITY.md`](SECURITY.md) for scope and response commitments.
 
-The threat model is documented in [`spec/04-security.md`](spec/04-security.md). **openhost is pre-alpha software and has not been audited. Do not use it to expose services you cannot afford to have compromised.**
+The threat model is documented in [`spec/04-security.md`](spec/04-security.md). **openhost is pre-audit software: `v0.1.0` has shipped but no third-party security review has taken place. Do not use it to expose services you cannot afford to have compromised.**
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,48 @@
+# Roadmap
+
+Where openhost is going after the `v0.1.0` tag. This document is intent, not a contract — priorities can shift in response to testing feedback, spec changes, or upstream library movement. For historical detail on what already shipped, see [`CHANGELOG.md`](CHANGELOG.md).
+
+## Status
+
+**`v0.1.0` shipped on 2026-04-18.** The daemon, client library, Pkarr adapter, WebRTC listener, channel binding, HTTP forwarder, pairing allowlist, and per-client rate limiter are all merged and tagged. Three known limitations carry over into the post-v0.1 work — see Phase 1 below.
+
+openhost remains **pre-audit software**. Do not expose services you cannot afford to have compromised. See [`SECURITY.md`](SECURITY.md) for threat-model scope and reporting.
+
+## Phase 1 — close v0.1 known limitations
+
+Three items from the `v0.1.0` release notes are user-visible enough to block a meaningful testing round. Each gets its own focused PR.
+
+- **Split the WebRTC answer across multiple Pkarr records.** A full trickled answer SDP, sealed and base64url-wrapped alongside the main `_openhost` record, can exceed BEP44's 1000-byte `v` cap. Today the encoder evicts the oldest queued answer to fit, so a paired client's first poll may miss the response. The fix chunks `_answer-<client-hash>-<n>` across multiple records; the dialer reassembles before unsealing.
+- **Ship `openhost-dial` as a first-class client CLI.** `v0.1.0` shipped `openhost-resolve` for record inspection only. A new `openhost-dial oh://<host>[/path]` binary makes the first end-to-end HTTP round-trip achievable from the terminal — no Rust library integration required.
+- **Hot-reload the pairing allowlist on every platform.** Today `openhostd pair add/remove` needs SIGHUP on Unix and a full daemon restart on Windows. A file-watcher on the pair-DB path removes the requirement for both, with SIGHUP retained as a secondary trigger.
+
+Each PR lands with tests, documentation, and a short note in `CHANGELOG.md`.
+
+## Phase 2 — docs so testers can actually try it
+
+Protocol specs and per-crate READMEs exist, but there is no operator-facing walkthrough. Phase 2 closes that gap so early testers can go from "I heard about this" to "I have my home service reachable from my phone, and I filed a useful bug report."
+
+- **Quickstart, install, and troubleshoot guides** under `site/src/content/docs/guides/`. Five-minute walkthrough for a local service; common failure-mode playbook (DHT misses, relay 5xx, `PollAnswerTimeout`, DTLS handshake failure).
+- **Refreshed repo `README.md` plus worked `examples/`** for Jellyfin, Home Assistant, and a static personal site. Each example: a complete `daemon.toml`, client pairing steps, expected output, and gotchas.
+- **`CONTRIBUTING.md` and feedback intake.** Dev setup, test commands, the plan → implement → self-review → fix-all → merge cadence we already use internally, and a "how to file good feedback" section pointing at issue templates.
+
+## Phase 3+ — backlog
+
+These are *intent*, not commitments. They enter the active sequence when the earlier phases land and the project has testers in the loop who can help prioritize.
+
+- **Distributable binaries.** GitHub Releases artifacts, a Homebrew tap, a systemd unit, and a launchd plist so operators don't need a Rust toolchain.
+- **Observability.** A `/health` endpoint on the daemon, Prometheus-compatible metrics, and structured-log formatting suitable for `journalctl` / `logdna` / `vector`.
+- **Keychain identity backends.** Plug macOS Keychain, iOS Keychain, Linux Secret Service, and Windows Credential Manager behind the existing `openhost-daemon::identity_store::KeyStore` trait. Filesystem remains the default for servers.
+- **`webrtc-rs` migration to sans-I/O.** Move to the v0.20+ `rtc` line so openhost stops depending on a forked branch of `webrtc-rs` to reach the DTLS exporter.
+- **Browser extension.** Minimum-permission manifest, reproducible builds, strict CSP — per the threat-model requirements in `spec/04-security.md`.
+- **iOS / macOS native apps.** BIP39 four-word fingerprint confirmation (spec §7.3), keychain-backed long-lived keys to survive iOS background eviction.
+- **TLS upstream forwarding.** Today `[forward]` accepts `http://` targets only. TLS lands once upstream trust configuration is specified.
+- **Per-path WebSocket allow-list.** `Upgrade: websocket` is globally rejected today; explicit per-path opt-in is the eventual path.
+
+## How to follow along
+
+- **Watch** the repository on GitHub to see releases as they're tagged.
+- **File issues** via the templates in `.github/ISSUE_TEMPLATE/`. Bug reports that include the `openhost-resolve --json` output for your host and the daemon's log at `log.level = "debug"` are dramatically easier to act on.
+- **Contribute** once `CONTRIBUTING.md` lands in Phase 2. Until then, open an issue before starting non-trivial work so we can line up direction.
+
+Security-sensitive reports: use GitHub's private Security Advisories (see [`SECURITY.md`](SECURITY.md)), not public issues.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ Three items from the `v0.1.0` release notes are user-visible enough to block a m
 - **Ship `openhost-dial` as a first-class client CLI.** `v0.1.0` shipped `openhost-resolve` for record inspection only. A new `openhost-dial oh://<host>[/path]` binary makes the first end-to-end HTTP round-trip achievable from the terminal — no Rust library integration required.
 - **Hot-reload the pairing allowlist on every platform.** Today `openhostd pair add/remove` needs SIGHUP on Unix and a full daemon restart on Windows. A file-watcher on the pair-DB path removes the requirement for both, with SIGHUP retained as a secondary trigger.
 
-Each PR lands with tests, documentation, and a short note in `CHANGELOG.md`.
+Each Phase 1 PR lands with tests, documentation, and a short note in `CHANGELOG.md`.
 
 ## Phase 2 — docs so testers can actually try it
 


### PR DESCRIPTION
## Summary

- Adds a new `ROADMAP.md` at the repo root sequencing post-v0.1 work into three phases — closing v0.1 known limitations, operator docs for testers, and a longer-horizon backlog.
- Refreshes the `README.md` status paragraph (drops the outdated "pre-alpha, no user-facing builds" banner, points readers at `CHANGELOG.md` and `ROADMAP.md`) and adds a Roadmap section.
- No code, spec, or site changes — subsequent PRs execute each roadmap item.

## What shipped in `ROADMAP.md`

- **Phase 1** closes the three known limitations documented in the `v0.1.0` release notes: answer-record splitting over Pkarr, a first-class `openhost-dial` CLI, and hot-reload of the pairing allowlist on every platform.
- **Phase 2** covers operator docs (site quickstart/install/troubleshoot, repo README refresh, worked `examples/` for Jellyfin / Home Assistant / personal site, `CONTRIBUTING.md`).
- **Phase 3+** lists longer-horizon intent (distributable binaries, observability, keychain backends, sans-I/O webrtc migration, browser extension, native apps, TLS upstreams, per-path WebSocket gating). Explicitly labelled as intent not commitment.

## Test plan

- [x] `cargo check --workspace` — clean (no code touched, sanity-check only).
- [x] Preview `ROADMAP.md` renders cleanly on GitHub.
- [x] `README.md` links to `ROADMAP.md` and `CHANGELOG.md` resolve.
- [x] Conventional commit subject; verbose body; co-author trailer.

## Spec compatibility

No spec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)