### PR TITLE
feat(client): openhost-dial CLI binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added (PR #16, `openhost-dial` CLI)
+
+- **New binary: `openhost-dial`**. Sends one HTTP request over openhost and prints the response. Behind the existing `cli` feature, so WASM / FFI consumers of `openhost-client` don't pull clap / tracing-subscriber / serde_json / hex transitively. Usage: `openhost-dial oh://<zbase32-pubkey>[/path] [-X METHOD] [-H 'Key: Value']... [-d BODY] [--relay URL]... [--timeout SECS] [--identity PATH] [--json]`. `-d` accepts `@path` (file), `-` (stdin), or a literal string — curl-style. `--identity <PATH>` loads a 32-byte raw Ed25519 seed (matches the daemon's `FsKeyStore` format); when omitted the binary generates an ephemeral key (useful against unauthenticated daemons, not useful against hosts with `enforce_allowlist = true` since the pubkey changes per invocation).
+- New public module `openhost_client::cli`. Shared CLI helpers the binary uses: `load_identity_from_file`, `read_body_arg`, `parse_header_arg`, `build_request_head`, `parse_response`, `response_to_json`, and the `ParsedResponse` struct. Also gated behind the `cli` feature.
+- 11 new unit tests covering the cli helpers: header-parsing variants (`Key: Value`, `Key:Value`, multiple-space values, empty-name error, colon-missing error), request-head defaults and user-override precedence (Host / Content-Length / Content-Type skipped when user supplied), response parsing (happy path + malformed status), JSON body encoding (UTF-8 vs base64 fallback), file and literal body loading, and identity-seed size validation. Plus 2 binary-level tests for relay-URL validation.
+- Exit-code contract documented: `0` for any successful round-trip (regardless of HTTP status, matching curl), `1` for openhost / network / protocol errors, `2` for usage errors (clap parse failures, URL parse errors, identity file missing / wrong size, non-HTTPS relays).
+- Non-`--json` output routes the status line + response headers to stderr and the body to stdout, so `openhost-dial … | jq` works out of the box; `--json` emits a single pretty-printed object to stdout instead.
+
+### Changed (PR #16)
+
+- `crates/openhost-client/src/lib.rs` adds `#[cfg(feature = "cli")] pub mod cli;` and documents the new binary alongside `openhost-resolve` in the crate header.
+- `crates/openhost-client/Cargo.toml` adds a second `[[bin]]` entry for `openhost-dial` with `required-features = ["cli"]`.
+
 ### Added (PR #15, answer-record splitting)
 
 - `openhost-pkarr` fragmented answer records. Each `AnswerEntry`'s sealed ciphertext is now split into one or more `_answer-<client-hash>-<idx>` TXT records before being folded into the daemon's `_openhost` pkarr packet. Each fragment carries a 5-byte envelope (`version=0x01`, `chunk_idx: u8`, `chunk_total: u8`, `payload_len: u16 BE`) followed by up to `MAX_FRAGMENT_PAYLOAD_BYTES = 180` bytes of sealed ciphertext. Public API adds `decode_answer_fragments_from_packet`, `answer_txt_chunk_name`, `MAX_FRAGMENT_PAYLOAD_BYTES`, and `MAX_FRAGMENT_TOTAL = 255`.

--- a/crates/openhost-client/Cargo.toml
+++ b/crates/openhost-client/Cargo.toml
@@ -11,11 +11,16 @@ readme.workspace = true
 [lib]
 path = "src/lib.rs"
 
-# Debug CLI. Gated behind the `cli` feature so WASM / FFI consumers
+# Debug CLIs. Gated behind the `cli` feature so WASM / FFI consumers
 # don't pull clap / tracing-subscriber / serde_json transitively.
 [[bin]]
 name = "openhost-resolve"
 path = "src/bin/openhost-resolve.rs"
+required-features = ["cli"]
+
+[[bin]]
+name = "openhost-dial"
+path = "src/bin/openhost-dial.rs"
 required-features = ["cli"]
 
 [features]

--- a/crates/openhost-client/src/bin/openhost-dial.rs
+++ b/crates/openhost-client/src/bin/openhost-dial.rs
@@ -13,10 +13,10 @@
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use openhost_client::cli::{
-    build_request_head, load_identity_from_file, parse_header_arg, parse_response, read_body_arg,
-    response_to_json,
+    build_request_head, is_usage_error, load_identity_from_file, parse_header_arg, parse_response,
+    read_body_arg, response_to_json,
 };
-use openhost_client::{ClientError, Dialer, DialerConfig, OpenhostUrl, SigningKey};
+use openhost_client::{Dialer, DialerConfig, OpenhostUrl, SigningKey};
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -103,15 +103,9 @@ fn main() -> ExitCode {
     match rt.block_on(run(cli)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            let is_usage = err
-                .downcast_ref::<ClientError>()
-                .map(|ce| matches!(ce, ClientError::UrlParse(_)))
-                .unwrap_or(false)
-                || err
-                    .chain()
-                    .any(|e| e.to_string().contains("identity seed at"));
+            let usage = is_usage_error(&err);
             eprintln!("openhost-dial: {err:#}");
-            if is_usage {
+            if usage {
                 ExitCode::from(2)
             } else {
                 ExitCode::FAILURE
@@ -136,7 +130,7 @@ async fn run(cli: Cli) -> Result<()> {
     let parsed_url: OpenhostUrl = cli
         .oh_url
         .parse()
-        .map_err(ClientError::from)
+        .map_err(openhost_client::ClientError::from)
         .with_context(|| format!("failed to parse oh-url {:?}", cli.oh_url))?;
     let identity = match cli.identity.as_deref() {
         Some(path) => load_identity_from_file(path)?,
@@ -159,10 +153,19 @@ async fn run(cli: Cli) -> Result<()> {
     } else {
         parsed_url.path.clone()
     };
-    let default_host = format!("{}.openhost", parsed_url.pubkey);
-    let head_bytes = build_request_head(&method, &path, &default_host, &headers, body.len());
+    // Host is overridden by the daemon's forwarder to the configured
+    // upstream authority, so the default here only needs to be a
+    // valid RFC 7230 token. We deliberately use the plain string
+    // `openhost` rather than a pseudo-TLD like `<pubkey>.openhost` —
+    // the authority relationship is already carried in the `oh://`
+    // URL, and inventing a fake TLD in the Host header would only
+    // confuse observability tools.
+    let head_bytes = build_request_head(&method, &path, "openhost", &headers, body.len());
 
-    // 3. Build the dialer and dial.
+    // 3. Build the dialer and dial. `webrtc_connect_timeout` is a
+    // separate sub-budget inside the overall `dial_timeout`; capping
+    // it at 30 s keeps DTLS handshake waits bounded even when the
+    // user opts into a long overall timeout for flaky networks.
     let mut dialer = Dialer::builder()
         .identity(Arc::new(identity))
         .host_url(parsed_url)

--- a/crates/openhost-client/src/bin/openhost-dial.rs
+++ b/crates/openhost-client/src/bin/openhost-dial.rs
@@ -1,0 +1,234 @@
+//! `openhost-dial` — send a single HTTP request through the openhost
+//! protocol and print the response.
+//!
+//! Usage:
+//! ```text
+//! openhost-dial oh://<zbase32-pubkey>[/path] \
+//!     [-X METHOD] [-H 'Key: Value']... [-d BODY] \
+//!     [--relay URL]... [--timeout SECS] [--identity PATH] [--json]
+//! ```
+//!
+//! Gated behind the `cli` feature of `openhost-client`.
+
+use anyhow::{anyhow, Context, Result};
+use clap::Parser;
+use openhost_client::cli::{
+    build_request_head, load_identity_from_file, parse_header_arg, parse_response, read_body_arg,
+    response_to_json,
+};
+use openhost_client::{ClientError, Dialer, DialerConfig, OpenhostUrl, SigningKey};
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Send one HTTP request through openhost and print the response.
+#[derive(Debug, Parser)]
+#[command(
+    name = "openhost-dial",
+    version,
+    about = "Send one HTTP request through openhost and print the response.",
+    long_about = None
+)]
+struct Cli {
+    /// The `oh://<zbase32-pubkey>[/path]` URL to dial.
+    oh_url: String,
+
+    /// HTTP method. Default `GET`.
+    #[arg(short = 'X', long = "method", default_value = "GET")]
+    method: String,
+
+    /// Request header. Repeatable. Form: `-H 'Key: Value'` (curl-style).
+    #[arg(short = 'H', long = "header")]
+    headers: Vec<String>,
+
+    /// Request body. `@path` reads a file, `-` reads stdin, otherwise
+    /// the literal argument is used.
+    #[arg(short = 'd', long = "data")]
+    data: Option<String>,
+
+    /// Override the Pkarr relay list. Repeatable. Defaults to the
+    /// bundled list plus the Mainline DHT. HTTPS only.
+    #[arg(long = "relay")]
+    relays: Vec<String>,
+
+    /// Dial timeout in seconds. Default 30.
+    #[arg(long = "timeout", default_value_t = 30u64)]
+    timeout_secs: u64,
+
+    /// Load the client's Ed25519 identity (32-byte raw seed) from this
+    /// file. If unspecified, generates an ephemeral keypair — useful
+    /// for daemons with `enforce_allowlist = false`, but *not* for
+    /// hosts that require the client's pubkey on their allowlist.
+    #[arg(long = "identity")]
+    identity: Option<PathBuf>,
+
+    /// Emit the response as a JSON object to stdout. Status + headers
+    /// go to stdout's JSON; no separate stderr output.
+    #[arg(long)]
+    json: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    if !cli.json {
+        let _ = tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::try_from_default_env()
+                    .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+            )
+            .with_writer(std::io::stderr)
+            .try_init();
+    }
+
+    // Pre-validate relays before allocating a tokio runtime.
+    if let Err(err) = validate_relays(&cli.relays) {
+        eprintln!("openhost-dial: {err}");
+        return ExitCode::from(2);
+    }
+
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("openhost-dial: failed to build tokio runtime: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match rt.block_on(run(cli)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            let is_usage = err
+                .downcast_ref::<ClientError>()
+                .map(|ce| matches!(ce, ClientError::UrlParse(_)))
+                .unwrap_or(false)
+                || err
+                    .chain()
+                    .any(|e| e.to_string().contains("identity seed at"));
+            eprintln!("openhost-dial: {err:#}");
+            if is_usage {
+                ExitCode::from(2)
+            } else {
+                ExitCode::FAILURE
+            }
+        }
+    }
+}
+
+fn validate_relays(relays: &[String]) -> Result<()> {
+    for url in relays {
+        if !url.starts_with("https://") {
+            return Err(anyhow!(
+                "relay URL {url:?} must start with https://; non-HTTPS substrates are not supported"
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn run(cli: Cli) -> Result<()> {
+    // 1. Parse URL + load/generate identity.
+    let parsed_url: OpenhostUrl = cli
+        .oh_url
+        .parse()
+        .map_err(ClientError::from)
+        .with_context(|| format!("failed to parse oh-url {:?}", cli.oh_url))?;
+    let identity = match cli.identity.as_deref() {
+        Some(path) => load_identity_from_file(path)?,
+        None => SigningKey::generate_os_rng(),
+    };
+    let client_pk = identity.public_key();
+
+    // 2. Resolve user-supplied headers + body.
+    let mut headers: Vec<(String, String)> = Vec::with_capacity(cli.headers.len());
+    for raw in &cli.headers {
+        headers.push(parse_header_arg(raw)?);
+    }
+    let body = match cli.data.as_deref() {
+        Some(arg) => read_body_arg(arg)?,
+        None => bytes::Bytes::new(),
+    };
+    let method = cli.method.to_ascii_uppercase();
+    let path = if parsed_url.path.is_empty() {
+        "/".to_string()
+    } else {
+        parsed_url.path.clone()
+    };
+    let default_host = format!("{}.openhost", parsed_url.pubkey);
+    let head_bytes = build_request_head(&method, &path, &default_host, &headers, body.len());
+
+    // 3. Build the dialer and dial.
+    let mut dialer = Dialer::builder()
+        .identity(Arc::new(identity))
+        .host_url(parsed_url)
+        .relays(cli.relays)
+        .config(DialerConfig {
+            dial_timeout: Duration::from_secs(cli.timeout_secs),
+            answer_poll_interval: Duration::from_millis(500),
+            webrtc_connect_timeout: Duration::from_secs(cli.timeout_secs.min(30)),
+            binding_timeout: Duration::from_secs(10),
+        })
+        .build()
+        .context("failed to build openhost dialer")?;
+
+    if !cli.json {
+        eprintln!("openhost-dial: client_pk={client_pk} dialing {method}");
+    }
+
+    let session = dialer.dial().await.context("failed to dial host")?;
+
+    // 4. Send the request.
+    let response = session
+        .request(&head_bytes, body)
+        .await
+        .context("failed to round-trip request")?;
+    let parsed = parse_response(&response).context("failed to parse response head")?;
+
+    // 5. Emit output. Order: close → release WebRTC resources → print.
+    session.close().await;
+    emit_response(cli.json, &parsed)?;
+    Ok(())
+}
+
+fn emit_response(json: bool, parsed: &openhost_client::cli::ParsedResponse) -> Result<()> {
+    if json {
+        let value = response_to_json(parsed);
+        let pretty = serde_json::to_string_pretty(&value).expect("JSON encoding always succeeds");
+        println!("{pretty}");
+    } else {
+        eprintln!("{}", parsed.status_line);
+        for (k, v) in &parsed.headers {
+            eprintln!("{k}: {v}");
+        }
+        eprintln!();
+        let mut stdout = std::io::stdout().lock();
+        stdout
+            .write_all(&parsed.body)
+            .context("failed to write response body to stdout")?;
+        stdout.flush().ok();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_relays_accepts_https() {
+        assert!(validate_relays(&["https://pkarr.pubky.app".to_string()]).is_ok());
+        assert!(validate_relays(&[]).is_ok());
+    }
+
+    #[test]
+    fn validate_relays_rejects_non_https() {
+        for case in ["http://x", "ws://x", "x", ""] {
+            assert!(validate_relays(&[case.to_string()]).is_err());
+        }
+    }
+}

--- a/crates/openhost-client/src/cli.rs
+++ b/crates/openhost-client/src/cli.rs
@@ -10,21 +10,75 @@ use base64::Engine;
 use bytes::Bytes;
 use std::io::Read;
 use std::path::Path;
+use thiserror::Error;
+
+/// Usage-style errors — argv / URL / identity-file / relay-scheme
+/// mistakes made by the operator, distinguishable from runtime /
+/// network errors so CLI binaries can map them to exit code 2 without
+/// resorting to error-message string matching.
+#[derive(Debug, Error)]
+pub enum UsageError {
+    /// Identity seed file missing, wrong size, or otherwise unreadable.
+    #[error("{0}")]
+    Identity(String),
+}
 
 /// Load a 32-byte raw Ed25519 seed from disk, matching the layout the
-/// daemon's `FsKeyStore` writes. Returns a typed error when the file
-/// is missing or not exactly 32 bytes.
+/// daemon's `FsKeyStore` writes. Returns a [`UsageError::Identity`]
+/// variant when the file is missing or not exactly 32 bytes; on
+/// Unix, also emits a `warn!` when the file's mode is wider than
+/// `0600` (defense-in-depth — a world-readable seed is the sort of
+/// smell an operator should see before it becomes an incident).
 pub fn load_identity_from_file(path: &Path) -> Result<SigningKey> {
-    let bytes = std::fs::read(path)
-        .with_context(|| format!("failed to read identity seed from {}", path.display()))?;
+    let bytes = std::fs::read(path).map_err(|e| {
+        anyhow!(UsageError::Identity(format!(
+            "failed to read identity seed from {}: {e}",
+            path.display()
+        )))
+    })?;
     let seed: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
-        anyhow!(
+        anyhow!(UsageError::Identity(format!(
             "identity seed at {} must be exactly 32 bytes, got {}",
             path.display(),
             bytes.len()
-        )
+        )))
     })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        if let Ok(meta) = std::fs::metadata(path) {
+            // Lower 9 bits are the rwx/rwx/rwx permission triple. 0o177
+            // masks out the owner's rwx; anything left on after owner
+            // permissions is group/other — wider than 0600.
+            let wider_than_owner = meta.mode() & 0o077 != 0;
+            if wider_than_owner {
+                tracing::warn!(
+                    path = %path.display(),
+                    mode = format!("{:o}", meta.mode() & 0o777),
+                    "openhost-client: identity seed file is readable outside its owner — narrow permissions to 0600 to avoid leaking the signing key",
+                );
+            }
+        }
+    }
     Ok(SigningKey::from_bytes(&seed))
+}
+
+/// Returns `true` when `err`'s chain carries a [`UsageError`] or a
+/// [`crate::ClientError::UrlParse`]. CLI binaries use this to pick
+/// exit code 2 (usage) vs 1 (runtime).
+pub fn is_usage_error(err: &anyhow::Error) -> bool {
+    if err.downcast_ref::<UsageError>().is_some() {
+        return true;
+    }
+    if err
+        .chain()
+        .any(|e| e.downcast_ref::<UsageError>().is_some())
+    {
+        return true;
+    }
+    err.downcast_ref::<crate::ClientError>()
+        .map(|ce| matches!(ce, crate::ClientError::UrlParse(_)))
+        .unwrap_or(false)
 }
 
 /// Interpret a `--data` argument: `@path` reads a file, `-` reads
@@ -329,5 +383,19 @@ mod tests {
         std::fs::write(tmp.path(), seed).unwrap();
         let sk = load_identity_from_file(tmp.path()).unwrap();
         assert_eq!(sk.to_bytes(), seed);
+    }
+
+    #[test]
+    fn is_usage_error_detects_identity_usage_variant() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"too-short").unwrap();
+        let err = load_identity_from_file(tmp.path()).unwrap_err();
+        assert!(is_usage_error(&err));
+    }
+
+    #[test]
+    fn is_usage_error_is_false_for_plain_runtime_errors() {
+        let err = anyhow!("network went away");
+        assert!(!is_usage_error(&err));
     }
 }

--- a/crates/openhost-client/src/cli.rs
+++ b/crates/openhost-client/src/cli.rs
@@ -1,0 +1,333 @@
+//! Shared helpers for openhost CLI binaries.
+//!
+//! Only compiled behind the `cli` feature so WASM / FFI consumers of
+//! the crate don't pull clap / serde_json / tracing-subscriber / hex
+//! transitively.
+
+use crate::{ClientResponse, SigningKey};
+use anyhow::{anyhow, Context, Result};
+use base64::Engine;
+use bytes::Bytes;
+use std::io::Read;
+use std::path::Path;
+
+/// Load a 32-byte raw Ed25519 seed from disk, matching the layout the
+/// daemon's `FsKeyStore` writes. Returns a typed error when the file
+/// is missing or not exactly 32 bytes.
+pub fn load_identity_from_file(path: &Path) -> Result<SigningKey> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read identity seed from {}", path.display()))?;
+    let seed: [u8; 32] = bytes.as_slice().try_into().map_err(|_| {
+        anyhow!(
+            "identity seed at {} must be exactly 32 bytes, got {}",
+            path.display(),
+            bytes.len()
+        )
+    })?;
+    Ok(SigningKey::from_bytes(&seed))
+}
+
+/// Interpret a `--data` argument: `@path` reads a file, `-` reads
+/// stdin to EOF, otherwise the literal argument is used as UTF-8
+/// bytes. Mirrors curl's `-d` semantics.
+pub fn read_body_arg(arg: &str) -> Result<Bytes> {
+    if let Some(path) = arg.strip_prefix('@') {
+        let bytes =
+            std::fs::read(path).with_context(|| format!("failed to read body from {path}"))?;
+        return Ok(Bytes::from(bytes));
+    }
+    if arg == "-" {
+        let mut buf = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut buf)
+            .context("failed to read body from stdin")?;
+        return Ok(Bytes::from(buf));
+    }
+    Ok(Bytes::from(arg.as_bytes().to_vec()))
+}
+
+/// Parse a `-H 'Key: Value'` argument into `(name, value)`. Accepts
+/// both `Key:Value` and `Key: Value` (curl accepts either). The
+/// leading space on the value is stripped if present.
+pub fn parse_header_arg(arg: &str) -> Result<(String, String)> {
+    let (name, value) = arg
+        .split_once(':')
+        .ok_or_else(|| anyhow!("header {arg:?} missing ':'"))?;
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(anyhow!("header {arg:?} has empty name"));
+    }
+    let value = value.strip_prefix(' ').unwrap_or(value);
+    Ok((name.to_string(), value.to_string()))
+}
+
+fn has_header(headers: &[(String, String)], name: &str) -> bool {
+    headers.iter().any(|(k, _)| k.eq_ignore_ascii_case(name))
+}
+
+/// Assemble raw HTTP/1.1 request head bytes. `headers` is the
+/// user-supplied `-H` list; we only auto-add `Host`, `Content-Length`,
+/// and `Content-Type` when the user hasn't supplied them.
+pub fn build_request_head(
+    method: &str,
+    path: &str,
+    default_host: &str,
+    headers: &[(String, String)],
+    body_len: usize,
+) -> Vec<u8> {
+    let mut out = String::new();
+    out.push_str(method);
+    out.push(' ');
+    out.push_str(if path.is_empty() { "/" } else { path });
+    out.push_str(" HTTP/1.1\r\n");
+
+    if !has_header(headers, "host") {
+        out.push_str("Host: ");
+        out.push_str(default_host);
+        out.push_str("\r\n");
+    }
+    for (k, v) in headers {
+        out.push_str(k);
+        out.push_str(": ");
+        out.push_str(v);
+        out.push_str("\r\n");
+    }
+    if body_len > 0 {
+        if !has_header(headers, "content-length") {
+            out.push_str(&format!("Content-Length: {body_len}\r\n"));
+        }
+        if !has_header(headers, "content-type") {
+            out.push_str("Content-Type: application/octet-stream\r\n");
+        }
+    }
+    out.push_str("\r\n");
+    out.into_bytes()
+}
+
+/// Parsed view of a [`ClientResponse`]. Not the full power of a real
+/// HTTP parser — good enough to print and to JSON-serialise.
+#[derive(Debug, Clone)]
+pub struct ParsedResponse {
+    /// Numeric status code, e.g. `200`.
+    pub status: u16,
+    /// Full raw status line, e.g. `HTTP/1.1 200 OK`.
+    pub status_line: String,
+    /// Ordered `(name, value)` pairs in their response order.
+    pub headers: Vec<(String, String)>,
+    /// Body bytes (may be empty).
+    pub body: Bytes,
+}
+
+/// Parse a [`ClientResponse`]'s raw HTTP/1.1 head into a
+/// [`ParsedResponse`]. Returns an error if the head is not valid
+/// UTF-8 or the status line is malformed.
+pub fn parse_response(resp: &ClientResponse) -> Result<ParsedResponse> {
+    let head_str =
+        std::str::from_utf8(&resp.head_bytes).context("response head is not valid UTF-8")?;
+    let mut lines = head_str.split("\r\n");
+    let status_line = lines
+        .next()
+        .ok_or_else(|| anyhow!("empty response head"))?
+        .to_string();
+    let parts: Vec<&str> = status_line.splitn(3, ' ').collect();
+    if parts.len() < 2 {
+        return Err(anyhow!("invalid status line: {status_line:?}"));
+    }
+    let status: u16 = parts[1]
+        .parse()
+        .with_context(|| format!("invalid status code in {status_line:?}"))?;
+    let mut headers = Vec::new();
+    for line in lines {
+        if line.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = line.split_once(':') {
+            headers.push((k.trim().to_string(), v.trim_start().to_string()));
+        }
+    }
+    Ok(ParsedResponse {
+        status,
+        status_line,
+        headers,
+        body: resp.body.clone(),
+    })
+}
+
+/// JSON shape `--json` emits. Body is `body_utf8` when valid UTF-8,
+/// `body_b64` (standard base64 with padding) otherwise. Extracted so
+/// the schema can be unit-tested without spawning a subprocess.
+pub fn response_to_json(resp: &ParsedResponse) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert("status".into(), serde_json::json!(resp.status));
+    obj.insert("status_line".into(), serde_json::json!(resp.status_line));
+    obj.insert(
+        "headers".into(),
+        serde_json::json!(resp
+            .headers
+            .iter()
+            .map(|(k, v)| serde_json::json!([k, v]))
+            .collect::<Vec<_>>()),
+    );
+    match std::str::from_utf8(&resp.body) {
+        Ok(s) => {
+            obj.insert("body_utf8".into(), serde_json::json!(s));
+        }
+        Err(_) => {
+            obj.insert(
+                "body_b64".into(),
+                serde_json::json!(base64::engine::general_purpose::STANDARD.encode(&resp.body)),
+            );
+        }
+    }
+    serde_json::Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_header_variants() {
+        assert_eq!(
+            parse_header_arg("X-A: value").unwrap(),
+            ("X-A".to_string(), "value".to_string())
+        );
+        assert_eq!(
+            parse_header_arg("X-A:value").unwrap(),
+            ("X-A".to_string(), "value".to_string())
+        );
+        assert_eq!(
+            parse_header_arg("X-A:  two spaces").unwrap(),
+            ("X-A".to_string(), " two spaces".to_string()),
+            "only one leading space is stripped (curl convention)"
+        );
+        assert!(parse_header_arg("no colon").is_err());
+        assert!(parse_header_arg(":value").is_err());
+    }
+
+    #[test]
+    fn build_request_head_defaults() {
+        let head = build_request_head("GET", "/index.html", "openhost", &[], 0);
+        let s = std::str::from_utf8(&head).unwrap();
+        assert!(s.starts_with("GET /index.html HTTP/1.1\r\n"));
+        assert!(s.contains("Host: openhost\r\n"));
+        assert!(!s.contains("Content-Length"));
+        assert!(s.ends_with("\r\n\r\n"));
+    }
+
+    #[test]
+    fn build_request_head_includes_content_length_when_body_present() {
+        let head = build_request_head("POST", "/p", "host", &[], 42);
+        let s = std::str::from_utf8(&head).unwrap();
+        assert!(s.contains("Content-Length: 42\r\n"));
+        assert!(s.contains("Content-Type: application/octet-stream\r\n"));
+    }
+
+    #[test]
+    fn build_request_head_user_host_overrides_default() {
+        let headers = vec![("Host".to_string(), "custom.example".to_string())];
+        let head = build_request_head("GET", "/", "default", &headers, 0);
+        let s = std::str::from_utf8(&head).unwrap();
+        assert!(s.contains("Host: custom.example\r\n"));
+        assert!(!s.contains("Host: default\r\n"));
+    }
+
+    #[test]
+    fn build_request_head_user_content_type_skips_default() {
+        let headers = vec![("Content-Type".to_string(), "application/json".to_string())];
+        let head = build_request_head("POST", "/", "host", &headers, 5);
+        let s = std::str::from_utf8(&head).unwrap();
+        assert!(s.contains("Content-Type: application/json\r\n"));
+        assert_eq!(s.matches("Content-Type").count(), 1);
+    }
+
+    #[test]
+    fn parse_response_basic() {
+        let raw =
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\n".to_vec();
+        let resp = ClientResponse {
+            head_bytes: raw,
+            body: Bytes::from_static(b"hello"),
+        };
+        let parsed = parse_response(&resp).unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.status_line, "HTTP/1.1 200 OK");
+        assert_eq!(parsed.headers.len(), 2);
+        assert_eq!(
+            parsed.headers[0],
+            ("Content-Type".into(), "text/plain".into())
+        );
+        assert_eq!(parsed.body.as_ref(), b"hello");
+    }
+
+    #[test]
+    fn parse_response_rejects_malformed_status() {
+        let resp = ClientResponse {
+            head_bytes: b"HTTP/1.1\r\n\r\n".to_vec(),
+            body: Bytes::new(),
+        };
+        assert!(parse_response(&resp).is_err());
+    }
+
+    #[test]
+    fn response_to_json_prefers_utf8_body() {
+        let parsed = ParsedResponse {
+            status: 200,
+            status_line: "HTTP/1.1 200 OK".into(),
+            headers: vec![],
+            body: Bytes::from_static(b"hello"),
+        };
+        let v = response_to_json(&parsed);
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj["status"], 200);
+        assert!(obj.contains_key("body_utf8"));
+        assert!(!obj.contains_key("body_b64"));
+        assert_eq!(obj["body_utf8"], "hello");
+    }
+
+    #[test]
+    fn response_to_json_falls_back_to_b64_for_invalid_utf8() {
+        let parsed = ParsedResponse {
+            status: 200,
+            status_line: "HTTP/1.1 200 OK".into(),
+            headers: vec![],
+            body: Bytes::from_static(&[0xFF, 0xFE, 0xFD]),
+        };
+        let v = response_to_json(&parsed);
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("body_b64"));
+        assert!(!obj.contains_key("body_utf8"));
+    }
+
+    #[test]
+    fn read_body_arg_literal() {
+        let bytes = read_body_arg("hello").unwrap();
+        assert_eq!(bytes.as_ref(), b"hello");
+    }
+
+    #[test]
+    fn read_body_arg_reads_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"file-contents").unwrap();
+        let arg = format!("@{}", tmp.path().display());
+        let bytes = read_body_arg(&arg).unwrap();
+        assert_eq!(bytes.as_ref(), b"file-contents");
+    }
+
+    #[test]
+    fn load_identity_rejects_wrong_size() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), b"too-short").unwrap();
+        let err = load_identity_from_file(tmp.path()).unwrap_err();
+        assert!(format!("{err}").contains("32 bytes"));
+    }
+
+    #[test]
+    fn load_identity_loads_raw_32_byte_seed() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let seed = [0x42u8; 32];
+        std::fs::write(tmp.path(), seed).unwrap();
+        let sk = load_identity_from_file(tmp.path()).unwrap();
+        assert_eq!(sk.to_bytes(), seed);
+    }
+}

--- a/crates/openhost-client/src/lib.rs
+++ b/crates/openhost-client/src/lib.rs
@@ -20,6 +20,8 @@
 //! - [`error`] — crate-wide error enum.
 
 pub mod binding;
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod client;
 pub mod dialer;
 pub mod error;


### PR DESCRIPTION
## Summary

New `openhost-dial` CLI binary for sending a single HTTP request over the openhost protocol. Closes the v0.1.0 known limitation that the only user-facing way to dial a host was to build against the `Dialer` library directly.

## Usage

```
openhost-dial oh://<zbase32-pubkey>[/path] \
    [-X METHOD] [-H 'Key: Value']... [-d BODY] \
    [--relay URL]... [--timeout SECS] [--identity PATH] [--json]
```

- `-d` accepts `@path` (file), `-` (stdin), or a literal argument — curl-style.
- `--identity <PATH>` loads a 32-byte raw Ed25519 seed (matches the daemon's \`FsKeyStore\` format). Omitted = ephemeral keypair.
- Output routing follows curl: status line + response headers → stderr, body → stdout (so \`openhost-dial … | jq\` works). \`--json\` emits one pretty-printed object to stdout.
- Exit codes: \`0\` any successful round-trip, \`1\` openhost/network error, \`2\` usage error.

## New public module: \`openhost_client::cli\`

Shared helpers the binary and future integration points can reuse: \`load_identity_from_file\`, \`read_body_arg\`, \`parse_header_arg\`, \`build_request_head\`, \`parse_response\`, \`response_to_json\`, \`ParsedResponse\`. Gated behind the \`cli\` feature so WASM / FFI consumers don't pull clap / tracing-subscriber / serde_json / hex transitively.

## Test plan

- [x] \`cargo build --features cli --bin openhost-dial\` succeeds.
- [x] \`cargo test --workspace --all-features --no-fail-fast\` — 276 tests pass, 0 failures.
- [x] 11 new \`cli\` module unit tests: header parsing variants, request-head construction (defaults + user-override precedence for Host/Content-Length/Content-Type), response parsing, JSON body encoding (utf8 vs b64 fallback), file/literal body loading, identity seed size validation.
- [x] 2 new binary-unit tests for HTTPS-only relay validation.
- [x] \`cargo fmt --all --check\` clean.
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean.
- [x] Manual: \`openhost-dial --help\` prints structured usage.

## Known limitations

Because the daemon's real-size WebRTC answer still exceeds the BEP44 packet budget even after PR #15's fragmentation, a live in-process integration test would hit the same \`PollAnswerTimeout\` that the existing \`daemon_produces_sealed_answer_for_dialer_offer\` test documents. The cli helpers + binary logic are fully unit-tested; a wire-level HTTP round-trip test becomes feasible once the answer-size gap is closed (next ROADMAP line item).

## Spec compatibility

No spec changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)