### PR TITLE
feat(daemon): hot-reload pairing DB via file-watcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added (PR #17, pair-DB file watcher)
+
+- **Automatic pair-DB reload on every platform.** New `openhost_daemon::pair_watcher` module wraps `notify-debouncer-mini` in a tokio-friendly handle: the watcher targets the pair-DB file's parent directory in non-recursive mode, filters events by filename inside a dedicated bridge thread, and forwards debounced reload triggers into the daemon's event loop via a tokio `mpsc`. The `App::run` event loop grows a third `tokio::select!` arm parallel to `shutdown_signal` and `reload_signal`; the SIGHUP path is retained as a secondary trigger on Unix so the existing SIGHUP integration test (`pairing_enforcement.rs`) continues to exercise the same reload code.
+- New `PairWatcherError` variant on `DaemonError` (`BadPath`, `Io`, `Backend`, `ThreadSpawn`). Spawn failures degrade gracefully — the watcher logs a `warn!` and returns `None`, the daemon keeps running, and pairing changes fall back to the SIGHUP path.
+- New config field `pairing.watch_debounce_ms: u64` (default 250). Operators can tune the coalesce window per deployment; the default swallows `pairing::save_atomic`'s write-then-rename burst and still feels interactive.
+- New integration test `crates/openhost-daemon/tests/pair_watcher.rs::watcher_reloads_allowlist_without_sighup`: boots `App`, modifies the pair DB on disk via `pairing::add`, and asserts `SharedState::is_client_allowed` becomes true within 3 s — without sending SIGHUP. Runs on both Unix and Windows (modulo notify-backend timing) under a multi-threaded tokio flavor so the watcher-driven reload arm of `App::run` can actually fire.
+- 3 new unit tests in `pair_watcher.rs`: fires on write, fires on initial-create (pair DB does not exist at daemon start), ignores sibling files in the same directory.
+
+### Changed (PR #17)
+
+- `openhostd pair add/remove` drops the "Send SIGHUP to the running daemon" reminder and instead prints a one-line note that a running daemon picks the change up automatically via the file watcher. SIGHUP remains documented as a fallback on Unix.
+- `App::run` factored the common post-reload logic into a new `reload_and_trigger(path, state, publisher, source)` helper. Both the SIGHUP and file-watcher arms now route through it; log lines carry a `source` field so operators can distinguish which trigger fired.
+- New dependency: `notify-debouncer-mini = "0.6"` (workspace-level; transitively pulls in `notify`, `inotify` on Linux, `fsevent-sys` on macOS, `notify-types`).
+
 ### Added (PR #16, `openhost-dial` CLI)
 
 - **New binary: `openhost-dial`**. Sends one HTTP request over openhost and prints the response. Behind the existing `cli` feature, so WASM / FFI consumers of `openhost-client` don't pull clap / tracing-subscriber / serde_json / hex transitively. Usage: `openhost-dial oh://<zbase32-pubkey>[/path] [-X METHOD] [-H 'Key: Value']... [-d BODY] [--relay URL]... [--timeout SECS] [--identity PATH] [--json]`. `-d` accepts `@path` (file), `-` (stdin), or a literal string — curl-style. `--identity <PATH>` loads a 32-byte raw Ed25519 seed (matches the daemon's `FsKeyStore` format); when omitted the binary generates an ephemeral key (useful against unauthenticated daemons, not useful against hosts with `enforce_allowlist = true` since the pubkey changes per invocation).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1505,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.11.1",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,6 +1646,26 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1784,6 +1833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1829,6 +1879,45 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.1",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1990,6 +2079,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "notify-debouncer-mini",
  "openhost-core",
  "openhost-pkarr",
  "pkarr",

--- a/crates/openhost-daemon/Cargo.toml
+++ b/crates/openhost-daemon/Cargo.toml
@@ -74,6 +74,12 @@ http-body-util = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 
+# Pair-DB file watcher (PR #17). `notify-debouncer-mini` wraps
+# `notify`'s inotify/FSEvents/ReadDirectoryChangesW backends with a
+# timeout-driven debouncer so a burst of atomic-write events
+# collapses into a single reload.
+notify-debouncer-mini = "0.6"
+
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -50,9 +50,14 @@ pub struct App {
     /// on the `build_with_transport` test path that doesn't provide a
     /// resolver, keeping pre-PR #7a tests working without changes.
     poller: Option<OfferPoller>,
-    /// Resolved path to the pairing DB. Consulted on SIGHUP to reload
-    /// the allow list + trigger a republish.
+    /// Resolved path to the pairing DB. Consulted on SIGHUP / watcher
+    /// events to reload the allow list + trigger a republish.
     pair_db_path: PathBuf,
+    /// File-watcher that fires whenever `pair_db_path` is created,
+    /// modified, or removed. `None` when the watcher couldn't start —
+    /// the daemon keeps running and pairing changes fall back to the
+    /// SIGHUP path (Unix) or a restart (Windows).
+    pair_watcher: Option<crate::pair_watcher::PairWatcher>,
 }
 
 impl App {
@@ -74,6 +79,10 @@ impl App {
             resolver,
             &publisher,
         );
+        let pair_watcher = crate::pair_watcher::PairWatcher::spawn(
+            &pair_db_path,
+            Duration::from_millis(cfg.pairing.watch_debounce_ms),
+        );
         Ok(Self {
             identity,
             cert,
@@ -82,6 +91,7 @@ impl App {
             listener,
             poller,
             pair_db_path,
+            pair_watcher,
         })
     }
 
@@ -97,6 +107,10 @@ impl App {
             build_listener(&cert, identity.clone(), state.clone(), forwarder.clone()).await?;
         let publisher =
             publish::start_with_transport(&cfg.pkarr, identity.clone(), state.clone(), transport);
+        let pair_watcher = crate::pair_watcher::PairWatcher::spawn(
+            &pair_db_path,
+            Duration::from_millis(cfg.pairing.watch_debounce_ms),
+        );
         Ok(Self {
             identity,
             cert,
@@ -105,6 +119,7 @@ impl App {
             listener,
             poller: None,
             pair_db_path,
+            pair_watcher,
         })
     }
 
@@ -133,6 +148,10 @@ impl App {
             resolver,
             &publisher,
         );
+        let pair_watcher = crate::pair_watcher::PairWatcher::spawn(
+            &pair_db_path,
+            Duration::from_millis(cfg.pairing.watch_debounce_ms),
+        );
         Ok(Self {
             identity,
             cert,
@@ -141,6 +160,7 @@ impl App {
             listener,
             poller,
             pair_db_path,
+            pair_watcher,
         })
     }
 
@@ -197,7 +217,7 @@ impl App {
     /// info log. `Exhausted` or timeout → a `warn!` makes the partial
     /// state observable; the daemon keeps running so a later scheduled
     /// republish can still succeed.
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         self.wait_for_initial_publish().await;
         tracing::info!(
             pubkey = %self.identity.public_key(),
@@ -205,33 +225,48 @@ impl App {
             "openhostd: up",
         );
 
-        // Drive the event loop: shutdown wins over concurrent SIGHUP
-        // (`biased;` makes the select poll the shutdown arm first).
-        // Rapid SIGHUP bursts coalesce at the tokio-signal layer and
-        // at the loop boundary — we reload at most once per iteration.
-        // Reload is idempotent: a later SIGHUP just runs the load +
-        // replace_allow again, so coalescing is acceptable.
+        // Drive the event loop: shutdown wins over concurrent
+        // SIGHUP/file-watcher events (`biased;` makes the select poll
+        // the shutdown arm first). Rapid reload bursts coalesce —
+        // tokio-signal collapses SIGHUPs, notify-debouncer-mini
+        // collapses bursty filesystem writes at the 250 ms window, and
+        // the loop boundary provides a final coalescing point. Reload
+        // is idempotent: each event just re-runs load + replace_allow.
         loop {
+            // `pair_watcher.recv()` needs `&mut` access but `None` when
+            // the watcher didn't start; use a branch guard so the
+            // select resolves only when the option is populated.
+            let watcher_active = self.pair_watcher.is_some();
             tokio::select! {
                 biased;
                 _ = shutdown_signal() => {
                     break;
                 }
                 _ = reload_signal() => {
-                    match reload_pair_db(&self.pair_db_path, &self.state) {
-                        Ok(count) => {
-                            tracing::info!(
-                                count,
-                                "openhostd: pairing DB reloaded; republishing",
-                            );
-                            self.publisher.trigger();
-                        }
-                        Err(err) => {
-                            tracing::warn!(
-                                ?err,
-                                "openhostd: pairing DB reload failed; keeping previous allow list",
-                            );
-                        }
+                    reload_and_trigger(
+                        &self.pair_db_path,
+                        &self.state,
+                        &self.publisher,
+                        "SIGHUP",
+                    );
+                }
+                event = async {
+                    match self.pair_watcher.as_mut() {
+                        Some(w) => w.recv().await,
+                        // Never resolves: the `watcher_active` guard
+                        // below keeps this branch disabled when the
+                        // watcher is `None`, but the future body still
+                        // needs to type-check on the `None` side.
+                        None => std::future::pending().await,
+                    }
+                }, if watcher_active => {
+                    if event.is_some() {
+                        reload_and_trigger(
+                            &self.pair_db_path,
+                            &self.state,
+                            &self.publisher,
+                            "file-watcher",
+                        );
                     }
                 }
             }
@@ -240,10 +275,15 @@ impl App {
         tracing::info!("openhostd: shutdown signal received, stopping publisher");
         // Order: listener first (tears down in-flight DTLS); poller
         // next (stops the loop that might otherwise push a late answer
-        // into the publisher); publisher last.
+        // into the publisher); pair-watcher next (drops inotify
+        // resources before the publisher whose trigger it calls);
+        // publisher last.
         self.listener.shutdown().await;
         if let Some(p) = self.poller {
             p.shutdown().await;
+        }
+        if let Some(w) = self.pair_watcher.take() {
+            w.shutdown();
         }
         self.publisher.shutdown().await;
         tracing::info!("openhostd: bye");
@@ -280,6 +320,9 @@ impl App {
         self.listener.shutdown().await;
         if let Some(p) = self.poller {
             p.shutdown().await;
+        }
+        if let Some(w) = self.pair_watcher {
+            w.shutdown();
         }
         self.publisher.shutdown().await;
     }
@@ -441,6 +484,35 @@ fn reload_pair_db(path: &Path, state: &SharedState) -> Result<usize> {
     let count = hashes.len();
     state.replace_allow(hashes);
     Ok(count)
+}
+
+/// Shared handler for both reload paths (SIGHUP + file-watcher):
+/// re-read the pair DB, swap the allow list, trigger a republish.
+/// Never panics; a failed reload logs a `warn!` and leaves the
+/// previous allow list in place.
+fn reload_and_trigger(
+    path: &Path,
+    state: &SharedState,
+    publisher: &PublishService,
+    source: &'static str,
+) {
+    match reload_pair_db(path, state) {
+        Ok(count) => {
+            tracing::info!(
+                count,
+                source,
+                "openhostd: pairing DB reloaded; republishing",
+            );
+            publisher.trigger();
+        }
+        Err(err) => {
+            tracing::warn!(
+                ?err,
+                source,
+                "openhostd: pairing DB reload failed; keeping previous allow list",
+            );
+        }
+    }
 }
 
 /// Install a global `tracing_subscriber` with the configured level filter.

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -128,12 +128,31 @@ impl Default for OfferPollConfig {
 }
 
 /// Pairing-database configuration.
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct PairingConfig {
     /// Path to the pairing TOML database. `None` resolves to the
     /// platform-default path under the openhost config directory.
     pub db_path: Option<PathBuf>,
+    /// Debounce window (milliseconds) for the pair-DB file watcher.
+    /// Raises to coalesce bursty atomic-write patterns; defaults to
+    /// 250 ms which is slow enough to swallow `pair add`'s
+    /// write-then-rename but fast enough to feel interactive.
+    #[serde(default = "default_pair_watch_debounce_ms")]
+    pub watch_debounce_ms: u64,
+}
+
+impl Default for PairingConfig {
+    fn default() -> Self {
+        Self {
+            db_path: None,
+            watch_debounce_ms: default_pair_watch_debounce_ms(),
+        }
+    }
+}
+
+fn default_pair_watch_debounce_ms() -> u64 {
+    250
 }
 
 fn default_enforce_allowlist() -> bool {

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -44,9 +44,42 @@ pub enum DaemonError {
     #[error(transparent)]
     Pairing(#[from] crate::pairing::PairingError),
 
+    /// Pair-DB file-watcher spawn or run failed (PR #17).
+    #[error(transparent)]
+    PairWatcher(#[from] PairWatcherError),
+
     /// Low-level I/O failure not caught by a more specific variant.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Pair-DB file-watcher failures.
+#[derive(Debug, Error)]
+pub enum PairWatcherError {
+    /// The pair-DB path is structurally unusable (no parent directory,
+    /// no filename).
+    #[error("pair-DB path is invalid: {0}")]
+    BadPath(&'static str),
+
+    /// I/O error while preparing the watcher (creating the parent
+    /// directory, stat, etc.).
+    #[error("pair watcher io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The backend (inotify / FSEvents / ReadDirectoryChangesW) refused
+    /// to set up a watch.
+    #[error("pair watcher backend refused {path}: {source}")]
+    Backend {
+        /// Path the backend was asked to watch.
+        path: PathBuf,
+        /// Underlying notify error.
+        #[source]
+        source: notify_debouncer_mini::notify::Error,
+    },
+
+    /// Could not spawn the sync-to-async bridge thread.
+    #[error("pair watcher thread spawn: {0}")]
+    ThreadSpawn(std::io::Error),
 }
 
 /// Config-loading failures.

--- a/crates/openhost-daemon/src/lib.rs
+++ b/crates/openhost-daemon/src/lib.rs
@@ -28,6 +28,7 @@ pub mod forward;
 pub mod identity_store;
 pub mod listener;
 pub mod offer_poller;
+pub mod pair_watcher;
 pub mod pairing;
 pub mod publish;
 pub mod rate_limit;

--- a/crates/openhost-daemon/src/main.rs
+++ b/crates/openhost-daemon/src/main.rs
@@ -154,8 +154,9 @@ fn run_pair(cfg: &Config, cmd: PairCmd) -> anyhow::Result<()> {
                 println!("  nickname: {n}");
             }
             eprintln!(
-                "openhostd: pair DB updated at {}. Send SIGHUP to the running daemon \
-                 (or restart) to apply.",
+                "openhostd: pair DB updated at {}. A running daemon picks \
+                 this up automatically within ~250 ms via the pair-DB file \
+                 watcher (SIGHUP still works as a fallback on Unix).",
                 db_path.display(),
             );
         }
@@ -165,8 +166,9 @@ fn run_pair(cfg: &Config, cmd: PairCmd) -> anyhow::Result<()> {
             pairing::remove(&db_path, &pk)?;
             println!("removed {pk}");
             eprintln!(
-                "openhostd: pair DB updated at {}. Send SIGHUP to the running daemon \
-                 (or restart) to apply.",
+                "openhostd: pair DB updated at {}. A running daemon picks \
+                 this up automatically within ~250 ms via the pair-DB file \
+                 watcher (SIGHUP still works as a fallback on Unix).",
                 db_path.display(),
             );
         }

--- a/crates/openhost-daemon/src/pair_watcher.rs
+++ b/crates/openhost-daemon/src/pair_watcher.rs
@@ -1,0 +1,256 @@
+//! File-system watcher that signals pairing-DB reload events.
+//!
+//! Wraps `notify-debouncer-mini` and bridges its blocking `std::sync`
+//! channel to a tokio `mpsc` receiver the daemon's event loop awaits
+//! alongside `shutdown_signal` and `reload_signal`. Each watcher-fired
+//! event carries no payload; the consumer re-reads the DB from disk.
+//!
+//! # What gets watched
+//!
+//! The watcher targets the pair-DB file's **parent directory** in
+//! non-recursive mode and filters events by filename inside the bridge
+//! thread. Two reasons:
+//!
+//! 1. `pairing::save_atomic` writes a `.tmp` sibling, `fsync`s, then
+//!    `rename`s it into place — a create+rename sequence at the inode
+//!    level. Watching the file directly loses the watch on rename.
+//!    Watching the parent catches both the tmp write and the final
+//!    name appearance.
+//! 2. The pair DB may not exist at daemon startup. Watching a
+//!    non-existent file errors immediately on most backends; watching
+//!    the parent directory succeeds and fires a `Create` event when the
+//!    operator runs `openhostd pair add` for the first time.
+//!
+//! # Error model
+//!
+//! The watcher is a best-effort facility. A spawn failure (inotify
+//! fd exhaustion, FSEvents permission denial, a missing parent
+//! directory) emits a `warn!` at `spawn` time and returns `None`; the
+//! daemon keeps running and pairing changes fall back to the SIGHUP
+//! path (Unix) or a restart (Windows). Errors after spawn are logged
+//! and the thread survives.
+
+use crate::error::PairWatcherError;
+use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode};
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+/// Async-side handle on the file-watcher.
+pub struct PairWatcher {
+    rx: mpsc::UnboundedReceiver<()>,
+    /// Kept alive for the lifetime of the handle; dropping it stops
+    /// the debouncer's OS thread and releases inotify/FSEvents FDs.
+    _debouncer: notify_debouncer_mini::Debouncer<notify_debouncer_mini::notify::RecommendedWatcher>,
+    /// Join handle for the bridge thread — joined on `shutdown` so
+    /// shutdown is deterministic.
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl PairWatcher {
+    /// Spawn a watcher that fires whenever the file at `path` is
+    /// created, modified, or removed. `debounce` coalesces bursts
+    /// (`pairing::save_atomic`'s `.tmp` write + rename is a two-event
+    /// burst). Returns `None` — plus a `warn!` — if the watcher
+    /// cannot be set up; the daemon continues without auto-reload.
+    pub fn spawn(path: &Path, debounce: Duration) -> Option<Self> {
+        match Self::try_spawn(path, debounce) {
+            Ok(watcher) => Some(watcher),
+            Err(err) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    ?err,
+                    "openhostd: pair-DB file watcher could not be started; \
+                     falling back to SIGHUP-only reload. Run the daemon \
+                     with RUST_LOG=openhost_daemon=debug for detail.",
+                );
+                None
+            }
+        }
+    }
+
+    fn try_spawn(path: &Path, debounce: Duration) -> std::result::Result<Self, PairWatcherError> {
+        let path = path.to_path_buf();
+        let parent = path
+            .parent()
+            .ok_or(PairWatcherError::BadPath("no parent directory"))?
+            .to_path_buf();
+        let filename = path
+            .file_name()
+            .ok_or(PairWatcherError::BadPath("no file name"))?
+            .to_os_string();
+
+        // Ensure the parent directory exists. `notify::Watcher::watch`
+        // returns an opaque backend error otherwise; a typed pre-check
+        // here gives operators a clear message.
+        if !parent.exists() {
+            std::fs::create_dir_all(&parent)?;
+        }
+
+        let (sync_tx, sync_rx) = std::sync::mpsc::channel();
+        let mut debouncer =
+            new_debouncer(debounce, sync_tx).map_err(|e| PairWatcherError::Backend {
+                path: parent.clone(),
+                source: e,
+            })?;
+        debouncer
+            .watcher()
+            .watch(&parent, RecursiveMode::NonRecursive)
+            .map_err(|e| PairWatcherError::Backend {
+                path: parent.clone(),
+                source: e,
+            })?;
+
+        let (async_tx, async_rx) = mpsc::unbounded_channel::<()>();
+        let target_filename = filename;
+        let target_display = path.display().to_string();
+        let join = thread::Builder::new()
+            .name("openhost-pair-watcher".into())
+            .spawn(move || Self::bridge(sync_rx, async_tx, &target_filename, &target_display))
+            .map_err(PairWatcherError::ThreadSpawn)?;
+
+        tracing::info!(
+            path = %path.display(),
+            debounce_ms = debounce.as_millis() as u64,
+            "openhostd: pair-DB file watcher armed",
+        );
+
+        Ok(Self {
+            rx: async_rx,
+            _debouncer: debouncer,
+            join: Some(join),
+        })
+    }
+
+    /// Forward sync-channel events from `notify-debouncer-mini` into
+    /// the tokio `mpsc` the event loop awaits. Runs until the sync
+    /// channel is closed (which happens when `Debouncer` is dropped
+    /// during shutdown).
+    fn bridge(
+        sync_rx: std::sync::mpsc::Receiver<notify_debouncer_mini::DebounceEventResult>,
+        async_tx: mpsc::UnboundedSender<()>,
+        target_filename: &std::ffi::OsStr,
+        target_display: &str,
+    ) {
+        while let Ok(result) = sync_rx.recv() {
+            let events = match result {
+                Ok(e) => e,
+                Err(errors) => {
+                    // A debouncer `Err` carries one-or-more backend
+                    // errors; emit a warn but stay in the loop so a
+                    // transient failure (e.g. one inotify queue
+                    // overflow) doesn't silently disable auto-reload.
+                    tracing::warn!(
+                        path = %target_display,
+                        ?errors,
+                        "openhostd: pair-DB watcher backend error — retrying",
+                    );
+                    continue;
+                }
+            };
+
+            let matches_target = events
+                .iter()
+                .any(|ev| ev.path.file_name() == Some(target_filename));
+            if !matches_target {
+                continue;
+            }
+
+            if async_tx.send(()).is_err() {
+                // Receiver dropped → daemon is shutting down.
+                break;
+            }
+        }
+    }
+
+    /// Await the next reload-trigger event. Returns `None` only if the
+    /// underlying tokio channel closes, which happens during shutdown.
+    pub async fn recv(&mut self) -> Option<()> {
+        self.rx.recv().await
+    }
+
+    /// Stop the watcher. Drops the debouncer (terminating the backend
+    /// thread) and joins the bridge thread so no dangling threads
+    /// outlive `App::shutdown`.
+    pub fn shutdown(mut self) {
+        drop(self._debouncer);
+        if let Some(join) = self.join.take() {
+            // `unwrap_or_else(|_|)` swallows a panicking bridge thread —
+            // logged there already. Joining still matters for
+            // deterministic shutdown.
+            let _ = join.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fires_on_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("allow.toml");
+        fs::write(&path, b"pairs = []\n").unwrap();
+
+        let mut watcher =
+            PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
+
+        // Give the backend a moment to start; notify-debouncer-mini's
+        // first tick after `watch` is somewhat backend-dependent.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        fs::write(&path, b"pairs = [{ pubkey = \"abc\" }]\n").unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), watcher.recv())
+            .await
+            .expect("watcher event within 2 s")
+            .expect("channel stays open");
+        watcher.shutdown();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fires_on_initial_create() {
+        // File does not exist at spawn time. Watcher targets the
+        // parent directory; creating the file should fire one event.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("allow.toml");
+
+        let mut watcher =
+            PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        fs::write(&path, b"pairs = []\n").unwrap();
+
+        tokio::time::timeout(Duration::from_secs(2), watcher.recv())
+            .await
+            .expect("watcher event within 2 s")
+            .expect("channel stays open");
+        watcher.shutdown();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ignores_siblings_in_parent() {
+        // A write to a DIFFERENT file in the same directory must not
+        // fire the watcher — we filter by filename in the bridge.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("allow.toml");
+        let sibling = tmp.path().join("other.toml");
+        fs::write(&path, b"pairs = []\n").unwrap();
+
+        let mut watcher =
+            PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        fs::write(&sibling, b"unrelated").unwrap();
+
+        let res = tokio::time::timeout(Duration::from_millis(500), watcher.recv()).await;
+        assert!(
+            res.is_err(),
+            "no event expected for sibling file; got {res:?}",
+        );
+        watcher.shutdown();
+    }
+}

--- a/crates/openhost-daemon/src/pair_watcher.rs
+++ b/crates/openhost-daemon/src/pair_watcher.rs
@@ -28,7 +28,22 @@
 //! directory) emits a `warn!` at `spawn` time and returns `None`; the
 //! daemon keeps running and pairing changes fall back to the SIGHUP
 //! path (Unix) or a restart (Windows). Errors after spawn are logged
-//! and the thread survives.
+//! and the thread survives. A panicking bridge thread (unexpected but
+//! possible if a downstream `tracing` subscriber fails) is caught and
+//! logged via `tracing::error!` before the thread exits, so silent
+//! failure of auto-reload is observable in the daemon's log.
+//!
+//! # Filesystem caveats
+//!
+//! The underlying `notify` crate uses inotify on Linux, FSEvents on
+//! macOS, and ReadDirectoryChangesW on Windows. Events do **not** fire
+//! reliably on network filesystems (NFS, SMB, FUSE-backed mounts).
+//! Operators who put the pair DB on a remote filesystem should expect
+//! the watcher to silently miss events and should either move the DB
+//! to a local path or rely on SIGHUP (Unix) / daemon restart (Windows)
+//! to apply changes. The initial spawn usually still succeeds on such
+//! filesystems, so `warn!`-on-failure is not a substitute for this
+//! caveat.
 
 use crate::error::PairWatcherError;
 use notify_debouncer_mini::{new_debouncer, notify::RecursiveMode};
@@ -107,7 +122,25 @@ impl PairWatcher {
         let target_display = path.display().to_string();
         let join = thread::Builder::new()
             .name("openhost-pair-watcher".into())
-            .spawn(move || Self::bridge(sync_rx, async_tx, &target_filename, &target_display))
+            .spawn(move || {
+                // Catch unwind so a panicking event callback (e.g., a
+                // `tracing` subscriber that failed half-way through) is
+                // loud rather than silent. Auto-reload stops either way,
+                // but an error line in the log is the difference
+                // between a bug report and a mystery.
+                let path = target_display.clone();
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    Self::bridge(sync_rx, async_tx, &target_filename, &target_display)
+                }));
+                if let Err(payload) = result {
+                    let msg = panic_payload_msg(&payload);
+                    tracing::error!(
+                        path = %path,
+                        panic = %msg,
+                        "openhostd: pair-DB watcher bridge thread panicked; auto-reload disabled until daemon restart",
+                    );
+                }
+            })
             .map_err(PairWatcherError::ThreadSpawn)?;
 
         tracing::info!(
@@ -176,11 +209,23 @@ impl PairWatcher {
     pub fn shutdown(mut self) {
         drop(self._debouncer);
         if let Some(join) = self.join.take() {
-            // `unwrap_or_else(|_|)` swallows a panicking bridge thread —
-            // logged there already. Joining still matters for
-            // deterministic shutdown.
+            // A panicking bridge thread is caught and logged before
+            // the thread exits; `join` here just returns `Err(_)` if
+            // the panic propagated past the catch, which we still
+            // discard — shutdown should not itself panic.
             let _ = join.join();
         }
+    }
+}
+
+/// Best-effort extraction of a panic payload's `&str` message.
+fn panic_payload_msg(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
     }
 }
 

--- a/crates/openhost-daemon/tests/pair_watcher.rs
+++ b/crates/openhost-daemon/tests/pair_watcher.rs
@@ -1,0 +1,120 @@
+//! Integration test for PR #17: the pair-DB file watcher reloads the
+//! allowlist in the running daemon without requiring SIGHUP.
+//!
+//! Boots the full `App` via `build_with_transport`, confirms the
+//! initial allowlist is empty, writes a new pair entry to the DB on
+//! disk, then waits for the watcher-driven reload to propagate into
+//! `SharedState`. Success requires the watcher path — the test never
+//! sends SIGHUP and runs identically on Unix and Windows (modulo
+//! notify-backend timing).
+
+mod support;
+
+use openhost_core::identity::SigningKey;
+use openhost_daemon::config::{
+    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, OfferPollConfig, PairingConfig,
+    PkarrConfig,
+};
+use openhost_daemon::{pairing, App};
+use std::sync::Arc;
+use std::time::Duration;
+use support::CaptureTransport;
+use tempfile::TempDir;
+
+fn build_config(tmp: &TempDir, pair_db_path: std::path::PathBuf) -> Config {
+    Config {
+        identity: IdentityConfig {
+            store: IdentityStore::Fs {
+                path: tmp.path().join("identity.key"),
+            },
+        },
+        pkarr: PkarrConfig {
+            relays: vec![],
+            republish_secs: 3600,
+            offer_poll: OfferPollConfig {
+                poll_secs: 1,
+                watched_clients: vec![],
+                per_client_throttle_secs: 0,
+                enforce_allowlist: false,
+                rate_limit_burst: 10,
+                rate_limit_refill_secs: 1.0,
+            },
+        },
+        dtls: DtlsConfig {
+            cert_path: tmp.path().join("dtls.pem"),
+            rotate_secs: 3600,
+        },
+        forward: None,
+        log: LogConfig::default(),
+        pairing: PairingConfig {
+            db_path: Some(pair_db_path),
+            // Shorter debounce so the test doesn't wait a full default
+            // 250 ms window on every modification.
+            watch_debounce_ms: 50,
+        },
+    }
+}
+
+/// Add a pubkey to the pair DB at `path` and wait for the daemon's
+/// `SharedState.allow` to contain its expected hash. The watcher
+/// must drive this reload; the test never sends SIGHUP.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn watcher_reloads_allowlist_without_sighup() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_test_writer()
+        .try_init();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db_path = tmp.path().join("allow.toml");
+    let cfg = build_config(&tmp, pair_db_path.clone());
+    let transport = Arc::new(CaptureTransport::default());
+    let app = App::build_with_transport(cfg, transport)
+        .await
+        .expect("app builds");
+
+    // Initial allow list is empty.
+    assert_eq!(app.state().allow().len(), 0);
+
+    // Drive the event loop concurrently so the watcher arm actually
+    // fires. The test writes to the DB, the loop's select! picks up
+    // the watcher event, `reload_and_trigger` runs, `SharedState`
+    // updates — all without SIGHUP.
+    let state = Arc::clone(app.state());
+    let run_task = tokio::spawn(async move { app.run().await });
+
+    // Allow the initial-publish wait + watcher arm to be armed.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Add a pubkey via the same `pairing::add` the CLI uses.
+    let client_pk = SigningKey::generate_os_rng().public_key();
+    pairing::add(&pair_db_path, &client_pk, Some("test-client".into()))
+        .expect("pair add writes TOML");
+
+    // Wait up to 3 s for the watcher → reload propagation.
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    let expected_hash = openhost_core::crypto::allowlist_hash(&state.salt(), &client_pk.to_bytes());
+    loop {
+        if state.is_client_allowed(&client_pk) {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            let snapshot = state.allow();
+            panic!(
+                "watcher never propagated the new entry into SharedState; \
+                 snapshot has {} entries, expected hash = {:?}",
+                snapshot.len(),
+                expected_hash,
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Abort the run task. We don't need an explicit shutdown here —
+    // `App::run` owns everything and aborting releases it via Drop.
+    run_task.abort();
+    let _ = run_task.await;
+}

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -66,6 +66,7 @@ fn build_config(
         log: LogConfig::default(),
         pairing: PairingConfig {
             db_path: pair_db_path,
+            ..PairingConfig::default()
         },
     }
 }


### PR DESCRIPTION
## Summary

Closes the v0.1.0 known limitation that \`openhostd pair add/remove\` required a SIGHUP on Unix or a daemon restart on Windows. The running daemon now picks up pair-DB changes automatically within the debounce window (default 250 ms).

## What this adds

- **New \`openhost_daemon::pair_watcher\` module** wrapping \`notify-debouncer-mini\`. Watches the pair-DB file's **parent directory** in non-recursive mode (handles \`pairing::save_atomic\`'s write-then-rename pattern and the first-\`pair add\` create event where the DB doesn't exist yet). Bridges the blocking \`std::sync::mpsc\` debouncer channel to a tokio \`mpsc::UnboundedReceiver<()>\`.
- **Event-loop integration.** \`App::run\` grows a third \`tokio::select!\` arm parallel to \`shutdown_signal\` and \`reload_signal\`. SIGHUP remains as a secondary trigger on Unix. Both paths share a new \`reload_and_trigger(path, state, publisher, source)\` helper so reload semantics are single-sourced; log lines carry \`source = \"SIGHUP\"|\"file-watcher\"\`.
- **Config surface.** \`pairing.watch_debounce_ms: u64\` (default 250). Operators can tune per deployment.
- **Graceful degradation.** Watcher spawn failures log \`warn!\` and return \`None\`; the daemon keeps running and the SIGHUP path still works on Unix.
- **CLI touch-up.** \`openhostd pair add/remove\` drops the SIGHUP reminder and prints a one-line note that a running daemon picks up the change automatically.

## Test plan

- [x] \`cargo test --workspace --all-features --no-fail-fast\` — 282 tests pass, 0 failures.
- [x] 3 new unit tests in \`pair_watcher.rs\`: fires on write, fires on initial-create, ignores sibling files.
- [x] New integration test \`tests/pair_watcher.rs::watcher_reloads_allowlist_without_sighup\` — boots \`App\`, writes to the pair DB, asserts \`SharedState::is_client_allowed\` becomes true within 3 s without SIGHUP. Multi-thread tokio flavor.
- [x] Existing 4 \`pairing_enforcement.rs\` tests unchanged (they pre-populate the DB before app startup).
- [x] \`cargo fmt --all --check\` clean.
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean.

## Spec compatibility

No spec changes.

## Known limits

- The new config field (\`watch_debounce_ms\`) gets a sensible default; existing TOML files continue to work unchanged.
- On Unix, SIGHUP is still wired up as a secondary trigger. This is deliberate — the existing \`pairing_enforcement.rs\` tests exercise it, and operators with established SIGHUP-based tooling (systemd \`ExecReload=\`) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)