### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-18
+
+Phase 1 + Phase 2 of the post-v0.1 roadmap, shipped as seven focused PRs (#14 – #20). Closes all three v0.1 known limitations (answer-record overflow, missing client CLI, SIGHUP-only pairing reload) and lands the operator-facing docs needed to actually test the release: install + quickstart + troubleshoot guides on the site, worked `examples/` for static sites + Jellyfin + Home Assistant, a README Quickstart, and a root-level `CONTRIBUTING.md`. Also a breaking wire-format change in `_answer-<client-hash>` records — see `### Changed` below.
+
 ### Added (PR #20, CONTRIBUTING.md)
 
 - **New root-level `CONTRIBUTING.md`.** Covers: what contributions are welcome and what needs discussion first; dev setup (Rust 1.90 toolchain, pnpm for site); the three test commands we gate on (`cargo test --workspace --all-features`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo fmt --all --check`) plus the opt-in `--features real-network` suite; the five-step plan → implement → self-review → fix-all → merge PR cadence; how to propose a spec change (issue first for non-trivial changes, `spec/**` is markdown-linted); a concrete "filing good bug reports" checklist (`openhost-resolve --json`, debug-level daemon log, client stderr) linking the bug-report issue template; and a security-report pointer at GitHub Private Security Advisories.
@@ -233,4 +237,6 @@ The first tagged release. Daemon + client + pkarr integration + WebRTC + channel
 - `spec/01-wire-format.md §2`: the four-row textual Pkarr record table is replaced with a single opaque TXT record at `_openhost` carrying `base64url(signature || canonical_signing_bytes)`. Semantic fields are carried inside `canonical_signing_bytes` as defined by `openhost-core::pkarr_record`.
 - Workspace dependencies bumped to match the adapter: `pkarr = "5"` (was `"3"`), `mainline = "6"` (was `"4"`).
 
-[Unreleased]: https://github.com/kaicoder03/openhost/commits/main
+[Unreleased]: https://github.com/kaicoder03/openhost/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/kaicoder03/openhost/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/kaicoder03/openhost/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,4 +239,4 @@ The first tagged release. Daemon + client + pkarr integration + WebRTC + channel
 
 [Unreleased]: https://github.com/kaicoder03/openhost/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/kaicoder03/openhost/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/kaicoder03/openhost/releases/tag/v0.1.0
+[0.1.0]: https://github.com/kaicoder03/openhost/tree/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openhost-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "openhost-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chacha20poly1305",
@@ -2064,7 +2064,7 @@ dependencies = [
 
 [[package]]
 name = "openhost-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2101,14 +2101,14 @@ dependencies = [
 
 [[package]]
 name = "openhost-ffi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "openhost-client",
 ]
 
 [[package]]
 name = "openhost-pkarr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
## Summary

Tags v0.2.0. Seven PRs landed since \`v0.1.0\` (#14–#20) — Phase 0 + Phase 1 + Phase 2 of the post-v0.1 roadmap. Closes all three v0.1 known limitations and ships the operator-facing docs needed to test the release.

## What's in 0.2.0

- **PR #14** — ROADMAP.md + README status refresh.
- **PR #15** — fragmented \`_answer-<client-hash>-<idx>\` TXT records. **Wire-format break vs v0.1**; lockstep upgrade.
- **PR #16** — \`openhost-dial\` CLI + \`openhost_client::cli\` module.
- **PR #17** — pair-DB file-watcher (no more SIGHUP requirement).
- **PR #18** — install / quickstart / troubleshoot site guides.
- **PR #19** — README Quickstart + \`examples/\` walkthroughs.
- **PR #20** — CONTRIBUTING.md.

## What this PR changes

- \`Cargo.toml:12\` — \`version = "0.1.0"\` → \`"0.2.0"\`. Every crate inherits via \`version.workspace = true\`.
- \`Cargo.lock\` regenerated.
- \`CHANGELOG.md\` — \`[Unreleased]\` accumulator moved under \`[0.2.0] - 2026-04-18\` with a one-paragraph summary header. Fresh empty \`[Unreleased]\` on top. Link references switch from \`commits/main\` to \`compare/v*...v*\` URLs.

## Residual limitation (carries over from v0.1)

Real webrtc-rs answer SDPs still exceed the BEP44 packet budget even with PR #15's fragmentation. Documented inline in the site quickstart + troubleshoot guides; fix is the next Phase 3 PR.

## Test plan

- [x] \`cargo check --workspace\` clean; \`Cargo.lock\` regenerates every crate at 0.2.0.
- [x] \`openhostd --version\` / \`openhost-dial --version\` both print 0.2.0.
- [x] \`cargo test --workspace --all-features --no-fail-fast\` — 282 tests pass, 0 failures (identical to pre-bump).
- [x] CHANGELOG compare URLs render correctly when PR is visible on GitHub.

## Post-merge

```bash
git tag -a v0.2.0 -m "v0.2.0"
git push origin v0.2.0
gh release create v0.2.0 --title "v0.2.0" --notes-file <extract from CHANGELOG>
```

## Spec compatibility

No spec changes in this PR. (The wire-format break is from PR #15, already documented.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)