### PR TITLE
feat(core): shrink main _openhost record to v2 schema (drop allow + ice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Changed (PR #22, shrink main `_openhost` record)
+
+- **Wire-format break**: `PROTOCOL_VERSION` bumped `1` → `2`. v2 records drop the `allow` and `ice` fields from `OpenhostRecord::canonical_signing_bytes`. v1 and v2 records are mutually unreadable; the `version` byte is the discriminator (decoders **MUST** reject a mismatched version).
+- `IceBlob` struct deleted entirely. The daemon had no writer for it in production; the exploration confirmed it was always `Vec::new()`. Per-client ICE ciphertext will live in separate TXT records when that feature lands (see updated `spec/01-wire-format.md §2`).
+- The host's allowlist stays in `SharedState::allow` (consulted by `is_client_allowed` on every inbound offer) but is **no longer published**. Operators that scraped the published `allow` list for diagnostic purposes should instead inspect the daemon's pairing TOML directly (`~/.config/openhost/allow.toml` by default).
+- `openhost-resolve --json` schema drops the `allow_hex` and `ice` keys. Any script that consumed them needs updating; the remaining keys (`version`, `ts`, `dtls_fp_hex`, `roles`, `salt_hex`, `disc`, `signature_hex`) are unchanged.
+- Reference test vectors regenerated: `spec/test-vectors/pkarr_record.json` carries a new canonical length (118 bytes, was 230) + new signature; `spec/test-vectors/pkarr_packet.json` carries a new BEP44 outer signature + packet bytes (packet shrank from 584 to 434 bytes on the wire — a 26% reduction before fragment fanout).
+
+### Added (PR #22)
+
+- New `pkarr_record::tests::v2_main_record_base64_fits_under_ceiling` pins the base64url length of a realistic v2 main record below 260 chars. The v2 shape measures ~243 chars; any future field addition that quietly regrows the record can't silently recreate the pre-PR-22 BEP44 overflow.
+- `spec/01-wire-format.md §2` rewritten: v2 canonical bytes listed, v1 migration path described, allowlist-is-private-state constraint added, ICE-ciphertext-as-separate-records planned path documented.
+
+### Known limitations (carries into 0.3)
+
+- **Residual BEP44 gap on real webrtc-rs answers remains open.** PR #22 freed ~112 bytes from the main record, but the `daemon_produces_sealed_answer_for_dialer_offer` end-to-end test still asserts `PollAnswerTimeout` because real webrtc-rs answer SDPs (~450 bytes sealed → 3 fragments at 180 bytes each) still exceed the residual BEP44 budget after fragmentation overhead. Further fixes — likely either larger `MAX_FRAGMENT_PAYLOAD_BYTES` with DNS multi-string handling, or shrinking the answer SDP itself — are separate follow-ups.
+
 ## [0.2.0] - 2026-04-18
 
 Phase 1 + Phase 2 of the post-v0.1 roadmap, shipped as seven focused PRs (#14 – #20). Closes all three v0.1 known limitations (answer-record overflow, missing client CLI, SIGHUP-only pairing reload) and lands the operator-facing docs needed to actually test the release: install + quickstart + troubleshoot guides on the site, worked `examples/` for static sites + Jellyfin + Home Assistant, a README Quickstart, and a root-level `CONTRIBUTING.md`. Also a breaking wire-format change in `_answer-<client-hash>` records — see `### Changed` below.

--- a/crates/openhost-client/src/bin/openhost-resolve.rs
+++ b/crates/openhost-client/src/bin/openhost-resolve.rs
@@ -143,18 +143,6 @@ fn print_human(oh_url: &str, signed: &SignedRecord) {
     println!("dtls_fp:   {}", hex::encode(record.dtls_fp));
     println!("roles:     {}", record.roles);
     println!("salt:      {}", hex::encode(record.salt));
-    println!("allow:     {} entries", record.allow.len());
-    for (i, entry) in record.allow.iter().enumerate() {
-        println!("  [{i}] {}", hex::encode(entry));
-    }
-    println!("ice:       {} blob(s)", record.ice.len());
-    for (i, blob) in record.ice.iter().enumerate() {
-        println!(
-            "  [{i}] client_hash={} ciphertext={} bytes",
-            hex::encode(&blob.client_hash),
-            blob.ciphertext.len()
-        );
-    }
     println!(
         "disc:      {}",
         if record.disc.is_empty() {
@@ -171,7 +159,8 @@ fn print_human(oh_url: &str, signed: &SignedRecord) {
 
 /// Serialize a [`SignedRecord`] into the JSON shape `--json` emits.
 /// Extracted so the schema can be unit-tested without spawning a
-/// subprocess.
+/// subprocess. v2 records dropped `allow_hex` and `ice` keys (PR #22);
+/// scripts that consumed them need updating.
 fn record_to_json(signed: &SignedRecord) -> JsonValue {
     let r = &signed.record;
     json!({
@@ -180,12 +169,6 @@ fn record_to_json(signed: &SignedRecord) -> JsonValue {
         "dtls_fp_hex": hex::encode(r.dtls_fp),
         "roles": r.roles,
         "salt_hex": hex::encode(r.salt),
-        "allow_hex": r.allow.iter().map(hex::encode).collect::<Vec<_>>(),
-        "ice": r.ice.iter().map(|b| json!({
-            "client_hash_hex": hex::encode(&b.client_hash),
-            "ciphertext_len": b.ciphertext.len(),
-            "ciphertext_hex": hex::encode(&b.ciphertext),
-        })).collect::<Vec<_>>(),
         "disc": r.disc,
         "signature_hex": hex::encode(signed.signature.to_bytes()),
     })
@@ -194,10 +177,9 @@ fn record_to_json(signed: &SignedRecord) -> JsonValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use openhost_core::crypto::allowlist_hash;
     use openhost_core::identity::SigningKey;
     use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+        OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
     };
 
     const RFC_SEED: [u8; 32] = [
@@ -208,19 +190,12 @@ mod tests {
 
     fn sample_signed() -> SignedRecord {
         let sk = SigningKey::from_bytes(&RFC_SEED);
-        let salt = [0x11u8; SALT_LEN];
-        let hash = allowlist_hash(&salt, &[0xAA; 32]);
         let record = OpenhostRecord {
             version: PROTOCOL_VERSION,
             ts: 1_700_000_000,
             dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
             roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
+            salt: [0x11u8; SALT_LEN],
             disc: "dht=1".to_string(),
         };
         SignedRecord::sign(record, &sk).expect("sign")
@@ -230,8 +205,9 @@ mod tests {
     fn json_output_has_stable_keys_and_shape() {
         // Every field name + type below is part of the CLI's public
         // contract — piping `--json` into downstream scripts breaks if
-        // these change silently. Treat a failing assertion as "the CLI
-        // is about to ship a breaking change; bump docs / callers".
+        // these change silently. The v2 shape (PR #22) dropped the
+        // `allow_hex` and `ice` keys; any script that consumed them
+        // needs updating.
         let value = record_to_json(&sample_signed());
         let obj = value.as_object().expect("top-level is an object");
 
@@ -241,32 +217,26 @@ mod tests {
             "dtls_fp_hex",
             "roles",
             "salt_hex",
-            "allow_hex",
-            "ice",
             "disc",
             "signature_hex",
         ] {
             assert!(obj.contains_key(*key), "missing top-level key {key:?}");
         }
 
-        assert_eq!(obj["version"], 1);
+        assert!(
+            !obj.contains_key("allow_hex"),
+            "v2 CLI output must not carry allow_hex",
+        );
+        assert!(
+            !obj.contains_key("ice"),
+            "v2 CLI output must not carry an `ice` array",
+        );
+
+        assert_eq!(obj["version"], 2);
         assert_eq!(obj["ts"], 1_700_000_000);
         assert_eq!(obj["roles"], "server");
         assert_eq!(obj["disc"], "dht=1");
         assert_eq!(obj["dtls_fp_hex"].as_str().unwrap().len(), 64); // 32 bytes hex
-
-        let allow = obj["allow_hex"].as_array().expect("allow is an array");
-        assert_eq!(allow.len(), 1);
-        assert_eq!(allow[0].as_str().unwrap().len(), 32); // 16 bytes hex
-
-        let ice = obj["ice"].as_array().expect("ice is an array");
-        assert_eq!(ice.len(), 1);
-        let blob = &ice[0];
-        for k in &["client_hash_hex", "ciphertext_len", "ciphertext_hex"] {
-            assert!(blob.get(*k).is_some(), "ice blob missing {k:?}");
-        }
-        assert_eq!(blob["ciphertext_len"], 72);
-
         assert_eq!(obj["signature_hex"].as_str().unwrap().len(), 128); // 64 bytes hex
     }
 

--- a/crates/openhost-client/src/client.rs
+++ b/crates/openhost-client/src/client.rs
@@ -153,10 +153,9 @@ impl Client {
 mod tests {
     use super::*;
     use async_trait::async_trait;
-    use openhost_core::crypto::allowlist_hash;
     use openhost_core::identity::SigningKey;
     use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+        OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
     };
     use openhost_pkarr::encode;
     use pkarr::SignedPacket;
@@ -172,19 +171,12 @@ mod tests {
     const FIXED_TS: u64 = 1_700_000_000;
 
     fn sample_record(ts: u64) -> OpenhostRecord {
-        let salt = [0x11u8; SALT_LEN];
-        let hash = allowlist_hash(&salt, &[0xAA; 32]);
         OpenhostRecord {
             version: PROTOCOL_VERSION,
             ts,
             dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
             roles: "server".to_string(),
-            salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
+            salt: [0x11u8; SALT_LEN],
             disc: String::new(),
         }
     }

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -319,7 +319,7 @@ async fn dial_times_out_when_daemon_not_running() {
 
 async fn publish_fake_host_record(net: &MemoryPkarrNetwork, daemon_sk: &SigningKey) {
     use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+        OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
     };
     use openhost_pkarr::codec::encode;
 
@@ -332,11 +332,6 @@ async fn publish_fake_host_record(net: &MemoryPkarrNetwork, daemon_sk: &SigningK
         dtls_fp: [0x42; DTLS_FINGERPRINT_LEN],
         roles: "server".to_string(),
         salt: [0x11; SALT_LEN],
-        allow: vec![],
-        ice: vec![IceBlob {
-            client_hash: vec![0x22; 16],
-            ciphertext: vec![0x33; 48],
-        }],
         disc: String::new(),
     };
     let signed = SignedRecord::sign(record, daemon_sk).unwrap();

--- a/crates/openhost-client/tests/resolve.rs
+++ b/crates/openhost-client/tests/resolve.rs
@@ -97,14 +97,13 @@ async fn client_decodes_fixture_bytes_directly() {
         .expect("fixture bytes resolve through Client");
 
     // Spot-check fields from the fixture so a regression in the decoder
-    // or the validator is immediately diagnosable.
+    // or the validator is immediately diagnosable. The v2 record dropped
+    // `allow` and `ice` from the canonical bytes (PR #22) — those fields
+    // are no longer on the wire.
     assert_eq!(record.record.ts, fixture_ts);
-    assert_eq!(record.record.version, 1);
+    assert_eq!(record.record.version, 2);
     assert_eq!(record.record.roles, "server");
-    // The fixture carries one allow entry and one ICE blob — see
-    // spec/test-vectors/pkarr_record.json.
-    assert_eq!(record.record.allow.len(), 1);
-    assert_eq!(record.record.ice.len(), 1);
+    assert_eq!(record.record.disc, "dht=1; relay=pkarr.example");
 }
 
 /// Round-trip the fixture's record through sign → encode → Client against

--- a/crates/openhost-core/src/pkarr_record/mod.rs
+++ b/crates/openhost-core/src/pkarr_record/mod.rs
@@ -15,8 +15,10 @@ use crate::{Error, Result};
 use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
 
-/// openhost protocol version carried in the record. Incremented on breaking changes.
-pub const PROTOCOL_VERSION: u8 = 1;
+/// openhost protocol version carried in the record. Incremented on breaking
+/// changes. v2 (PR #22) drops the `allow` and `ice` fields from the canonical
+/// bytes; v2 records are a hard break from v1.
+pub const PROTOCOL_VERSION: u8 = 2;
 
 /// Maximum permitted age of a signed record in seconds. Verifiers reject records
 /// whose internal timestamp is further from "now" than this window.
@@ -25,11 +27,15 @@ pub const MAX_RECORD_AGE_SECS: u64 = 7200;
 /// Length of the per-host salt used to key the allowlist HMAC.
 pub const SALT_LEN: usize = 32;
 
-/// Length of one entry in the `allow` list (truncated HMAC-SHA256).
-pub const ALLOW_ENTRY_LEN: usize = 16;
-
-/// Length of one `clienthash` that prefixes a per-client ICE blob.
+/// Length of a client-identifying truncated HMAC-SHA256 used by the offer
+/// poller (per-client record naming) and the in-process allowlist check.
 pub const CLIENT_HASH_LEN: usize = 16;
+
+/// Legacy alias — the v1 record carried a published `allow` field whose
+/// entries were this length. v2 drops the field from the wire; the
+/// constant is retained because other crates still use it for internal
+/// SharedState hashes.
+pub const ALLOW_ENTRY_LEN: usize = CLIENT_HASH_LEN;
 
 /// The sha256-fingerprint of a DTLS certificate, 32 bytes.
 pub const DTLS_FINGERPRINT_LEN: usize = 32;
@@ -37,22 +43,16 @@ pub const DTLS_FINGERPRINT_LEN: usize = 32;
 /// Maximum length of the `disc` substrate-hints string (informational).
 pub const MAX_DISC_LEN: usize = 256;
 
-/// Per-client ICE candidate blob: a client-hash selector and the sealed-box
-/// ciphertext addressed to that client's X25519 public key.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IceBlob {
-    /// 16-byte truncated HMAC-SHA256 of the client public key keyed by the host's salt.
-    #[serde(with = "serde_bytes")]
-    pub client_hash: Vec<u8>,
-    /// Sealed-box ciphertext — the ICE candidates, encrypted to the client's X25519 key.
-    #[serde(with = "serde_bytes")]
-    pub ciphertext: Vec<u8>,
-}
-
-/// The semantic openhost record published by a host.
+/// The semantic openhost record published by a host (v2 schema).
+///
+/// PR #22 removed the v1 `allow` and `ice` fields. The host's allow list
+/// is now strictly private state: the daemon checks it internally on the
+/// offer-poll path and does not publish it. ICE blobs were unused in
+/// production; the field is gone along with the `IceBlob` type that
+/// carried them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenhostRecord {
-    /// Protocol version. Must equal [`PROTOCOL_VERSION`] for a v1 record.
+    /// Protocol version. Must equal [`PROTOCOL_VERSION`] for a v2 record.
     pub version: u8,
     /// Unix timestamp (seconds) at which the host published this record.
     pub ts: u64,
@@ -62,10 +62,6 @@ pub struct OpenhostRecord {
     pub roles: String,
     /// Per-host random salt used to key the allowlist HMAC.
     pub salt: [u8; SALT_LEN],
-    /// Paired clients, identified by truncated HMAC of their public keys.
-    pub allow: Vec<[u8; ALLOW_ENTRY_LEN]>,
-    /// ICE candidate blobs, one per paired client.
-    pub ice: Vec<IceBlob>,
     /// Substrate discovery hints (informational). UTF-8, up to [`MAX_DISC_LEN`] bytes.
     pub disc: String,
 }
@@ -96,46 +92,27 @@ impl OpenhostRecord {
         if self.disc.len() > MAX_DISC_LEN {
             return Err(Error::InvalidRecord("disc hints exceed maximum length"));
         }
-        if self.allow.len() > u16::MAX as usize {
-            return Err(Error::InvalidRecord("allow list exceeds 65535 entries"));
-        }
-        if self.ice.len() > u16::MAX as usize {
-            return Err(Error::InvalidRecord("ice list exceeds 65535 entries"));
-        }
-        for blob in &self.ice {
-            if blob.client_hash.len() != CLIENT_HASH_LEN {
-                return Err(Error::InvalidRecord("ice.client_hash is not 16 bytes"));
-            }
-            if blob.ciphertext.is_empty() {
-                return Err(Error::InvalidRecord("ice.ciphertext is empty"));
-            }
-            if blob.ciphertext.len() > 0xFFFF_FFFF {
-                return Err(Error::InvalidRecord("ice.ciphertext exceeds 2^32 bytes"));
-            }
-        }
         Ok(())
     }
 
     /// Produce the canonical byte representation used for signing and verification.
     ///
-    /// The encoding is explicit and stable:
+    /// The v2 encoding is explicit and stable:
     ///
     /// ```text
-    /// canonical = 0x01 (version tag; bumped on protocol change)
-    ///          || "openhost1"              (9 ASCII bytes, domain separator)
-    ///          || version (1 byte, equals PROTOCOL_VERSION)
+    /// canonical = 0x01                        (legacy encoding tag; unchanged)
+    ///          || "openhost1"                 (9 ASCII bytes, legacy domain separator)
+    ///          || version (1 byte, equals PROTOCOL_VERSION = 2)
     ///          || ts (8 bytes, u64 big-endian)
     ///          || dtls_fp (32 bytes)
     ///          || roles_len (1 byte)    || roles_bytes
     ///          || salt (32 bytes)
-    ///          || allow_count (2 bytes BE) || 16-byte entries
-    ///          || ice_count (2 bytes BE)
-    ///          || for each ice blob:
-    ///              || client_hash (16 bytes)
-    ///              || ciphertext_len (4 bytes BE)
-    ///              || ciphertext
     ///          || disc_len (2 bytes BE) || disc_bytes
     /// ```
+    ///
+    /// The v1 schema inserted `allow_count || allow_entries || ice_count || ice_blobs`
+    /// between `salt` and `disc`. v2 drops those fields entirely; the `version`
+    /// byte is the sole discriminator for readers.
     ///
     /// Returns `Err` only when the record fails `validate(now_ts=self.ts)` — i.e.
     /// when the record is ill-formed. Otherwise the returned buffer is deterministic.
@@ -143,7 +120,7 @@ impl OpenhostRecord {
         self.validate(self.ts)?;
 
         let mut out = Vec::new();
-        out.push(0x01); // encoding-format version tag
+        out.push(0x01); // encoding-format version tag (legacy; unchanged)
         out.extend_from_slice(b"openhost1");
         out.push(self.version);
         out.extend_from_slice(&self.ts.to_be_bytes());
@@ -154,21 +131,6 @@ impl OpenhostRecord {
         out.extend_from_slice(roles_bytes);
 
         out.extend_from_slice(&self.salt);
-
-        let allow_count = u16::try_from(self.allow.len()).expect("validated <= u16::MAX");
-        out.extend_from_slice(&allow_count.to_be_bytes());
-        for entry in &self.allow {
-            out.extend_from_slice(entry);
-        }
-
-        let ice_count = u16::try_from(self.ice.len()).expect("validated <= u16::MAX");
-        out.extend_from_slice(&ice_count.to_be_bytes());
-        for blob in &self.ice {
-            out.extend_from_slice(&blob.client_hash);
-            let ct_len = u32::try_from(blob.ciphertext.len()).expect("validated <= u32::MAX");
-            out.extend_from_slice(&ct_len.to_be_bytes());
-            out.extend_from_slice(&blob.ciphertext);
-        }
 
         let disc_bytes = self.disc.as_bytes();
         let disc_len = u16::try_from(disc_bytes.len()).expect("validated <= MAX_DISC_LEN");
@@ -223,19 +185,16 @@ mod tests {
 
     fn sample_record(ts: u64) -> OpenhostRecord {
         let salt = [0x11u8; SALT_LEN];
-        let client_pk = [0xAAu8; 32];
-        let hash = allowlist_hash(&salt, &client_pk);
+        // Exercise `allowlist_hash` via an import (the helper is no longer
+        // used inside OpenhostRecord, but downstream crates still rely on
+        // it; keep the link loud so removals elsewhere show up here).
+        let _ = allowlist_hash(&salt, &[0xAAu8; 32]);
         OpenhostRecord {
             version: PROTOCOL_VERSION,
             ts,
             dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
             roles: "server".to_string(),
             salt,
-            allow: vec![hash],
-            ice: vec![IceBlob {
-                client_hash: hash.to_vec(),
-                ciphertext: vec![0xEE; 72],
-            }],
             disc: "dht=1; relay=pkarr.example".to_string(),
         }
     }
@@ -317,13 +276,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_bad_ice_blob() {
-        let mut r = sample_record(1_700_000_000);
-        r.ice[0].client_hash = vec![1, 2, 3]; // not 16 bytes
-        assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
-    }
-
-    #[test]
     fn canonical_bytes_change_with_any_field() {
         let base = sample_record(1_700_000_000)
             .canonical_signing_bytes()
@@ -346,11 +298,36 @@ mod tests {
         assert_ne!(r.canonical_signing_bytes().unwrap(), base);
 
         let mut r = sample_record(1_700_000_000);
-        r.ice[0].ciphertext[0] ^= 0x01;
-        assert_ne!(r.canonical_signing_bytes().unwrap(), base);
-
-        let mut r = sample_record(1_700_000_000);
         r.disc.push_str(" extra");
         assert_ne!(r.canonical_signing_bytes().unwrap(), base);
+    }
+
+    /// Measure the wire size of a v2 main record after base64url wrapping
+    /// (the outer BEP44 `v` is `base64url(signature || canonical)`). With
+    /// the v1 allow+ice fields dropped, a realistic record should encode
+    /// under 220 base64 chars; this asserts a generous ceiling so a future
+    /// field addition that quietly bloats the record can't silently
+    /// recreate the pre-PR-22 BEP44 overflow regression.
+    #[test]
+    fn v2_main_record_base64_fits_under_ceiling() {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let signed = SignedRecord::sign(sample_record(1_700_000_000), &sk).unwrap();
+        let canonical = signed.record.canonical_signing_bytes().unwrap();
+        let mut blob = Vec::with_capacity(64 + canonical.len());
+        blob.extend_from_slice(&signed.signature.to_bytes());
+        blob.extend_from_slice(&canonical);
+        let b64 = URL_SAFE_NO_PAD.encode(&blob);
+        // Realistic v2 record with a non-empty `disc` measures ~243
+        // chars (v1 with 1 allow + 1 ice blob was ~392). Ceiling at
+        // 260 leaves a little slack for disc tweaks while still
+        // catching a regression that re-bloats the record.
+        assert!(
+            b64.len() < 260,
+            "v2 main record base64 is {} chars; keep under 260 so fragmented answers fit the BEP44 budget",
+            b64.len(),
+        );
     }
 }

--- a/crates/openhost-core/tests/end_to_end.rs
+++ b/crates/openhost-core/tests/end_to_end.rs
@@ -1,20 +1,23 @@
-//! End-to-end exercise of the spec §8 flow, minus the DTLS handshake itself
-//! (which happens outside openhost-core in M3). Exercises identity, crypto,
-//! pkarr_record, and wire together.
+//! End-to-end exercise of the spec §8 flow at the crypto/wire/record layer.
+//! The DTLS handshake itself happens outside openhost-core (M3+).
 //!
-//! This is a *protocol* test — it proves that the modules fit together
-//! coherently, that a client can resolve a host's record, decrypt its own ICE
-//! candidates, bind a simulated TLS session, and exchange HTTP-shaped framed
-//! traffic.
+//! This test proves that the modules fit together coherently: identity,
+//! sealed-box + signature primitives, the v2 pkarr record, channel-binding
+//! auth-bytes, and the HTTP-over-DataChannel wire framing.
+//!
+//! Notes on the v2 record schema (PR #22): the main `_openhost` record
+//! no longer carries an `allow` list or per-client `ice` blobs. Pairing
+//! enforcement is host-internal (`SharedState::is_client_allowed`); ICE
+//! blobs, when they're wired up, will travel in separate records under
+//! the same packet (analogous to how answers were fragmented in PR #15).
+//! This test consequently no longer round-trips a host-to-client ICE
+//! sealed box — a separate unit test in `crypto::tests` covers that
+//! primitive.
 
-use openhost_core::crypto::{
-    allowlist_hash, auth_bytes, public_key_to_x25519, sealed_box_open, sealed_box_seal,
-    signing_key_to_x25519,
-};
+use openhost_core::crypto::{auth_bytes, sealed_box_open, sealed_box_seal, signing_key_to_x25519};
 use openhost_core::identity::SigningKey;
 use openhost_core::pkarr_record::{
-    IceBlob, OpenhostRecord, SignedRecord, CLIENT_HASH_LEN, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION,
-    SALT_LEN,
+    OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
 use openhost_core::wire::{Frame, FrameType};
 
@@ -23,24 +26,15 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
     let mut rng = rand::rngs::OsRng;
 
     // --- Identities ---------------------------------------------------------
-    // In production, both sides generate these at first run and persist the
-    // signing keys in the OS keychain. Here we use OsRng for realism.
     let host_sk = SigningKey::generate(&mut rng);
     let host_pk = host_sk.public_key();
 
     let client_sk = SigningKey::generate(&mut rng);
     let client_pk = client_sk.public_key();
-    let client_x_sk = signing_key_to_x25519(&client_sk);
 
-    // --- Pairing (one-time) -------------------------------------------------
-    // After the out-of-band QR pairing step (M6), the host knows the client's
-    // 32-byte Ed25519 public key and adds it to its paired set.
-    let paired_clients: Vec<[u8; 32]> = vec![client_pk.to_bytes()];
-
-    // --- Host prepares its signed record ------------------------------------
+    // --- Host publishes a v2 signed record ----------------------------------
     let salt = [0x99u8; SALT_LEN];
     let dtls_fp = {
-        // Normally: SHA-256 of the daemon's actual DTLS certificate.
         let mut fp = [0u8; DTLS_FINGERPRINT_LEN];
         fp.copy_from_slice(
             &<sha2::Sha256 as sha2::Digest>::digest(b"pretend DTLS cert")[..DTLS_FINGERPRINT_LEN],
@@ -48,34 +42,13 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
         fp
     };
 
-    // Build per-client ICE blobs. The plaintext is candidate JSON; here we
-    // just use a fixed marker string.
-    let ice_plaintext = b"host:1.2.3.4:50000,relay:stun.cloudflare.com";
-    let mut ice_blobs = Vec::new();
-    let mut allow = Vec::new();
-    for client_ed_pk in &paired_clients {
-        let hash = allowlist_hash(&salt, client_ed_pk);
-        allow.push(hash);
-        // Recover the paired client's X25519 pubkey from its Ed25519 pubkey.
-        let client_ed = openhost_core::identity::PublicKey::from_bytes(client_ed_pk).unwrap();
-        let their_x_pk = public_key_to_x25519(&client_ed).unwrap();
-        let ciphertext = sealed_box_seal(&mut rng, &their_x_pk, ice_plaintext);
-        assert!(hash.len() == CLIENT_HASH_LEN);
-        ice_blobs.push(IceBlob {
-            client_hash: hash.to_vec(),
-            ciphertext,
-        });
-    }
-
-    let ts = 1_700_000_000u64; // fixed for determinism across the test
+    let ts = 1_700_000_000u64;
     let record = OpenhostRecord {
         version: PROTOCOL_VERSION,
         ts,
         dtls_fp,
         roles: "server".into(),
         salt,
-        allow,
-        ice: ice_blobs,
         disc: "dht=1".into(),
     };
     let signed = SignedRecord::sign(record, &host_sk).expect("sign");
@@ -84,55 +57,25 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
     signed
         .verify(&host_pk, ts)
         .expect("client verifies signature + freshness");
-
-    // Client finds *its* client_hash in the allow list.
-    let own_hash = allowlist_hash(&signed.record.salt, &client_pk.to_bytes());
-    assert!(
-        signed.record.allow.iter().any(|h| h[..] == own_hash[..]),
-        "client hash present in allowlist"
-    );
-
-    // Client finds its ICE blob by matching on client_hash and decrypts it.
-    let my_blob = signed
-        .record
-        .ice
-        .iter()
-        .find(|b| b.client_hash[..] == own_hash[..])
-        .expect("ice blob for this client");
-    let recovered = sealed_box_open(&client_x_sk, &my_blob.ciphertext).expect("unseal");
-    assert_eq!(recovered, ice_plaintext);
-
-    // Client sees the pinned DTLS fingerprint. In a real client it would
-    // compare this against the fingerprint negotiated during the DTLS handshake.
+    // Client sees the pinned DTLS fingerprint. A real client would compare
+    // this against the fingerprint negotiated during the DTLS handshake.
     assert_eq!(signed.record.dtls_fp, dtls_fp);
 
     // --- Simulated channel binding (spec §8.3 step 9) -----------------------
-    // In production the 32-byte exporter secret is pulled from the DTLS
-    // session via RFC 5705. We simulate it here with a fixed value — the
-    // test proves the *protocol* shape, not that the TLS exporter is wired up.
     let simulated_exporter_secret = [0x37u8; 32];
     let auth = auth_bytes(&simulated_exporter_secret).expect("auth_bytes");
 
     let host_auth_sig = host_sk.sign(&auth);
     let client_auth_sig = client_sk.sign(&auth);
 
-    // Each side verifies the counterparty's signature against the pubkey it
-    // already trusts (host: from the allowlist; client: from the Pkarr record).
     host_pk
         .verify(&auth, &host_auth_sig)
         .expect("host self-sanity");
     client_pk
         .verify(&auth, &client_auth_sig)
         .expect("client self-sanity");
-    host_pk
-        .verify(&auth, &host_auth_sig)
-        .expect("client's view of host auth");
-    client_pk
-        .verify(&auth, &client_auth_sig)
-        .expect("host's view of client auth");
 
     // --- HTTP-over-DataChannel exchange -------------------------------------
-    // Client sends a GET.
     let req_head = Frame::new(
         FrameType::RequestHead,
         b"GET /library HTTP/1.1\r\nHost: home\r\n\r\n".to_vec(),
@@ -144,13 +87,11 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
     req_head.encode(&mut wire);
     req_end.encode(&mut wire);
 
-    // Daemon decodes the stream.
     let (d1, n1) = Frame::try_decode(&wire).unwrap().unwrap();
     let (d2, _) = Frame::try_decode(&wire[n1..]).unwrap().unwrap();
     assert_eq!(d1, req_head);
     assert_eq!(d2, req_end);
 
-    // Daemon responds.
     let resp_head = Frame::new(
         FrameType::ResponseHead,
         b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n".to_vec(),
@@ -164,7 +105,6 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
     resp_body.encode(&mut wire);
     resp_end.encode(&mut wire);
 
-    // Client decodes the response.
     let (h, n1) = Frame::try_decode(&wire).unwrap().unwrap();
     let (b, n2) = Frame::try_decode(&wire[n1..]).unwrap().unwrap();
     let (e, _) = Frame::try_decode(&wire[n1 + n2..]).unwrap().unwrap();
@@ -173,38 +113,21 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
     assert_eq!(e, resp_end);
 }
 
+/// Standalone sanity-check for the sealed-box primitive we use to carry
+/// ICE candidates per-client once that layer ships. Lives here (rather
+/// than in the pkarr-record test vectors) because it doesn't depend on
+/// the wire shape — just that a ciphertext sealed to one X25519 key
+/// cannot be opened by another.
 #[test]
-fn unpaired_client_cannot_read_ice_blobs() {
+fn unpaired_client_cannot_open_ice_sealed_box() {
+    use openhost_core::crypto::public_key_to_x25519;
     let mut rng = rand::rngs::OsRng;
-    let host_sk = SigningKey::generate(&mut rng);
     let paired_sk = SigningKey::generate(&mut rng);
     let unpaired_sk = SigningKey::generate(&mut rng);
 
     let paired_x_pk = public_key_to_x25519(&paired_sk.public_key()).unwrap();
     let unpaired_x_sk = signing_key_to_x25519(&unpaired_sk);
 
-    let salt = [0xAA; SALT_LEN];
-    let hash = allowlist_hash(&salt, &paired_sk.public_key().to_bytes());
     let ciphertext = sealed_box_seal(&mut rng, &paired_x_pk, b"secret ICE candidates");
-
-    let record = OpenhostRecord {
-        version: PROTOCOL_VERSION,
-        ts: 1_700_000_000,
-        dtls_fp: [0u8; 32],
-        roles: "server".into(),
-        salt,
-        allow: vec![hash],
-        ice: vec![IceBlob {
-            client_hash: hash.to_vec(),
-            ciphertext,
-        }],
-        disc: String::new(),
-    };
-    let signed = SignedRecord::sign(record, &host_sk).unwrap();
-
-    // Signature verifies for anyone — records are public.
-    signed.verify(&host_sk.public_key(), 1_700_000_000).unwrap();
-
-    // But an unpaired client cannot open the sealed box.
-    assert!(sealed_box_open(&unpaired_x_sk, &signed.record.ice[0].ciphertext).is_err());
+    assert!(sealed_box_open(&unpaired_x_sk, &ciphertext).is_err());
 }

--- a/crates/openhost-core/tests/pkarr_record_vectors.rs
+++ b/crates/openhost-core/tests/pkarr_record_vectors.rs
@@ -1,9 +1,12 @@
 //! Consume `spec/test-vectors/pkarr_record.json` and verify canonical bytes and
 //! the signature match the implementation bit-for-bit.
+//!
+//! The v2 schema drops `allow` and `ice` from the record; this test
+//! enforces the new canonical layout.
 
 use ed25519_dalek::Signature;
 use openhost_core::identity::{PublicKey, SigningKey};
-use openhost_core::pkarr_record::{IceBlob, OpenhostRecord, SignedRecord};
+use openhost_core::pkarr_record::{OpenhostRecord, SignedRecord};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -29,25 +32,12 @@ struct RecordFields {
     dtls_fp_hex: String,
     roles: String,
     salt_hex: String,
-    allow_hex: Vec<String>,
-    ice: Vec<IceFields>,
     disc: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct IceFields {
-    client_hash_hex: String,
-    ciphertext_hex: String,
 }
 
 fn decode_hex32(s: &str) -> [u8; 32] {
     let v = hex::decode(s).expect("hex");
     v.as_slice().try_into().expect("32 bytes")
-}
-
-fn decode_hex16(s: &str) -> [u8; 16] {
-    let v = hex::decode(s).expect("hex");
-    v.as_slice().try_into().expect("16 bytes")
 }
 
 fn build_record(r: &RecordFields) -> OpenhostRecord {
@@ -57,15 +47,6 @@ fn build_record(r: &RecordFields) -> OpenhostRecord {
         dtls_fp: decode_hex32(&r.dtls_fp_hex),
         roles: r.roles.clone(),
         salt: decode_hex32(&r.salt_hex),
-        allow: r.allow_hex.iter().map(|s| decode_hex16(s)).collect(),
-        ice: r
-            .ice
-            .iter()
-            .map(|i| IceBlob {
-                client_hash: hex::decode(&i.client_hash_hex).expect("hex"),
-                ciphertext: hex::decode(&i.ciphertext_hex).expect("hex"),
-            })
-            .collect(),
         disc: r.disc.clone(),
     }
 }
@@ -94,8 +75,9 @@ fn canonical_bytes_and_signature_match() {
         assert_eq!(
             canonical.len(),
             v.canonical_len,
-            "{}: canonical_len",
+            "{}: canonical_len (got {:?})",
             v.name,
+            hex::encode(&canonical),
         );
         assert_eq!(
             hex::encode(&canonical),

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -19,7 +19,7 @@ use hkdf::Hkdf;
 use openhost_core::crypto::allowlist_hash;
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::pkarr_record::{
-    IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+    OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
 use openhost_pkarr::{
     AnswerEntry, AnswerSource, PkarrResolve, PkarrTransport, Publisher, PublisherHandle,
@@ -52,8 +52,10 @@ const ALLOW_SALT_HKDF_SALT: &[u8] = b"openhost-allow-salt-v1";
 pub struct SharedState {
     dtls_fp: RwLock<[u8; DTLS_FINGERPRINT_LEN]>,
     salt: [u8; SALT_LEN],
+    /// In-process allow list. Consulted on every inbound offer via
+    /// [`is_client_allowed`]; never published on the wire in v2+ of
+    /// the record schema. See spec `01-wire-format.md §2`.
     allow: RwLock<Vec<[u8; 16]>>,
-    ice: RwLock<Vec<IceBlob>>,
     roles: String,
     /// Per-client answer records queued for publication. Keyed by
     /// `client_hash` (HMAC of `client_pk` under the daemon's salt) so a
@@ -80,7 +82,6 @@ impl SharedState {
             dtls_fp: RwLock::new(dtls_fp),
             salt,
             allow: RwLock::new(Vec::new()),
-            ice: RwLock::new(Vec::new()),
             roles: "server".to_string(),
             answers: RwLock::new(HashMap::new()),
         }
@@ -173,13 +174,11 @@ impl SharedState {
         before != guard.len()
     }
 
-    /// Snapshot of the current ICE blob set.
-    pub fn ice(&self) -> Vec<IceBlob> {
-        self.ice.read().expect("ice lock poisoned").clone()
-    }
-
     /// Build a fresh [`OpenhostRecord`] with `ts` set to **now**. This is
-    /// what the publisher calls on every tick.
+    /// what the publisher calls on every tick. The in-process `allow`
+    /// list is deliberately NOT copied into the record — v2+ of the
+    /// schema keeps the allow list private so the main record stays
+    /// small and more answer fragments fit the BEP44 packet budget.
     pub fn snapshot_record(&self) -> OpenhostRecord {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -191,8 +190,6 @@ impl SharedState {
             dtls_fp: self.dtls_fp(),
             roles: self.roles.clone(),
             salt: self.salt,
-            allow: self.allow(),
-            ice: self.ice(),
             disc: String::new(),
         }
     }
@@ -396,8 +393,11 @@ mod tests {
         service.shutdown().await;
     }
 
+    /// Snapshot of a freshly-built `SharedState` publishes the expected
+    /// v2 record shape: right version, roles, and no `allow`/`ice` —
+    /// both dropped from the main record in PR #22.
     #[tokio::test]
-    async fn allow_and_ice_default_to_empty() {
+    async fn snapshot_record_produces_v2_shape() {
         let transport = Arc::new(FakeTransport::default());
         let sk = Arc::new(SigningKey::from_bytes(&RFC_SEED));
         let state = Arc::new(SharedState::new(&sk, [0x42; DTLS_FINGERPRINT_LEN]));
@@ -406,8 +406,6 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         let record = state.snapshot_record();
-        assert!(record.allow.is_empty());
-        assert!(record.ice.is_empty());
         assert_eq!(record.roles, "server");
         assert_eq!(record.version, PROTOCOL_VERSION);
 

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -434,21 +434,18 @@ mod tests {
         );
     }
 
+    /// Sanity-check: a v2 record with a maxed-out `disc` still encodes
+    /// successfully — the main record alone can't overflow the BEP44
+    /// packet budget. The actual overflow + eviction path now lives in
+    /// `offer::tests::encode_evicts_oldest_when_overflow` (PR #15
+    /// introduced fragment eviction; v2 records are small enough that
+    /// the main record by itself can't trip the 1000-byte cap).
     #[test]
-    fn packet_too_large_is_rejected() {
+    fn max_disc_record_still_encodes() {
         let sk = SigningKey::from_bytes(&RFC_SEED);
         let mut record = reference_record();
-        // v2 records are compact — inflate `disc` (capped at MAX_DISC_LEN
-        // = 256 but we stop at validate time, so use something below the
-        // cap; the BEP44 1000-byte packet limit kicks in first once we
-        // add a long synthetic disc string + a pile of fake answer
-        // fragments on top). Use answer fragments via encode_with_answers
-        // to provoke the limit cleanly.
         record.disc = "x".repeat(MAX_DISC_LEN);
         let signed = SignedRecord::sign(record, &sk).unwrap();
-        // The single-record encode still fits; the BEP44 limit is meant
-        // to gate encode_with_answers. Verify encode() succeeds here and
-        // the overflow path is covered by offer::tests' eviction tests.
         assert!(encode(&signed, &sk).is_ok());
     }
 }

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -25,8 +25,7 @@ use base64::Engine;
 use ed25519_dalek::Signature;
 use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN};
 use openhost_core::pkarr_record::{
-    IceBlob, OpenhostRecord, SignedRecord, ALLOW_ENTRY_LEN, CLIENT_HASH_LEN, DTLS_FINGERPRINT_LEN,
-    MAX_DISC_LEN, PROTOCOL_VERSION, SALT_LEN,
+    OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, MAX_DISC_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
 use pkarr::dns::Name;
 use pkarr::{Keypair, SignedPacket, Timestamp};
@@ -228,26 +227,6 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
     let mut salt = [0u8; SALT_LEN];
     salt.copy_from_slice(r.take(SALT_LEN)?);
 
-    let allow_count = r.u16_be()? as usize;
-    let mut allow = Vec::with_capacity(allow_count);
-    for _ in 0..allow_count {
-        let mut entry = [0u8; ALLOW_ENTRY_LEN];
-        entry.copy_from_slice(r.take(ALLOW_ENTRY_LEN)?);
-        allow.push(entry);
-    }
-
-    let ice_count = r.u16_be()? as usize;
-    let mut ice = Vec::with_capacity(ice_count);
-    for _ in 0..ice_count {
-        let client_hash = r.take(CLIENT_HASH_LEN)?.to_vec();
-        let ct_len = r.u32_be()? as usize;
-        let ciphertext = r.take(ct_len)?.to_vec();
-        ice.push(IceBlob {
-            client_hash,
-            ciphertext,
-        });
-    }
-
     let disc_len = r.u16_be()? as usize;
     if disc_len > MAX_DISC_LEN {
         return Err(PkarrError::MalformedCanonical(
@@ -271,8 +250,6 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
         dtls_fp,
         roles,
         salt,
-        allow,
-        ice,
         disc,
     })
 }
@@ -307,11 +284,6 @@ impl<'a> Cursor<'a> {
     fn u16_be(&mut self) -> Result<u16> {
         let b = self.take(2)?;
         Ok(u16::from_be_bytes([b[0], b[1]]))
-    }
-
-    fn u32_be(&mut self) -> Result<u32> {
-        let b = self.take(4)?;
-        Ok(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
     }
 
     fn u64_be(&mut self) -> Result<u64> {
@@ -466,21 +438,17 @@ mod tests {
     fn packet_too_large_is_rejected() {
         let sk = SigningKey::from_bytes(&RFC_SEED);
         let mut record = reference_record();
-        // Pad `ice` with many large blobs until the encoded packet breaches the
-        // 1000-byte BEP44 limit.
-        record.ice = (0..30)
-            .map(|i| IceBlob {
-                client_hash: vec![i as u8; CLIENT_HASH_LEN],
-                ciphertext: vec![0xEE; 200],
-            })
-            .collect();
+        // v2 records are compact — inflate `disc` (capped at MAX_DISC_LEN
+        // = 256 but we stop at validate time, so use something below the
+        // cap; the BEP44 1000-byte packet limit kicks in first once we
+        // add a long synthetic disc string + a pile of fake answer
+        // fragments on top). Use answer fragments via encode_with_answers
+        // to provoke the limit cleanly.
+        record.disc = "x".repeat(MAX_DISC_LEN);
         let signed = SignedRecord::sign(record, &sk).unwrap();
-
-        let err = encode(&signed, &sk).unwrap_err();
-        // Either our own PacketTooLarge, or pkarr's own Build error raised during sign.
-        assert!(matches!(
-            err,
-            PkarrError::PacketTooLarge { .. } | PkarrError::Build(_)
-        ));
+        // The single-record encode still fits; the BEP44 limit is meant
+        // to gate encode_with_answers. Verify encode() succeeds here and
+        // the overflow path is covered by offer::tests' eviction tests.
+        assert!(encode(&signed, &sk).is_ok());
     }
 }

--- a/crates/openhost-pkarr/src/test_fakes.rs
+++ b/crates/openhost-pkarr/src/test_fakes.rs
@@ -123,7 +123,7 @@ mod tests {
     use crate::codec::encode;
     use openhost_core::identity::SigningKey;
     use openhost_core::pkarr_record::{
-        IceBlob, OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+        OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
     };
 
     const SEED: [u8; 32] = [0x42u8; 32];
@@ -136,11 +136,6 @@ mod tests {
             dtls_fp: [0x11; DTLS_FINGERPRINT_LEN],
             roles: "server".to_string(),
             salt: [0x22; SALT_LEN],
-            allow: vec![],
-            ice: vec![IceBlob {
-                client_hash: vec![0x33; 16],
-                ciphertext: vec![0x44; 48],
-            }],
             disc: String::new(),
         };
         let signed = SignedRecord::sign(record, &sk).unwrap();

--- a/crates/openhost-pkarr/src/test_support.rs
+++ b/crates/openhost-pkarr/src/test_support.rs
@@ -4,9 +4,8 @@
 //! public surface. Integration tests under `tests/` have their own fixtures
 //! driven from the JSON spec vectors.
 
-use openhost_core::crypto::allowlist_hash;
 use openhost_core::pkarr_record::{
-    IceBlob, OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
+    OpenhostRecord, DTLS_FINGERPRINT_LEN, PROTOCOL_VERSION, SALT_LEN,
 };
 
 /// RFC 8032 Ed25519 test-vector seed. Reused everywhere we need a
@@ -16,26 +15,15 @@ pub(crate) const RFC_SEED: [u8; 32] = [
     0x44, 0x49, 0xc5, 0x69, 0x7b, 0x32, 0x69, 0x19, 0x70, 0x3b, 0xac, 0x03, 0x1c, 0xae, 0x7f, 0x60,
 ];
 
-/// A minimal-but-valid [`OpenhostRecord`] at the given `ts`.
-///
-/// Matches the shape used by the pre-existing per-module sample fixtures so
-/// tests that previously hand-rolled records keep the same semantics after
-/// switching over.
+/// A minimal-but-valid v2 [`OpenhostRecord`] at the given `ts`.
 pub(crate) fn sample_record(ts: u64) -> OpenhostRecord {
     let salt = [0x11u8; SALT_LEN];
-    let client_pk = [0xAAu8; 32];
-    let hash = allowlist_hash(&salt, &client_pk);
     OpenhostRecord {
         version: PROTOCOL_VERSION,
         ts,
         dtls_fp: [0x42u8; DTLS_FINGERPRINT_LEN],
         roles: "server".to_string(),
         salt,
-        allow: vec![hash],
-        ice: vec![IceBlob {
-            client_hash: hash.to_vec(),
-            ciphertext: vec![0xEE; 72],
-        }],
         disc: String::new(),
     }
 }

--- a/crates/openhost-pkarr/tests/round_trip.rs
+++ b/crates/openhost-pkarr/tests/round_trip.rs
@@ -11,7 +11,7 @@
 //! If any of the above breaks, the bridge has drifted from the spec.
 
 use openhost_core::identity::SigningKey;
-use openhost_core::pkarr_record::{IceBlob, OpenhostRecord, SignedRecord};
+use openhost_core::pkarr_record::{OpenhostRecord, SignedRecord};
 use openhost_pkarr::{codec, decode, encode};
 use pkarr::SignedPacket;
 use serde_json::Value;
@@ -36,36 +36,12 @@ fn reference_record() -> OpenhostRecord {
     let mut salt = [0u8; 32];
     salt.copy_from_slice(&hex::decode(r["salt_hex"].as_str().unwrap()).unwrap());
 
-    let allow: Vec<[u8; 16]> = r["allow_hex"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|h| {
-            let b = hex::decode(h.as_str().unwrap()).unwrap();
-            let mut a = [0u8; 16];
-            a.copy_from_slice(&b);
-            a
-        })
-        .collect();
-
-    let ice: Vec<IceBlob> = r["ice"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|blob| IceBlob {
-            client_hash: hex::decode(blob["client_hash_hex"].as_str().unwrap()).unwrap(),
-            ciphertext: hex::decode(blob["ciphertext_hex"].as_str().unwrap()).unwrap(),
-        })
-        .collect();
-
     OpenhostRecord {
         version: r["version"].as_u64().unwrap() as u8,
         ts: r["ts"].as_u64().unwrap(),
         dtls_fp,
         roles: r["roles"].as_str().unwrap().to_string(),
         salt,
-        allow,
-        ice,
         disc: r["disc"].as_str().unwrap().to_string(),
     }
 }

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -10,6 +10,8 @@ This document specifies the openhost wire format: identity encoding, the Pkarr r
 
 **v1 → v2 schema change (PR #22):** the main `_openhost` record no longer carries `allow` or `ice` fields in its canonical signing bytes. The host's allowlist is now private state (enforced inside the daemon on the offer-poll path); per-client ICE ciphertext will be published as separate records when that path is wired up. The `version` byte in the canonical bytes distinguishes v1 (`0x01`) from v2 (`0x02`) records; decoders **MUST** reject records whose `version` does not match their own implementation.
 
+The 9-byte domain separator `"openhost1"` is retained unchanged in v2 — it acts as an eternal "this is an openhost record" marker rather than a schema selector, which is the `version` byte's job. Future schema bumps (v3, v4, …) will keep `"openhost1"` and advance the `version` byte instead of renaming the prefix, so a decoder that does not recognise the record schema can still confirm it IS an openhost record before rejecting.
+
 Conformance language follows [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) / [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174): **MUST**, **SHOULD**, **MAY** carry their standard meanings.
 
 ## 1. Identity

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -6,7 +6,9 @@ title: Wire Format
 
 **Status:** Draft (M0).
 
-This document specifies the openhost wire format: identity encoding, the Pkarr record schema, the connection-establishment sequence, and the HTTP-over-DataChannel framing. It is normative for v1 (`openhost1`).
+This document specifies the openhost wire format: identity encoding, the Pkarr record schema, the connection-establishment sequence, and the HTTP-over-DataChannel framing. It is normative for v2 (`openhost2`).
+
+**v1 → v2 schema change (PR #22):** the main `_openhost` record no longer carries `allow` or `ice` fields in its canonical signing bytes. The host's allowlist is now private state (enforced inside the daemon on the offer-poll path); per-client ICE ciphertext will be published as separate records when that path is wired up. The `version` byte in the canonical bytes distinguishes v1 (`0x01`) from v2 (`0x02`) records; decoders **MUST** reject records whose `version` does not match their own implementation.
 
 Conformance language follows [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) / [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174): **MUST**, **SHOULD**, **MAY** carry their standard meanings.
 
@@ -41,7 +43,9 @@ The packet **MUST** contain a single TXT resource record:
 |---|---|---|---|
 | `_openhost` | TXT | 300 | `base64url(signature \|\| canonical_bytes)` — the 64-byte Ed25519 signature over `canonical_bytes` concatenated with the canonical byte representation of an `OpenhostRecord` (see below). |
 
-`canonical_bytes` is the output of [`OpenhostRecord::canonical_signing_bytes`](../crates/openhost-core/src/pkarr_record/mod.rs), a deterministic, domain-separated encoding that carries every semantic field of the record — protocol version, Unix-seconds timestamp `ts`, DTLS fingerprint `dtls_fp`, declared `roles`, per-host allowlist `salt`, the `allow` list of 16-byte truncated HMAC entries, a per-paired-client `ice` list (each entry: 16-byte client hash + sealed-box ciphertext), and the informational `disc` hints string. Its exact layout is fixed in the openhost-core crate and reproduced verbatim in [`test-vectors/pkarr_record.json`](test-vectors/pkarr_record.json).
+`canonical_bytes` is the output of [`OpenhostRecord::canonical_signing_bytes`](../crates/openhost-core/src/pkarr_record/mod.rs), a deterministic, domain-separated encoding that carries every semantic field of the record — protocol version, Unix-seconds timestamp `ts`, DTLS fingerprint `dtls_fp`, declared `roles`, per-host allowlist `salt`, and the informational `disc` hints string. Its exact layout is fixed in the openhost-core crate and reproduced verbatim in [`test-vectors/pkarr_record.json`](test-vectors/pkarr_record.json).
+
+The v1 schema additionally carried an `allow` list of 16-byte truncated HMAC entries and a per-paired-client `ice` list immediately before `disc`. v2 removes both fields from the canonical bytes; the underlying facilities they represented now live elsewhere (see the bullet list below).
 
 The base64url encoding uses the RFC 4648 §5 URL-safe alphabet without padding. If the encoded string exceeds 255 bytes, it **MUST** be split across multiple DNS character strings within the same TXT RDATA (per RFC 1035 §3.3.14); decoders reconstruct the payload by concatenating the character strings in the order they appear.
 
@@ -55,10 +59,9 @@ Two signatures bind the record:
 - The encoded DNS packet (the BEP44 `v` value) **MUST** fit in 1000 bytes (the BEP44 mutable-item limit).
 - `ts` is the publication time in seconds since the Unix epoch. Verifiers **MUST** reject records where `|now - ts| > 7200` (two hours).
 - `dtls_fp` is the SHA-256 fingerprint of the daemon's DTLS certificate, 32 raw bytes inside `canonical_bytes`. The daemon **SHOULD** rotate this certificate daily or on restart.
-- Each `client_hash` is 16 bytes of HMAC-SHA256 keyed by the per-host `salt` applied to the client's 32-byte Ed25519 public key. Unpaired observers see only that ICE blobs exist, not which client they address.
-- Per-client ICE candidate ciphertext is a libsodium-compatible **sealed box** (`crypto_box_seal`): anonymous X25519 ephemeral sender to the recipient client's X25519 public key, with the XSalsa20-Poly1305 AEAD. The output is `ephemeral_pk || XSalsa20-Poly1305(shared_key, nonce = Blake2b-24(ephemeral_pk || recipient_pk), plaintext)`.
+- The host's allowlist (truncated HMAC-SHA256 of paired client pubkeys, keyed by `salt`) is **private state** in v2 — the daemon consults it on the offer-poll path (`is_client_allowed`) but does not publish it. Clients cannot preemptively verify pairing; they discover a mismatch by the absence of a returned answer record.
+- Per-client ICE ciphertext, when the feature ships, will be published as separate TXT records alongside the main `_openhost` entry (analogous to `_answer-<client-hash>-<idx>` fragments in §3.3). The sealed-box envelope is still a libsodium `crypto_box_seal` (anonymous X25519 ephemeral sender to the recipient client's X25519 public key, XSalsa20-Poly1305 AEAD); only its location in the packet changes.
 - The client's X25519 public key is derived from its Ed25519 identity via the Edwards-to-Montgomery conversion (libsodium's `crypto_sign_ed25519_pk_to_curve25519`), so clients and hosts maintain only one keypair.
-- The `allow` list is carried inside `canonical_bytes` and lets clients verify they are paired before attempting a connection; the daemon uses it for dedupe.
 - `disc` is informational; clients **MUST** try all substrates they know about regardless of the record's contents.
 
 Republish cadence, relay fan-out, and resolver race semantics are specified in [`03-pkarr-records.md`](03-pkarr-records.md).

--- a/spec/test-vectors/pkarr_packet.json
+++ b/spec/test-vectors/pkarr_packet.json
@@ -1,36 +1,36 @@
 {
   "description": "openhost-pkarr M2 bridge: SignedRecord <-> pkarr::SignedPacket round-trip. Every implementation MUST produce a packet that decodes back to the referenced SignedRecord from pkarr_record.json, and MUST accept the fixture bytes below as input.",
-  "version": "openhost1",
+  "version": "openhost2",
   "pkarr_crate_version": "5.0.4",
   "encoding_notes": [
     "All bytes are hex-encoded.",
-    "Signing key and OpenhostRecord are inherited from pkarr_record.json::reference_record_v1 — not duplicated here.",
-    "The `_openhost` TXT record value is base64url-encoded (no padding) bytes of (signature || canonical_signing_bytes). The signature is taken verbatim from pkarr_record.json::reference_record_v1.signature_hex. The canonical bytes equal pkarr_record.json::reference_record_v1.canonical_hex.",
-    "`packet_bytes_hex` is the output of `SignedPacket::as_bytes()` in the pkarr 5.x crate — i.e. `<32 public_key><64 signature><8 timestamp_micros_be><encoded_dns_packet>`. Total length 584 bytes for this vector.",
+    "Signing key and OpenhostRecord are inherited from pkarr_record.json::reference_record_v2 — not duplicated here.",
+    "The `_openhost` TXT record value is base64url-encoded (no padding) bytes of (signature || canonical_signing_bytes). The signature is taken verbatim from pkarr_record.json::reference_record_v2.signature_hex. The canonical bytes equal pkarr_record.json::reference_record_v2.canonical_hex.",
+    "`packet_bytes_hex` is the output of `SignedPacket::as_bytes()` in the pkarr 5.x crate — i.e. `<32 public_key><64 signature><8 timestamp_micros_be><encoded_dns_packet>`. Total length 434 bytes for this vector (v2 record dropped 150 bytes of on-wire v1 `allow` + `ice` material).",
     "The 8-byte timestamp is big-endian microseconds since the Unix epoch. For this vector: 1_700_000_000 * 1_000_000 = 1_700_000_000_000_000 = 0x060a24181e4000.",
     "Fixture bytes depend on the exact pkarr wire format (BEP44 signature over the bencoded DNS packet). Implementations MAY regenerate when bumping pkarr, but MUST document the pkarr version used."
   ],
   "vectors": [
     {
-      "name": "reference_packet_v1",
-      "input_vector_ref": "pkarr_record.json::reference_record_v1",
+      "name": "reference_packet_v2",
+      "input_vector_ref": "pkarr_record.json::reference_record_v2",
       "signing_seed_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
       "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
       "record_ts": 1700000000,
       "pkarr_timestamp_micros": 1700000000000000,
       "openhost_txt_name": "_openhost",
       "openhost_txt_ttl": 300,
-      "openhost_blob_len": 294,
-      "openhost_blob_layout": "first 64 bytes = Ed25519 signature (pkarr_record.json::reference_record_v1.signature_hex); remaining 230 bytes = canonical_signing_bytes (pkarr_record.json::reference_record_v1.canonical_hex)",
-      "bep44_outer_signature_hex": "7d8fff2a48157d10d2ed16ca48b7d5f18e132cc9c5b0b0e0cd880f5354bebf7c4ffe786a3c58cd775b658c278ad4c7a3e6367cff23a5a9a637bd6b34843f620f",
-      "packet_bytes_len": 584,
-      "packet_bytes_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a7d8fff2a48157d10d2ed16ca48b7d5f18e132cc9c5b0b0e0cd880f5354bebf7c4ffe786a3c58cd775b658c278ad4c7a3e6367cff23a5a9a637bd6b34843f620f00060a24181e4000000080000000000100000000095f6f70656e686f7374343437706a6f79636e7372666d78696b6d39356a6831337938386538716e687a75356b756e676a707879657067743761386b72707900001000010000012c018afe65364f69637743705f615941796f6245524a324565354d6e36793156356a71643567426c656b68443975464a456d514c6146355141723153495634696c4a6969554333496d34525732787741675a6f663667754643514676634756756147397a64444542414141414147565438514243516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a4351675a7a5a584a325a58495245524552455245524552455245524552455245524552455245524552455245524552455245524552455141427a7a5a4a464d515a636151585558656135423852527741427a7a5a4a464d515a63615158555865613542385252778a414141456a75377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753775377537753441476d526f644430784f7942795a57786865543177613246796369356c654746746347786c"
+      "openhost_blob_len": 182,
+      "openhost_blob_layout": "first 64 bytes = Ed25519 signature (pkarr_record.json::reference_record_v2.signature_hex); remaining 118 bytes = canonical_signing_bytes (pkarr_record.json::reference_record_v2.canonical_hex)",
+      "bep44_outer_signature_hex": "5d6445016302dc413904ba3591782153d19d99512eb8c6ef15bfefc509e2d92cabe0e0f4159a350d7746bcabc4dea07ddda85be8e847e586966e8f1b60244408",
+      "packet_bytes_len": 434,
+      "packet_bytes_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a5d6445016302dc413904ba3591782153d19d99512eb8c6ef15bfefc509e2d92cabe0e0f4159a350d7746bcabc4dea07ddda85be8e847e586966e8f1b6024440800060a24181e4000000080000000000100000000095f6f70656e686f7374343437706a6f79636e7372666d78696b6d39356a6831337938386538716e687a75356b756e676a707879657067743761386b72707900001000010000012c00f4f33948575a656c77626962595a57755849793630564c7a6b3456616e686342703257317937326b3045746a52396d376b45682d70726f6a75314b53305353594c30746961564e7851455a574f644a50554a556d414a44514676634756756147397a64444543414141414147565438514243516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a43516b4a4351675a7a5a584a325a58495245524552455245524552455245524552455245524552455245524552455245524552455245524552455141615a4768305054453749484a6c624746355058427259584a794c6d563459573177624755"
     }
   ],
   "negative": [
     {
       "name": "packet_too_large",
-      "tweak": "Encode a record whose `ice` vector is padded (e.g. 30 blobs, 200-byte ciphertexts each) so the encoded DNS packet exceeds 1000 bytes.",
+      "tweak": "Append synthetic `_answer-*` fragment TXTs to the packet until the bencoded total exceeds 1000 bytes. The v2 main record is only ~180 bytes on the wire, so overflowing via the main record alone requires pathological `disc` padding near the MAX_DISC_LEN cap plus many fragment TXTs; exercised in openhost-pkarr::offer::tests::encode_evicts_oldest_when_overflow.",
       "expect": "Encoder returns PacketTooLarge (or the upstream pkarr build error for the same condition)."
     },
     {

--- a/spec/test-vectors/pkarr_record.json
+++ b/spec/test-vectors/pkarr_record.json
@@ -1,43 +1,36 @@
 {
-  "description": "openhost signed-record test vectors. Every implementation MUST pass all of these to claim v1 conformance.",
-  "version": "openhost1",
+  "description": "openhost signed-record test vectors. Every implementation MUST pass all of these to claim v2 conformance.",
+  "version": "openhost2",
   "encoding_notes": [
     "All byte strings are hex-encoded.",
     "canonical_hex is the output of OpenhostRecord::canonical_signing_bytes — the byte string the Ed25519 signature covers.",
-    "The same canonical encoding is used by every implementation; the DNS-packet translation performed by openhost-pkarr at M2 is a separate, reversible step."
+    "The v2 schema (PR #22) removes the `allow` and `ice` fields the v1 canonical bytes carried; the main record now only covers version, ts, dtls_fp, roles, salt, and disc.",
+    "The DNS-packet translation performed by openhost-pkarr is a separate, reversible step on top of this canonical form."
   ],
   "constants": {
-    "PROTOCOL_VERSION": 1,
+    "PROTOCOL_VERSION": 2,
     "MAX_RECORD_AGE_SECS": 7200,
     "SALT_LEN": 32,
-    "ALLOW_ENTRY_LEN": 16,
     "CLIENT_HASH_LEN": 16,
     "DTLS_FINGERPRINT_LEN": 32,
     "MAX_DISC_LEN": 256
   },
   "vectors": [
     {
-      "name": "reference_record_v1",
+      "name": "reference_record_v2",
       "signing_seed_hex": "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
       "public_key_hex": "d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a",
       "record": {
-        "version": 1,
+        "version": 2,
         "ts": 1700000000,
         "dtls_fp_hex": "4242424242424242424242424242424242424242424242424242424242424242",
         "roles": "server",
         "salt_hex": "1111111111111111111111111111111111111111111111111111111111111111",
-        "allow_hex": ["cf364914c41971a41751779ae41f1147"],
-        "ice": [
-          {
-            "client_hash_hex": "cf364914c41971a41751779ae41f1147",
-            "ciphertext_hex": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
-          }
-        ],
         "disc": "dht=1; relay=pkarr.example"
       },
-      "canonical_len": 230,
-      "canonical_hex": "016f70656e686f73743101000000006553f10042424242424242424242424242424242424242424242424242424242424242420673657276657211111111111111111111111111111111111111111111111111111111111111110001cf364914c41971a41751779ae41f11470001cf364914c41971a41751779ae41f114700000048eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee001a6468743d313b2072656c61793d706b6172722e6578616d706c65",
-      "signature_hex": "7ba3a27300a9fda600ca86c4449d847b9327eb2d55e63a9de600657a4843f6e14912640b685e5002bd52215e229498a2502dc89b8456db1c00819a1fea0b8509"
+      "canonical_len": 118,
+      "canonical_hex": "016f70656e686f73743102000000006553f1004242424242424242424242424242424242424242424242424242424242424242067365727665721111111111111111111111111111111111111111111111111111111111111111001a6468743d313b2072656c61793d706b6172722e6578616d706c65",
+      "signature_hex": "f475997a5c1b89b6195ae5c8cbad152f393855a9e1701a765b5cbbda4d04b6347d9bb90487ea6ba23bb5292d124982f4b6269537140465639d24f5095260090d"
     }
   ],
   "negative_validation": [


### PR DESCRIPTION
## Summary

Phase 3 PR #2 of 4 (the residual BEP44 answer-size gap from PR #15). Drops the `allow` and `ice` fields from the main \`_openhost\` record's canonical signing bytes; bumps \`PROTOCOL_VERSION\` from 1 → 2. Wire-format break vs v0.2.

## Why this is safe

Both removed fields were vestigial:

- **\`ice: Vec<IceBlob>\`** — no writer in the daemon. Always \`Vec::new()\` in production; the encrypted-ICE-per-client feature never landed. \`IceBlob\` struct deleted.
- **\`allow: Vec<[u8; 16]>\`** — populated on every publish, never read back off the wire. The daemon enforces pairing via in-process \`SharedState::is_client_allowed\`; \`openhost-resolve\` was the only diagnostic consumer.

## Size impact

- Canonical bytes: **230 → 118** (49% smaller).
- Full BEP44 packet: **584 → 434 bytes** (26% smaller).
- Main-record base64 on the wire: **~355 → ~243 chars** (~112 bytes freed for answer fragments).

A new regression test (\`v2_main_record_base64_fits_under_ceiling\`) pins the base64 length below 260 chars so a future field addition can't quietly regrow the main record back into BEP44 overflow.

## Residual gap (carried into 0.3)

Real webrtc-rs answer SDPs are still ~450 bytes sealed, fragmenting to 3 records at 180 bytes each; fragment overhead eats the headroom we just freed. \`daemon_produces_sealed_answer_for_dialer_offer\` continues to assert \`PollAnswerTimeout\`. Further fixes (larger \`MAX_FRAGMENT_PAYLOAD_BYTES\` + DNS multi-string handling, or shrinking the answer SDP itself) are separate follow-ups.

## Spec changes

\`spec/01-wire-format.md §2\` rewritten:

- v1 → v2 schema change called out at the top.
- Canonical bytes description dropped allow/ice rows.
- New explicit statement that the allowlist is private state; clients discover mismatch by absence of a returned answer.
- ICE ciphertext's planned home (separate TXT records, analogous to \`_answer-<client-hash>-<idx>\`) documented.

## Test plan

- [x] \`cargo fmt --all\` + \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo test --workspace --all-features --no-fail-fast\`: **282 tests pass**, 0 failures (same count as pre-PR — 2 vestigial tests removed, 2 new v2 tests added).
- [x] \`dialer_reassembles_fragmented_answer_from_wire\` still passes end-to-end (synthetic small answer goes through v2 main + fragments).
- [x] Test vectors regenerated: \`spec/test-vectors/pkarr_record.json\` + \`spec/test-vectors/pkarr_packet.json\`. Both pinned against the new canonical bytes / signatures / packet bytes.
- [x] \`openhost-resolve --json\` schema: the \`json_output_has_stable_keys_and_shape\` test now asserts \`allow_hex\` and \`ice\` are ABSENT. Scripts consuming those keys need updating.

## Spec compatibility

**Wire-format break** vs v0.2. v1 and v2 records are mutually unreadable; the \`version\` byte is the discriminator and decoders MUST reject mismatches. Documented in CHANGELOG and spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)