### PR TITLE
docs(site): install, quickstart, troubleshoot operator guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added (PR #18, site operator guides)
+
+- New **Guides** section under `site/src/content/docs/guides/` with three pages:
+  - **`install.md`** — Rust 1.90 prerequisites, `cargo build --release` commands for the daemon + `--features cli` client crate, binary destinations, install hints (`~/.local/bin`), per-platform notes (macOS / Linux / Windows), and a pointer at Phase 3+ distributable-binary work in `ROADMAP.md`.
+  - **`quickstart.md`** — six-step walkthrough: upstream HTTP service on the host (`python3 -m http.server`), minimal `~/.config/openhost/daemon.toml` (identity, pkarr, dtls, forward sections), `openhostd run` + `openhostd identity show`, `openhost-dial oh://<pubkey>/` from the client, switching to `enforce_allowlist = true` + `openhostd pair add`, and `openhost-resolve --json` as a diagnostic. Includes an inline caveat on the residual BEP44 answer-size gap (tracked in `ROADMAP.md` post-Phase-2).
+  - **`troubleshoot.md`** — failure-mode playbook structured by symptom: DHT/relay miss, relay 5xx, `PollAnswerTimeout` (three common causes including the residual size gap and pair-watcher unreliability on network filesystems), DTLS handshake failure, and pair-DB changes not propagating. Each section carries 2–4 verification steps with concrete commands.
+- Starlight sidebar now carries a **Guides** section between **Get started** and **Specification**. `site/astro.config.mjs` extended with three explicit slugs so ordering is deterministic.
+
+### Verification (PR #18)
+
+- `cd site && pnpm install && pnpm build` — 10 pages generated (was 7), including the three new `/guides/*/index.html` routes.
+- No code changes; `cargo check --workspace` unaffected.
+
 ### Added (PR #17, pair-DB file watcher)
 
 - **Automatic pair-DB reload on every platform.** New `openhost_daemon::pair_watcher` module wraps `notify-debouncer-mini` in a tokio-friendly handle: the watcher targets the pair-DB file's parent directory in non-recursive mode, filters events by filename inside a dedicated bridge thread, and forwards debounced reload triggers into the daemon's event loop via a tokio `mpsc`. The `App::run` event loop grows a third `tokio::select!` arm parallel to `shutdown_signal` and `reload_signal`; the SIGHUP path is retained as a secondary trigger on Unix so the existing SIGHUP integration test (`pairing_enforcement.rs`) continues to exercise the same reload code.

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -30,6 +30,14 @@ export default defineConfig({
           ],
         },
         {
+          label: "Guides",
+          items: [
+            { slug: "guides/install" },
+            { slug: "guides/quickstart" },
+            { slug: "guides/troubleshoot" },
+          ],
+        },
+        {
           label: "Specification",
           autogenerate: { directory: "spec" },
         },

--- a/site/src/content/docs/guides/install.md
+++ b/site/src/content/docs/guides/install.md
@@ -1,0 +1,70 @@
+---
+title: Install openhost
+description: Build the daemon and client binaries from source; distributable packages are on the roadmap.
+sidebar:
+  order: 1
+---
+
+openhost is pre-release software and does not yet ship distributable binaries. For `v0.1.0` you build from source; the Rust toolchain handles the rest.
+
+## Prerequisites
+
+- **Rust 1.90** (stable). The repository pins this version via `rust-toolchain.toml`, so `rustup` fetches it automatically the first time you build.
+- **pnpm** (only if you also want to work on this documentation site).
+- **macOS, Linux, or Windows**. The daemon has been exercised on all three during v0.1 development; binary-release artifacts for each land in a future release.
+
+Install `rustup` from [rustup.rs](https://rustup.rs/) if you don't have it; no other Rust setup is required.
+
+## Clone and build
+
+```bash
+git clone https://github.com/kaicoder03/openhost.git
+cd openhost
+
+# Daemon + (optional) debug CLI that reads pkarr records.
+cargo build --release -p openhost-daemon
+
+# Client crate, including the openhost-dial + openhost-resolve binaries
+# that sit behind the `cli` feature.
+cargo build --release --features cli -p openhost-client
+```
+
+The first build fetches the pinned toolchain and every dependency, and will take 3–8 minutes on a warm machine. Subsequent builds are incremental.
+
+### Where the binaries land
+
+```
+target/release/openhostd        # host daemon
+target/release/openhost-dial    # client CLI — dial a host, get an HTTP response
+target/release/openhost-resolve # debug CLI — inspect a host's published pkarr record
+```
+
+Copy them into a directory on your `PATH`; `~/.local/bin` or `/usr/local/bin` are common choices.
+
+```bash
+install -m 0755 target/release/openhostd        ~/.local/bin/
+install -m 0755 target/release/openhost-dial    ~/.local/bin/
+install -m 0755 target/release/openhost-resolve ~/.local/bin/
+```
+
+## Verify
+
+```bash
+openhostd --version
+openhost-dial --version
+openhost-resolve --version
+```
+
+All three should print `0.1.0`.
+
+## Platform notes
+
+- **macOS.** The build uses a forked [`webrtc`](https://github.com/kaicoder03/webrtc) crate pinned via the workspace's `[patch.crates-io]`. Apple's toolchain occasionally lags on `rustls`/`ring` ABI compatibility; if a build fails, a `rustup toolchain update stable` is usually enough.
+- **Linux.** No distro-specific packages required beyond a working C toolchain for `ring`'s assembly fast paths (`build-essential` on Debian/Ubuntu, `base-devel` on Arch).
+- **Windows.** Build works under both MSVC and GNU toolchains; MSVC gets better download sizes. The pair-DB file watcher uses ReadDirectoryChangesW under the hood; no extra configuration needed.
+
+## Coming later
+
+Distributable binaries, a Homebrew tap, a systemd unit, and a launchd plist are tracked in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md) under Phase 3+. Until those land, "install from source" is the supported path.
+
+With the binaries in place, head to [Quickstart](/openhost/guides/quickstart/) to bring up a reachable service.

--- a/site/src/content/docs/guides/quickstart.md
+++ b/site/src/content/docs/guides/quickstart.md
@@ -33,7 +33,7 @@ Create `~/.config/openhost/daemon.toml` on the host machine:
 
 ```toml
 [identity]
-store = { type = "fs", path = "~/.config/openhost/identity.key" }
+store = { kind = "fs", path = "~/.config/openhost/identity.key" }
 
 [pkarr]
 # Relays default to the bundled public list; leaving this empty uses them.
@@ -108,20 +108,27 @@ That's a real HTTP request, traversing the client's NAT, hole-punched through We
 
 ## 5. Pair the client (switch to enforced mode)
 
-Ephemeral keys are fine for the smoke test; for actual use the daemon should only accept your client's identity. On the client:
+Ephemeral keys are fine for the smoke test; for actual use the daemon should only accept your client's identity. `openhost-dial` accepts a 32-byte raw Ed25519 seed via `--identity`, in the same on-disk format the daemon's filesystem identity store uses.
+
+On the **client** machine:
 
 ```bash
-# Persist the client's identity so future dials use the same pubkey.
-dd if=/dev/urandom of=~/.config/openhost/client.key bs=32 count=1
+# Persist a client-side identity seed.
+install -d -m 0700 ~/.config/openhost
+dd if=/dev/urandom of=~/.config/openhost/client.key bs=32 count=1 2>/dev/null
 chmod 0600 ~/.config/openhost/client.key
 
-# Print the pubkey that matches that seed.
-openhost-dial --help >/dev/null  # any command with --identity picks it up
+# Dial once with --identity so the log line prints the matching pubkey.
+# The first line openhost-dial writes to stderr is:
+#   openhost-dial: client_pk=<zbase32-pubkey> dialing GET
+openhost-dial --identity ~/.config/openhost/client.key oh://<daemon-pubkey>/ 2>&1 | head -1
 ```
 
-There is no standalone keygen CLI in v0.1; the ephemeral-keypair path is usable today, and pairing against a persistent key will be simpler once the `openhost-keygen` helper lands (tracked in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md)). For now, using the `--identity` flag with a file you created with `dd` is the supported approach.
+Copy the `<zbase32-pubkey>` from that log line. That's your stable client identity; every `--identity` dial with the same seed file yields the same pubkey.
 
-Grab the matching pubkey (a future tool will print it; until then, the easiest path is to pipe it through any client tool that logs `client_pk=`). Add it to the host:
+There is no standalone keygen CLI at `v0.1.0` — deriving the pubkey by dialing once (even if the dial itself fails because the client isn't paired yet) is the supported workflow. A dedicated helper may be added in a future release.
+
+On the **host** machine:
 
 ```bash
 openhostd pair add <client-pubkey-zbase32>
@@ -137,7 +144,7 @@ enforce_allowlist = true                  # was: false
 watched_clients = ["<client-pubkey-zbase32>"]
 ```
 
-Restart the daemon. Now only paired clients succeed.
+Restart the daemon so the new `watched_clients` takes effect (the file-watcher reloads pair entries, not offer-poll config). From now on, only paired clients succeed.
 
 ## 6. Verify the record on its own
 

--- a/site/src/content/docs/guides/quickstart.md
+++ b/site/src/content/docs/guides/quickstart.md
@@ -1,0 +1,154 @@
+---
+title: Quickstart
+description: Bring up an openhost daemon and dial it from a second machine in under five minutes.
+sidebar:
+  order: 2
+---
+
+This walkthrough takes you from built binaries to a live end-to-end HTTP request over openhost. You'll need [two machines](#prerequisites) and about five minutes.
+
+## Prerequisites
+
+- The three binaries from [Install](/openhost/guides/install/) — `openhostd`, `openhost-dial`, `openhost-resolve` — on your `PATH`.
+- A **host machine** (the computer that runs the service you want to reach) with an HTTP service listening on `127.0.0.1`. Any will do; for this walkthrough we'll use `python3 -m http.server 8000` in an empty directory.
+- A **client machine** (a different computer, ideally on a different network) with at least `openhost-dial` installed.
+
+Both machines need outbound internet; inbound port forwarding is **not** required.
+
+## 1. Start an upstream service on the host
+
+In one terminal on the host machine:
+
+```bash
+mkdir /tmp/openhost-demo && cd /tmp/openhost-demo
+echo "hello from openhost" > index.html
+python3 -m http.server 8000
+```
+
+This exposes a trivial HTTP service on `http://127.0.0.1:8000/`.
+
+## 2. Configure the daemon
+
+Create `~/.config/openhost/daemon.toml` on the host machine:
+
+```toml
+[identity]
+store = { type = "fs", path = "~/.config/openhost/identity.key" }
+
+[pkarr]
+# Relays default to the bundled public list; leaving this empty uses them.
+relays = []
+republish_secs = 1800
+
+[pkarr.offer_poll]
+# Start permissive for the smoke test. Flip this to `true` after step 5
+# and pair your client explicitly.
+enforce_allowlist = false
+# Poll known client zones once per second for offer records.
+poll_secs = 1
+# Add your client's pubkey here after step 3 so the daemon knows
+# whose zone to watch. Until then the list is empty.
+watched_clients = []
+
+[dtls]
+cert_path = "~/.config/openhost/dtls.pem"
+
+[forward]
+# Point this at the upstream service you started in step 1.
+target = "http://127.0.0.1:8000"
+```
+
+The daemon expands `~` automatically; the parent directory is created on first run.
+
+## 3. Launch the daemon
+
+```bash
+openhostd run
+```
+
+On first boot the daemon generates a fresh Ed25519 identity, a self-signed DTLS certificate, and publishes a signed record to the public Pkarr relays. Watch the log for:
+
+```
+INFO openhost_daemon::app: openhostd: DTLS certificate generated
+INFO openhost_pkarr::publisher: openhost-pkarr: initial publish succeeded attempt=1
+INFO openhost_daemon::app: openhostd: up pubkey=… dtls_fp=…
+```
+
+The `pubkey=…` value on the "up" line is what the client will dial. Copy it.
+
+In a separate terminal on the host:
+
+```bash
+openhostd identity show
+```
+
+prints the same pubkey in a predictable location. Keep that terminal open; you'll need it.
+
+## 4. Dial from the client
+
+Switch to the client machine. In a terminal:
+
+```bash
+openhost-dial oh://<paste-pubkey-here>/
+```
+
+You should see the response on stderr (status line + headers) and the body on stdout:
+
+```
+openhost-dial: client_pk=<ephemeral-client-pk> dialing GET
+HTTP/1.1 200 OK
+Content-Type: text/html
+Server: SimpleHTTP/0.6 Python/3.12.0
+
+<!DOCTYPE html>
+<html>...<li><a href="index.html">index.html</a></li>...
+```
+
+That's a real HTTP request, traversing the client's NAT, hole-punched through WebRTC, authenticated with channel binding, forwarded to the upstream service on `127.0.0.1:8000` by the daemon.
+
+## 5. Pair the client (switch to enforced mode)
+
+Ephemeral keys are fine for the smoke test; for actual use the daemon should only accept your client's identity. On the client:
+
+```bash
+# Persist the client's identity so future dials use the same pubkey.
+dd if=/dev/urandom of=~/.config/openhost/client.key bs=32 count=1
+chmod 0600 ~/.config/openhost/client.key
+
+# Print the pubkey that matches that seed.
+openhost-dial --help >/dev/null  # any command with --identity picks it up
+```
+
+There is no standalone keygen CLI in v0.1; the ephemeral-keypair path is usable today, and pairing against a persistent key will be simpler once the `openhost-keygen` helper lands (tracked in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md)). For now, using the `--identity` flag with a file you created with `dd` is the supported approach.
+
+Grab the matching pubkey (a future tool will print it; until then, the easiest path is to pipe it through any client tool that logs `client_pk=`). Add it to the host:
+
+```bash
+openhostd pair add <client-pubkey-zbase32>
+```
+
+The CLI prints a one-line confirmation noting that the running daemon will pick this up automatically — the pair-DB file watcher reloads within ~250 ms without a SIGHUP.
+
+Then tighten the daemon config:
+
+```toml
+[pkarr.offer_poll]
+enforce_allowlist = true                  # was: false
+watched_clients = ["<client-pubkey-zbase32>"]
+```
+
+Restart the daemon. Now only paired clients succeed.
+
+## 6. Verify the record on its own
+
+If a dial fails, run the debug resolver first:
+
+```bash
+openhost-resolve oh://<daemon-pubkey>/ --json
+```
+
+This fetches the host's signed pkarr record and prints the decoded contents. If this succeeds, discovery is working and the problem is downstream. See [Troubleshooting](/openhost/guides/troubleshoot/) for what to check next.
+
+## One known caveat
+
+At `v0.1.0` a full WebRTC answer SDP — after ICE trickles fully — can still exceed the BEP44 1000-byte packet budget on some configurations, even after PR #15's answer-record fragmentation. If `openhost-dial` reliably returns `PollAnswerTimeout` against a real-world daemon, that's the residual size gap; it is the next line item after Phase 2 on [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md). For `v0.1.0` testing, the server-side flow is still fully exercised and the daemon's log will confirm the answer was queued.

--- a/site/src/content/docs/guides/troubleshoot.md
+++ b/site/src/content/docs/guides/troubleshoot.md
@@ -1,0 +1,115 @@
+---
+title: Troubleshooting
+description: Common failure modes at v0.1.0 — what to check, in what order.
+sidebar:
+  order: 3
+---
+
+Order your debugging from the outside in: confirm the record is discoverable, then the answer returns, then the handshake completes, then the upstream responds. Most dial failures stop at one of the first two steps.
+
+Before you start, re-run the daemon with verbose logs so the rest of these steps have context:
+
+```bash
+RUST_LOG=openhost_daemon=debug,openhost_pkarr=debug openhostd run
+```
+
+## "The DHT / relays can't find my record"
+
+**Symptom:** `openhost-resolve oh://<pubkey>/` returns no record, or `openhost-dial` never moves past "dialing".
+
+**Check:**
+
+1. **Look for a successful initial publish** in the daemon log:
+
+   ```
+   INFO openhost-pkarr: initial publish succeeded attempt=1
+   ```
+
+   If you see `initial publish retries exhausted` instead, every configured relay is rejecting the record or unreachable. Check your outbound network.
+
+2. **Confirm the public relays accept your pubkey.** The bundled defaults are `https://pkarr.pubky.app` and `https://relay.iroh.network`. Run the resolver with a single explicit relay to isolate:
+
+   ```bash
+   openhost-resolve oh://<pubkey>/ --relay https://pkarr.pubky.app --fast
+   ```
+
+   `--fast` skips the 1.5 s grace window so you get a clean success/failure.
+
+3. **Verify clock skew.** The protocol enforces a ±2-hour freshness window on records (`spec/01-wire-format.md §3`). A machine with a badly-set clock will publish records the resolver immediately rejects. `timedatectl status` (Linux) or `sntp -sS pool.ntp.org` (macOS) both work.
+
+## "A relay is returning 5xx"
+
+**Symptom:** The publisher logs `warn!` lines with HTTP 500/502/503 from the relay host.
+
+The bundled default relays are **shared public infrastructure**, rate-limited and occasionally unavailable. Override them in `~/.config/openhost/daemon.toml`:
+
+```toml
+[pkarr]
+relays = [
+  "https://your-own-relay.example.com",
+]
+```
+
+Mainline DHT publishing still happens regardless of the relay list; relays are a convenience for faster lookup. A daemon with `relays = []` publishes only to the DHT and is still discoverable — just slower.
+
+## "The client times out with `PollAnswerTimeout`"
+
+**Symptom:** `openhost-dial` errors with `openhost-dial: failed to round-trip request: PollAnswerTimeout(30)` (or whatever `--timeout` you passed).
+
+Three common causes, in order of likelihood:
+
+1. **The client's pubkey isn't in the daemon's watched list.** The daemon only polls offer records under pubkeys listed in `pkarr.offer_poll.watched_clients`. If you're using the ephemeral keypair `openhost-dial` generates, that pubkey changes every invocation — add it explicitly or switch to a persisted identity via `--identity <path>`.
+
+2. **Allowlist enforcement is on and the client isn't paired.** Check `openhostd pair list`; the client pubkey must appear. With `enforce_allowlist = true` (the default as of `v0.1.0`), an unpaired offer is silently dropped after unseal, and no answer is ever produced.
+
+3. **The residual answer-size gap.** Real WebRTC answer SDPs — after full ICE trickle — still exceed the BEP44 1000-byte packet budget on some configurations, even with PR #15's fragmentation. The daemon produces the answer and queues it, but the publisher evicts it. You can confirm by checking the daemon log for:
+
+   ```
+   WARN openhost-pkarr: answer entry evicted — packet would exceed BEP44 1000-byte limit
+   ```
+
+   This is tracked as the next line item after Phase 2 in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md); there is no clean workaround at `v0.1.0`.
+
+## "The DTLS handshake fails"
+
+**Symptom:** Daemon log shows `webrtc error: handshake failed`, or the client gets an `openhost-dial: WebRtcSetup` error after a successful poll.
+
+**Check:**
+
+1. **Fingerprint pin agrees on both sides.** The resolved record's `dtls_fp` **must** equal the daemon's own "up" line:
+
+   ```bash
+   openhost-resolve oh://<pubkey>/ | grep dtls_fp
+   ```
+
+   Compared with the daemon's:
+
+   ```
+   INFO openhost_daemon::app: openhostd: up … dtls_fp=AB:CD:…
+   ```
+
+   A mismatch usually means the client resolved a cached or stale record — retry with `--fast` to skip the grace window and pick up the freshest.
+
+2. **Cert rotation crossed mid-dial.** `dtls.rotate_secs` defaults to 86400 (24 h). If your daemon rotated between the resolver fetching the record and the handshake starting, the fingerprint won't match. Retry.
+
+3. **UDP traffic is blocked.** WebRTC needs outbound UDP to the STUN servers and to the eventual peer. Corporate / hotel networks sometimes drop it. A quick test: `nc -u -v stun.l.google.com 19302` from both sides.
+
+## "`openhostd pair add` doesn't seem to take effect"
+
+**Symptom:** Paired a client, but the daemon still rejects their offers.
+
+The pair-DB file watcher reloads the allow list within ~250 ms; look for this on the daemon side:
+
+```
+INFO openhost_daemon::pair_watcher: openhostd: pair-DB file watcher armed
+INFO openhost_daemon::app: openhostd: pairing DB reloaded; republishing source=file-watcher
+```
+
+If you see the "armed" line but never the "reloaded" line, the watcher is running but not seeing file events. Two common reasons:
+
+- **Network filesystem.** inotify (Linux) and FSEvents (macOS) do not fire reliably on NFS, SMB, or FUSE mounts. If `~/.config/openhost/allow.toml` is on a remote filesystem, move the pair DB to a local path via `pairing.db_path` in your config, or fall back to SIGHUP on Unix (`kill -HUP $(pgrep openhostd)`) / a restart on Windows.
+- **Spawn failure.** If the watcher never armed, you'll see a `warn!` at daemon startup: `pair-DB file watcher could not be started`. Check the path exists and the parent directory is writable.
+
+## Still stuck
+
+Capture the `RUST_LOG=openhost_daemon=debug,openhost_pkarr=debug` output from the daemon plus the exact `openhost-dial` invocation and open an issue on [GitHub](https://github.com/kaicoder03/openhost/issues). Bug reports that include the `openhost-resolve --json` output for your host are dramatically easier to act on.


### PR DESCRIPTION
## Summary

Phase 2 of the post-v0.1 roadmap. Adds three operator-facing guides to the Starlight docs site so self-hosters can go from "heard about this" to "my home service is reachable from my phone" with concrete commands.

## What this adds

- **`guides/install.md`** — Rust 1.90 prerequisites, \`cargo build --release\` commands for the daemon + \`--features cli\` client crate, binary destinations, \`install -m 0755\` snippets, per-platform notes (macOS toolchain quirks, Linux \`build-essential\`, Windows ReadDirectoryChangesW), and a pointer at Phase 3+ distributable binaries in ROADMAP.
- **`guides/quickstart.md`** — six-step walkthrough: upstream \`python3 -m http.server\` on the host, a minimal \`~/.config/openhost/daemon.toml\`, \`openhostd run\` + \`identity show\`, dialing with \`openhost-dial oh://<pubkey>/\`, tightening with \`enforce_allowlist = true\` + \`openhostd pair add\`, \`openhost-resolve --json\` as a diagnostic. Inline caveat on the residual BEP44 answer-size gap.
- **`guides/troubleshoot.md`** — symptom-structured playbook: DHT/relay miss, relay 5xx, \`PollAnswerTimeout\` (three causes: wrong watched_clients, allowlist blocking, residual size gap), DTLS handshake failure (fingerprint cross-check, cert rotation, UDP blocking), pair-DB changes not propagating (file-watcher armed vs not, NFS caveat).
- **Sidebar:** new "Guides" section between "Get started" and "Specification" in \`site/astro.config.mjs\` with explicit slugs so ordering is deterministic.

## Test plan

- [x] \`cd site && pnpm install && pnpm build\` — 10 pages generated (was 7), including the three new \`/guides/*/index.html\` routes.
- [x] Sidebar renders the new "Guides" section in order: install → quickstart → troubleshoot.
- [x] No code changes; \`cargo check --workspace\` unaffected.
- [x] Every binary / flag / config field referenced in the guides exists post-PR-16 / PR-17 (no link rot).

## Spec compatibility

No spec changes.

## Out of scope (next PRs in Phase 2)

- PR #19 — repo \`README.md\` refresh + worked \`examples/\` for Jellyfin, Home Assistant, a static site.
- PR #20 — \`CONTRIBUTING.md\` + feedback-intake docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)