### PR TITLE
feat(release): distributable binaries + systemd unit + launchd plist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,182 @@
+name: Release
+
+# Fires when a `v*` tag is pushed (the standard trigger) or manually via
+# the Actions tab (`workflow_dispatch`). The latter is useful for
+# backfilling binaries onto an already-tagged release, e.g. v0.2.0 which
+# was tagged before this workflow existed.
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to build binaries for (e.g. v0.2.0)"
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # Independent per-platform failures are diagnosable on their own;
+      # no reason to cancel a working Linux build because macOS hit an
+      # SDK quirk.
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          - name: macos-aarch64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+            archive: tar.gz
+          - name: macos-x86_64
+            runner: macos-latest
+            target: x86_64-apple-darwin
+            archive: tar.gz
+          - name: windows-x86_64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+
+    steps:
+      - name: Check out ${{ github.event.inputs.tag || github.ref }}
+        uses: actions/checkout@v4
+        with:
+          # workflow_dispatch passes the tag via input; the tag-push
+          # trigger leaves inputs.tag empty and uses the default ref.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust target ${{ matrix.target }}
+        # Toolchain version is pinned via rust-toolchain.toml; rustup
+        # resolves it automatically on first cargo invocation. We only
+        # need to add the cross-target triple on macOS x86_64 (the
+        # arm64 runner builds arm64 natively).
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: release-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Build daemon
+        run: cargo build --release --target ${{ matrix.target }} -p openhost-daemon
+
+      - name: Build client + cli
+        run: cargo build --release --target ${{ matrix.target }} --features cli -p openhost-client
+
+      - name: Stage artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bin_ext=""
+          if [[ "${{ matrix.runner }}" == windows-* ]]; then
+            bin_ext=".exe"
+          fi
+          stage="openhost-${{ matrix.name }}"
+          mkdir -p "$stage"
+          for bin in openhostd openhost-dial openhost-resolve; do
+            src="target/${{ matrix.target }}/release/${bin}${bin_ext}"
+            test -f "$src" || { echo "missing: $src"; exit 1; }
+            cp "$src" "$stage/"
+          done
+          cp CHANGELOG.md LICENSE-APACHE LICENSE-MIT README.md "$stage/"
+          cp -r examples distribution "$stage/" 2>/dev/null || true
+          echo "STAGE_DIR=$stage" >> "$GITHUB_ENV"
+
+      - name: Strip binaries (Unix)
+        if: matrix.runner != 'windows-latest'
+        run: |
+          for bin in openhostd openhost-dial openhost-resolve; do
+            strip "$STAGE_DIR/$bin" || true
+          done
+
+      - name: Pack ${{ matrix.archive }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ matrix.archive }}" == "zip" ]]; then
+            # GitHub runners ship 7z by default on windows-latest.
+            7z a "${STAGE_DIR}.zip" "$STAGE_DIR" > /dev/null
+          else
+            tar czf "${STAGE_DIR}.tar.gz" "$STAGE_DIR"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: openhost-${{ matrix.name }}.${{ matrix.archive }}
+          retention-days: 7
+
+  publish:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    # workflow_dispatch runs always fire the build step; we only
+    # publish on tag push OR explicit dispatch. The condition keeps a
+    # future scheduled re-run (if someone adds one) from nuking the
+    # release body.
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    steps:
+      - name: Check out for CHANGELOG slicing
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Resolve tag name
+        id: tag
+        shell: bash
+        run: |
+          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ steps.tag.outputs.tag }}"
+          version="${tag#v}"
+          # Slice out the section between `## [X.Y.Z]` and the next
+          # `## [` header. Drop the trailing header line.
+          awk -v v="[$version]" '
+            $0 ~ "^## "v {flag=1; print; next}
+            flag && $0 ~ "^## \\[" {exit}
+            flag {print}
+          ' CHANGELOG.md > release-notes.md
+          echo "--- release-notes.md:"
+          cat release-notes.md
+
+      - name: Publish or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body_path: release-notes.md
+          # `fail_on_unmatched_files` guards against the glob matching
+          # zero artifacts (a silent no-op would be worse than a loud
+          # failure at release time).
+          fail_on_unmatched_files: true
+          files: artifacts/**/openhost-*.*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,14 +160,20 @@ jobs:
           tag="${{ steps.tag.outputs.tag }}"
           version="${tag#v}"
           # Slice out the section between `## [X.Y.Z]` and the next
-          # `## [` header. Drop the trailing header line.
-          awk -v v="[$version]" '
-            $0 ~ "^## "v {flag=1; print; next}
-            flag && $0 ~ "^## \\[" {exit}
-            flag {print}
+          # `## [` header. Uses literal-prefix comparison (index with
+          # offset 1) rather than regex — `[` in awk's `~` operator
+          # is a character class, not a literal, which silently
+          # emptied the output on every release.
+          awk -v hdr="## [$version]" '
+            index($0, hdr) == 1 && !flag { flag = 1; print; next }
+            flag && index($0, "## [") == 1 { exit }
+            flag { print }
           ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "WARN: no CHANGELOG section matched '## [$version]' — release body will be empty" >&2
+          fi
           echo "--- release-notes.md:"
-          cat release-notes.md
+          cat release-notes.md || true
 
       - name: Publish or update release
         uses: softprops/action-gh-release@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added (PR #23, distributable binaries)
+
+- **New `.github/workflows/release.yml`** — fires on `v*` tag push (or `workflow_dispatch` for backfills). Builds `openhostd`, `openhost-dial`, `openhost-resolve` on native GitHub runners for Linux x86_64, macOS aarch64, macOS x86_64, and Windows x86_64; strips, packs (`.tar.gz` / `.zip`), and uploads to the matching GitHub release via `softprops/action-gh-release`. Release body is sliced out of the matching `## [X.Y.Z]` section of `CHANGELOG.md` by a small awk filter; `fail_on_unmatched_files: true` guards against a silent no-op on a misconfigured glob.
+- **New `distribution/`** tree with operator-ready service-manager files:
+  - `distribution/systemd/openhostd.service` — Linux systemd unit with resource ceilings (`MemoryMax=256M`, `TasksMax=64`), sandboxing (`ProtectSystem=strict`, `PrivateTmp=true`, `NoNewPrivileges=true`, `MemoryDenyWriteExecute=true`, and friends), and backoff that caps crashloops before they hammer public Pkarr relays.
+  - `distribution/launchd/com.openhost.openhostd.plist` — macOS launchd plist with user-agent and system-daemon install modes; documented in comments, including the `UserName` block to uncomment for the system install.
+  - `distribution/README.md` — install commands + uninstall commands for both platforms, plus a security-posture note (the daemon runs unprivileged by default; don't grant more).
+- **Site install guide reshuffle** — `guides/install.md` now leads with a "Pre-built binaries" section and a platform-archive table; "Build from source" moves to a fallback section. README's "Building from source" gains a one-line pointer at the releases page.
+
+### Out of scope for PR #23
+
+- Homebrew tap — requires a separate `homebrew-openhost` repo + formula with pinned SHA256s against a real release artifact. Easier to land once the workflow has run once and produced verifiable checksums.
+- macOS notarization / Windows code signing — requires paid developer certs; follow-up.
+- ARM Linux (aarch64-unknown-linux-gnu) — cross-compile requires extra toolchain setup, and native ARM GitHub runners are paid. Start with x86_64 Linux; revisit if users ask.
+- musl builds for Alpine Linux — follow-up once there's demand.
+
 ### Changed (PR #22, shrink main `_openhost` record)
 
 - **Wire-format break**: `PROTOCOL_VERSION` bumped `1` → `2`. v2 records drop the `allow` and `ice` fields from `OpenhostRecord::canonical_signing_bytes`. v1 and v2 records are mutually unreadable; the `version` byte is the discriminator (decoders **MUST** reject a mismatched version).

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The full walkthrough — including how to pair a persistent client identity and 
 
 ## Building from source
 
+Pre-built binaries for Linux / macOS / Windows are published on every tagged release at [github.com/kaicoder03/openhost/releases](https://github.com/kaicoder03/openhost/releases/latest). Build from source only if you need a pre-release build or your platform isn't on the list.
+
 ```bash
 # Rust workspace (toolchain is pinned via rust-toolchain.toml — rustup fetches it automatically)
 cargo check --workspace

--- a/distribution/README.md
+++ b/distribution/README.md
@@ -1,0 +1,85 @@
+# Distribution artifacts
+
+Service-manager files and other artifacts that help operators run the daemon in production. Each subdirectory is self-contained — install or skip per your environment.
+
+## What's here
+
+| Path | Purpose |
+|---|---|
+| [`systemd/openhostd.service`](systemd/openhostd.service) | Linux systemd unit with resource limits and basic sandboxing. |
+| [`launchd/com.openhost.openhostd.plist`](launchd/com.openhost.openhostd.plist) | macOS launchd property list (user or system agent). |
+
+A Homebrew tap (`kaicoder03/homebrew-openhost`) is planned once at least one tagged release has produced binary artifacts via `.github/workflows/release.yml`. That workflow landed in PR #23; the first release it runs against will be the trigger for the tap.
+
+## Linux: systemd
+
+1. Install the binaries under `/usr/local/bin/` (see [install guide](https://kaicoder03.github.io/openhost/guides/install/)).
+2. Create the system user the unit runs as:
+
+   ```bash
+   sudo useradd --system --home-dir /var/lib/openhost --create-home --shell /usr/sbin/nologin openhost
+   sudo install -d -m 0700 -o openhost -g openhost /var/lib/openhost /etc/openhost
+   ```
+
+3. Install the unit:
+
+   ```bash
+   sudo install -m 0644 distribution/systemd/openhostd.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now openhostd.service
+   ```
+
+4. Inspect:
+
+   ```bash
+   systemctl status openhostd
+   journalctl -u openhostd -f
+   ```
+
+The unit points `$HOME` at `/var/lib/openhost` and expects the daemon config at `/etc/openhost/daemon.toml`. Adjust the unit's `Environment=OPENHOST_CONFIG=…` line if you keep config elsewhere.
+
+Uninstall:
+
+```bash
+sudo systemctl disable --now openhostd.service
+sudo rm /etc/systemd/system/openhostd.service
+sudo systemctl daemon-reload
+```
+
+## macOS: launchd
+
+The plist can run as a **user agent** (per-account, loaded at login) or a **system daemon** (machine-wide, loaded at boot). User-agent is the right choice for a personal home server; system-daemon is for shared-user setups.
+
+### User agent (recommended)
+
+```bash
+install -d -m 0700 ~/Library/LaunchAgents ~/Library/Logs/openhost
+install -m 0644 distribution/launchd/com.openhost.openhostd.plist \
+  ~/Library/LaunchAgents/com.openhost.openhostd.plist
+
+# Edit the plist to point `WorkingDirectory` and `StandardOutPath` at
+# paths inside your home directory if the defaults don't suit. Then:
+launchctl load ~/Library/LaunchAgents/com.openhost.openhostd.plist
+```
+
+Inspect:
+
+```bash
+launchctl list | grep openhost
+tail -f ~/Library/Logs/openhost/openhostd.log
+```
+
+Uninstall:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.openhost.openhostd.plist
+rm ~/Library/LaunchAgents/com.openhost.openhostd.plist
+```
+
+### System daemon
+
+Same file, but install to `/Library/LaunchDaemons/` with owner `root:wheel` and load with `sudo launchctl load`. Edit the plist's `UserName` key first.
+
+## Security note
+
+Both unit files run the daemon as an **unprivileged** user by default. The daemon does not need root — it binds no privileged port, writes no files outside its state directory, and talks to upstream services over loopback. If you find yourself editing the unit file to grant more permissions, double-check first; the defaults are deliberate.

--- a/distribution/launchd/com.openhost.openhostd.plist
+++ b/distribution/launchd/com.openhost.openhostd.plist
@@ -19,9 +19,10 @@
   <string>com.openhost.openhostd</string>
 
   <!-- Restart on boot (or at login for a user agent) and whenever the
-       daemon exits. KeepAlive's default value re-runs on any exit;
-       the ExitType variant below limits that to non-clean exits so
-       a manual `launchctl unload` doesn't get fought back. -->
+       daemon exits uncleanly. KeepAlive's dict form restricts the
+       restart to crash and network-state conditions — a manual
+       `launchctl unload` does not get fought back, and the daemon
+       doesn't respawn uselessly when no network is up. -->
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -29,6 +30,8 @@
     <key>SuccessfulExit</key>
     <false/>
     <key>Crashed</key>
+    <true/>
+    <key>NetworkState</key>
     <true/>
   </dict>
 
@@ -77,18 +80,5 @@
        hammer public Pkarr relays. -->
   <key>ThrottleInterval</key>
   <integer>10</integer>
-
-  <!-- Network prerequisites: wait until at least one interface has
-       an IPv4/IPv6 route before starting the daemon. Avoids noisy
-       initial-publish warnings during boot. -->
-  <key>KeepAlive</key>
-  <dict>
-    <key>NetworkState</key>
-    <true/>
-    <key>SuccessfulExit</key>
-    <false/>
-    <key>Crashed</key>
-    <true/>
-  </dict>
 </dict>
 </plist>

--- a/distribution/launchd/com.openhost.openhostd.plist
+++ b/distribution/launchd/com.openhost.openhostd.plist
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  openhost launchd property list.
+
+  User-agent install (recommended for a personal home server):
+    ~/Library/LaunchAgents/com.openhost.openhostd.plist
+
+  System-daemon install (all users, loaded at boot):
+    /Library/LaunchDaemons/com.openhost.openhostd.plist
+    Also uncomment the <key>UserName</key> block below and set it to
+    the unprivileged user that should run the daemon.
+
+  See distribution/README.md for full install and uninstall commands.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.openhost.openhostd</string>
+
+  <!-- Restart on boot (or at login for a user agent) and whenever the
+       daemon exits. KeepAlive's default value re-runs on any exit;
+       the ExitType variant below limits that to non-clean exits so
+       a manual `launchctl unload` doesn't get fought back. -->
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <!-- Where the daemon finds its config and where it writes state.
+       Edit to taste; `~` does NOT expand inside a plist, so you need
+       absolute paths. The defaults match the install instructions
+       in distribution/README.md. -->
+  <key>WorkingDirectory</key>
+  <string>/usr/local/var/openhost</string>
+
+  <!-- Logs. The daemon writes tracing output to stderr by default; we
+       redirect both streams here so the operator has one place to
+       look. Rotate with newsyslog(8) if they grow. -->
+  <key>StandardOutPath</key>
+  <string>/usr/local/var/log/openhost/openhostd.log</string>
+  <key>StandardErrorPath</key>
+  <string>/usr/local/var/log/openhost/openhostd.err</string>
+
+  <!-- Uncomment and set for a system-daemon install. Leaving this out
+       means launchd runs the process as the user that `launchctl
+       load`ed the plist — fine for a user agent. -->
+  <!--
+  <key>UserName</key>
+  <string>openhost</string>
+  <key>GroupName</key>
+  <string>openhost</string>
+  -->
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>OPENHOST_CONFIG</key>
+    <string>/usr/local/etc/openhost/daemon.toml</string>
+    <key>RUST_LOG</key>
+    <string>info</string>
+  </dict>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/openhostd</string>
+    <string>run</string>
+  </array>
+
+  <!-- Back-off on crashloop. launchd enforces a 10-second minimum
+       between respawns by default; ThrottleInterval makes that
+       explicit and large enough that a misconfigured host can't
+       hammer public Pkarr relays. -->
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <!-- Network prerequisites: wait until at least one interface has
+       an IPv4/IPv6 route before starting the daemon. Avoids noisy
+       initial-publish warnings during boot. -->
+  <key>KeepAlive</key>
+  <dict>
+    <key>NetworkState</key>
+    <true/>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+</dict>
+</plist>

--- a/distribution/systemd/openhostd.service
+++ b/distribution/systemd/openhostd.service
@@ -1,0 +1,63 @@
+[Unit]
+Description=openhost daemon
+Documentation=https://kaicoder03.github.io/openhost/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=openhost
+Group=openhost
+WorkingDirectory=/var/lib/openhost
+Environment=OPENHOST_CONFIG=/etc/openhost/daemon.toml
+Environment=RUST_LOG=info
+ExecStart=/usr/local/bin/openhostd run
+
+# Restart policy: restart on failure (panic, sigkill, non-zero exit),
+# but back off aggressively so a crashloop can't hammer public Pkarr
+# relays from a misconfigured host.
+Restart=on-failure
+RestartSec=5s
+StartLimitBurst=3
+StartLimitIntervalSec=60s
+
+# Resource ceilings. The daemon is small — ~15 MB resident in practice —
+# but it buffers full HTTP responses, so MemoryHigh accommodates a few
+# concurrent forwards. Raise if you expose a service that streams
+# larger bodies.
+MemoryHigh=128M
+MemoryMax=256M
+TasksMax=64
+
+# Security hardening. Each of these restricts kernel surface openhostd
+# has no reason to touch. Leave in place unless a change breaks
+# functionality (in which case, prefer a tighter override to disabling
+# the whole directive).
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectClock=true
+ProtectHostname=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+
+# State + config paths the daemon legitimately reads and writes.
+ReadWritePaths=/var/lib/openhost
+ReadOnlyPaths=/etc/openhost
+
+# Network: the daemon needs the public internet (Pkarr relays, DHT,
+# and WebRTC peers). If you route via a restrictive firewall, allow
+# outbound UDP on ephemeral ports + HTTPS to the pkarr relay list
+# published in your daemon.toml.
+IPAddressAllow=any
+
+[Install]
+WantedBy=multi-user.target

--- a/site/src/content/docs/guides/install.md
+++ b/site/src/content/docs/guides/install.md
@@ -1,21 +1,69 @@
 ---
 title: Install openhost
-description: Build the daemon and client binaries from source; distributable packages are on the roadmap.
+description: Download pre-built binaries or build from source.
 sidebar:
   order: 1
 ---
 
-openhost is pre-release software and does not yet ship distributable binaries. For `v0.1.0` you build from source; the Rust toolchain handles the rest.
+As of `v0.3.0+` (once the first release fires the binary workflow) you have two options: grab a pre-built archive from GitHub Releases, or build from source. Pre-built is the fast path.
 
-## Prerequisites
+## Pre-built binaries
+
+Download the archive for your platform from the [GitHub Releases page](https://github.com/kaicoder03/openhost/releases/latest):
+
+| Platform | Archive |
+|---|---|
+| Linux x86_64 | `openhost-linux-x86_64.tar.gz` |
+| macOS Apple Silicon (M-series) | `openhost-macos-aarch64.tar.gz` |
+| macOS Intel | `openhost-macos-x86_64.tar.gz` |
+| Windows x86_64 | `openhost-windows-x86_64.zip` |
+
+Each archive carries three binaries (`openhostd`, `openhost-dial`, `openhost-resolve`), the `CHANGELOG.md`, both `LICENSE-*` files, and the `distribution/` tree (systemd unit + launchd plist + install notes).
+
+```bash
+# Linux / macOS
+curl -sSL https://github.com/kaicoder03/openhost/releases/latest/download/openhost-linux-x86_64.tar.gz \
+  | tar xz
+install -m 0755 openhost-linux-x86_64/openhost* ~/.local/bin/
+
+# Windows PowerShell
+Invoke-WebRequest -Uri https://github.com/kaicoder03/openhost/releases/latest/download/openhost-windows-x86_64.zip -OutFile openhost.zip
+Expand-Archive openhost.zip -DestinationPath .
+```
+
+Verify:
+
+```bash
+openhostd --version
+openhost-dial --version
+openhost-resolve --version
+```
+
+All three should print the same version, matching the release tag.
+
+### Running as a service
+
+- **Linux (systemd):** copy `distribution/systemd/openhostd.service` into `/etc/systemd/system/` and follow the [distribution README](https://github.com/kaicoder03/openhost/blob/main/distribution/README.md).
+- **macOS (launchd):** copy `distribution/launchd/com.openhost.openhostd.plist` to `~/Library/LaunchAgents/`.
+- **Windows:** run `openhostd run` from a terminal for now; a Windows Service wrapper is tracked as a future ROADMAP item.
+
+### Homebrew
+
+Coming soon — the tap is blocked on the first automated release firing. Track `kaicoder03/homebrew-openhost` for progress.
+
+## Build from source
+
+Fallback when pre-built isn't an option: a supported platform that isn't on the pre-built list, or a build-from-HEAD for pre-release work.
+
+### Prerequisites
 
 - **Rust 1.90** (stable). The repository pins this version via `rust-toolchain.toml`, so `rustup` fetches it automatically the first time you build.
 - **pnpm** (only if you also want to work on this documentation site).
-- **macOS, Linux, or Windows**. The daemon has been exercised on all three during v0.1 development; binary-release artifacts for each land in a future release.
+- **macOS, Linux, or Windows**. The daemon has been exercised on all three.
 
 Install `rustup` from [rustup.rs](https://rustup.rs/) if you don't have it; no other Rust setup is required.
 
-## Clone and build
+### Clone and build
 
 ```bash
 git clone https://github.com/kaicoder03/openhost.git
@@ -47,24 +95,14 @@ install -m 0755 target/release/openhost-dial    ~/.local/bin/
 install -m 0755 target/release/openhost-resolve ~/.local/bin/
 ```
 
-## Verify
-
-```bash
-openhostd --version
-openhost-dial --version
-openhost-resolve --version
-```
-
-All three should print `0.1.0`.
-
-## Platform notes
+### Platform notes
 
 - **macOS.** The build uses a forked [`webrtc`](https://github.com/kaicoder03/webrtc) crate pinned via the workspace's `[patch.crates-io]`. Apple's toolchain occasionally lags on `rustls`/`ring` ABI compatibility; if a build fails, a `rustup toolchain update stable` is usually enough.
 - **Linux.** No distro-specific packages required beyond a working C toolchain for `ring`'s assembly fast paths (`build-essential` on Debian/Ubuntu, `base-devel` on Arch).
 - **Windows.** Build works under both MSVC and GNU toolchains; MSVC gets better download sizes. The pair-DB file watcher uses ReadDirectoryChangesW under the hood; no extra configuration needed.
 
-## Coming later
+## What's next
 
-Distributable binaries, a Homebrew tap, a systemd unit, and a launchd plist are tracked in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md) under Phase 3+. Until those land, "install from source" is the supported path.
+Homebrew tap, Windows Service wrapper, and musl / Alpine Linux builds are tracked in [`ROADMAP.md`](https://github.com/kaicoder03/openhost/blob/main/ROADMAP.md). Binary releases for Linux x86_64, macOS (aarch64 + x86_64), and Windows x86_64 fire automatically on every `v*` tag via `.github/workflows/release.yml`.
 
 With the binaries in place, head to [Quickstart](/openhost/guides/quickstart/) to bring up a reachable service.


### PR DESCRIPTION
## Summary

Phase 3 PR #3 of 4. Ships the release infrastructure so future `v*` tags produce downloadable binaries for Linux / macOS / Windows. Also lands service-manager files (systemd unit, launchd plist) so operators can run the daemon as a managed service without writing their own.

## What's in the box

### GitHub Actions — `.github/workflows/release.yml`

- Fires on `v*` tag push, plus `workflow_dispatch` (to backfill artifacts onto `v0.2.0` if we want).
- Four parallel builds on native runners — sidesteps cross-compile pain with the webrtc fork + `ring`:
  - `ubuntu-latest` → `x86_64-unknown-linux-gnu`
  - `macos-latest` → `aarch64-apple-darwin` (native M-series)
  - `macos-latest` → `x86_64-apple-darwin` (via `--target`)
  - `windows-latest` → `x86_64-pc-windows-msvc`
- Each archive carries all three binaries (\`openhostd\`, \`openhost-dial\`, \`openhost-resolve\`) + \`CHANGELOG.md\` + both \`LICENSE-*\` files + \`examples/\` + \`distribution/\`.
- Publish step slices the matching \`## [X.Y.Z]\` CHANGELOG section for the release body. \`fail_on_unmatched_files: true\` guards against the glob missing.

### \`distribution/\` tree

- **\`systemd/openhostd.service\`** — resource ceilings, full sandboxing suite (\`ProtectSystem=strict\`, \`PrivateTmp=true\`, \`MemoryDenyWriteExecute=true\`, …), backoff policy that prevents crashloops from hammering public Pkarr relays.
- **\`launchd/com.openhost.openhostd.plist\`** — user-agent mode by default; system-daemon instructions inline. KeepAlive on crash + network state; ThrottleInterval=10.
- **\`README.md\`** — install + uninstall commands for both platforms, plus a security-posture note.

### Docs

- \`site/guides/install.md\` reshuffled: Pre-built binaries section leads with a platform-archive table + curl/PowerShell examples; Build-from-source moves to a fallback section; "Coming later" block deleted.
- \`README.md\` gets a one-line pointer at the Releases page above Building from source.

## Test plan

- [x] \`cargo check --workspace\` clean (no code changes).
- [x] \`cd site && pnpm build\` regenerates cleanly (10 pages).
- [x] YAML eyeballed against the existing \`rust.yml\` / \`pages.yml\` conventions.
- [ ] **End-to-end workflow verification** can only happen on the next tag push. The \`workflow_dispatch\` trigger lets us smoke-test against v0.2.0 retroactively after this lands if we want.

## Spec compatibility

No spec changes.

## Out of scope

- Homebrew tap — needs a separate \`homebrew-openhost\` repo + formula with pinned SHA256s against real artifacts. Easier to land once this workflow has run once.
- macOS notarization / Windows code signing — paid developer certs.
- ARM Linux, musl / Alpine Linux — cross-compile or paid runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)