### PR TITLE
feat(daemon): WebSocket per-path allowlist (policy layer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ once it reaches a tagged release.
 
 ## [Unreleased]
 
+### Added (PR #24, WebSocket allowlist policy layer)
+
+- **New `[forward.websockets]` config section** with `allowed_paths: Vec<String>`. Each entry is an exact path match against the request URI (query string stripped); a single-entry `"*"` wildcard is accepted for development. Omitting the section preserves v0.2 behaviour (every `Upgrade: websocket` rejected). A present-but-empty `allowed_paths` is rejected at `Config::validate` time.
+- **Three-way WebSocket decision tree in the forwarder.** `sanitize_request_headers` now takes the websocket config + request path and classifies inbound upgrade requests:
+  - Path on the allowlist → **new `ForwardError::WebSocketPending { path }`** variant. The operator's config is correct; the daemon version at hand just hasn't shipped the tunnel implementation yet. The error message names the path so operators can distinguish "config is good, wait for the tunnel release" from "config is wrong".
+  - Path absent OR no allowlist configured → `ForwardError::WebSocketUnsupported` (existing). Message updated to cite `forward.websockets.allowed_paths` so operators know where to configure the fix.
+  - Anything else → normal HTTP forward (unchanged).
+- **Spec §4.2** added — documents the policy surface, conformance requirements for the daemon, and explicitly marks `0x20 WS_UPGRADE` and `0x21 WS_FRAME` as reserved for the tunnel implementation (policy-only daemons **MUST NOT** emit them).
+- 5 new unit tests in `forward::tests`: matching allowlist returns pending; query-string stripping before match; wildcard matches any path; path outside allowlist is unsupported; present-but-empty config fails closed.
+
+### Out of scope (deferred to a follow-up PR)
+
+Bidirectional WebSocket tunnel — hyper upgrade path on the forwarder, listener `WebSocket` state machine, `tokio-tungstenite`-backed integration test, client `OpenhostSession::upgrade_websocket()` ergonomic API. Operators can land their `[forward.websockets]` config against this release; the tunnel lands when the follow-up PR merges, with no config-schema changes required.
+
 ### Added (PR #23, distributable binaries)
 
 - **New `.github/workflows/release.yml`** — fires on `v*` tag push (or `workflow_dispatch` for backfills). Builds `openhostd`, `openhost-dial`, `openhost-resolve` on native GitHub runners for Linux x86_64, macOS aarch64, macOS x86_64, and Windows x86_64; strips, packs (`.tar.gz` / `.zip`), and uploads to the matching GitHub release via `softprops/action-gh-release`. Release body is sliced out of the matching `## [X.Y.Z]` section of `CHANGELOG.md` by a small awk filter; `fail_on_unmatched_files: true` guards against a silent no-op on a misconfigured glob.

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -99,6 +99,7 @@ fn daemon_config(tmp: &TempDir, watched: Vec<String>, upstream_port: Option<u16>
             target: Some(format!("http://127.0.0.1:{p}")),
             host_override: None,
             max_body_bytes: 1024 * 1024,
+            websockets: None,
         }),
         log: LogConfig::default(),
         pairing: Default::default(),

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -235,6 +235,13 @@ impl WebSocketConfig {
     /// Whether `request_path` is allowed to upgrade to WebSocket.
     /// `request_path` may include a query string (`?…`); only the path
     /// component is matched.
+    ///
+    /// Matching is strict byte equality after query-string stripping:
+    /// `/foo` and `/foo/` are distinct entries. WebSocket endpoints
+    /// conventionally have no trailing slash, so operators list them
+    /// in canonical form. If a future upstream requires prefix or
+    /// glob matching, this is the place to add it — no wire-format
+    /// implications.
     #[must_use]
     pub fn is_allowed(&self, request_path: &str) -> bool {
         let path = request_path.split('?').next().unwrap_or(request_path);

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -203,6 +203,45 @@ pub struct ForwardConfig {
     /// [`DEFAULT_MAX_BODY_BYTES`] (16 MiB).
     #[serde(default = "default_max_body_bytes")]
     pub max_body_bytes: usize,
+
+    /// WebSocket tunneling policy (spec §4.2, PR #24). Absent means
+    /// every `Upgrade: websocket` request is rejected — the current
+    /// v0.2 behaviour. Setting a non-empty [`WebSocketConfig::allowed_paths`]
+    /// signals intent to allow WebSocket upgrades for those paths; the
+    /// actual bidirectional tunnel lands in a follow-up PR, at which
+    /// point this same config becomes live without any schema change.
+    #[serde(default)]
+    pub websockets: Option<WebSocketConfig>,
+}
+
+/// Per-path WebSocket tunnel allowlist (spec §4.2).
+///
+/// The allowlist is matched against the HTTP request path (the part
+/// before `?`). A single entry of `"*"` matches every path and is
+/// intended for development — production deployments should enumerate
+/// paths explicitly. An empty `allowed_paths` vector is a configuration
+/// error (rejected by [`Config::validate`]); omit the whole
+/// `[forward.websockets]` section to disable tunnels entirely.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct WebSocketConfig {
+    /// Exact path match list (optionally containing the wildcard `"*"`).
+    /// Paths are compared byte-for-byte against the request's URI-path
+    /// component; query strings are stripped before comparison.
+    pub allowed_paths: Vec<String>,
+}
+
+impl WebSocketConfig {
+    /// Whether `request_path` is allowed to upgrade to WebSocket.
+    /// `request_path` may include a query string (`?…`); only the path
+    /// component is matched.
+    #[must_use]
+    pub fn is_allowed(&self, request_path: &str) -> bool {
+        let path = request_path.split('?').next().unwrap_or(request_path);
+        self.allowed_paths
+            .iter()
+            .any(|pat| pat == "*" || pat == path)
+    }
 }
 
 /// Default value for [`ForwardConfig::max_body_bytes`]. Chosen to match
@@ -305,6 +344,16 @@ impl Config {
             }
             if forward.max_body_bytes == 0 {
                 return Err(ConfigError::Invalid("forward.max_body_bytes must be > 0").into());
+            }
+            if let Some(ws) = &forward.websockets {
+                if ws.allowed_paths.is_empty() {
+                    return Err(ConfigError::Invalid(
+                        "forward.websockets.allowed_paths must have at least one entry \
+                         (use [\"*\"] to allow any path, or remove the [forward.websockets] \
+                         section entirely to disable WebSocket tunneling)",
+                    )
+                    .into());
+                }
             }
         }
         Ok(())

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -185,11 +185,24 @@ pub enum ForwardError {
         cap: usize,
     },
 
-    /// Request asserts `Upgrade: websocket`; per spec §4 line 162,
-    /// websockets are gated by explicit per-path config and this PR
-    /// doesn't ship that gating yet.
-    #[error("Upgrade: websocket is not supported by this daemon (gating is a future PR)")]
+    /// Request asserts `Upgrade: websocket` but no `[forward.websockets]`
+    /// allowlist is configured, or the target path is not on it. Operators
+    /// who want to allow WebSocket upgrades per spec §4.2 must add the
+    /// path (or `"*"`) to `forward.websockets.allowed_paths`.
+    #[error("Upgrade: websocket rejected — target path not on forward.websockets.allowed_paths")]
     WebSocketUnsupported,
+
+    /// Request asserts `Upgrade: websocket` AND the target path IS on
+    /// the configured allowlist, but the daemon version at hand hasn't
+    /// shipped the actual tunnel yet. Scope-B groundwork in PR #24;
+    /// PR #25 implements the bidirectional byte proxy. Operators who
+    /// see this error in the log can stop checking their config and
+    /// wait for the next release.
+    #[error("Upgrade: websocket for path {path:?} is allow-listed but the tunnel implementation is pending (tracked in ROADMAP.md)")]
+    WebSocketPending {
+        /// The request path the client attempted to upgrade on.
+        path: String,
+    },
 
     /// Upstream refused the connection, timed out, or returned an
     /// unrecoverable protocol error.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -22,7 +22,7 @@
 //! binary framing), and `Content-Length` rewritten to match the
 //! buffered body length.
 
-use crate::config::ForwardConfig;
+use crate::config::{ForwardConfig, WebSocketConfig};
 use crate::error::ForwardError;
 use bytes::Bytes;
 use http::header::{HeaderName, HeaderValue};
@@ -91,6 +91,9 @@ pub struct Forwarder {
     /// [`ForwardError::BodyTooLarge`] before any upstream bytes are
     /// sent.
     max_body_bytes: usize,
+    /// Optional WebSocket tunnel allowlist. `None` preserves the
+    /// pre-PR-24 behaviour of rejecting every `Upgrade: websocket`.
+    websockets: Option<WebSocketConfig>,
 }
 
 impl Forwarder {
@@ -131,6 +134,7 @@ impl Forwarder {
             host_override,
             client,
             max_body_bytes: cfg.max_body_bytes,
+            websockets: cfg.websockets.clone(),
         }))
     }
 
@@ -156,7 +160,12 @@ impl Forwarder {
         }
 
         let (method, path, mut headers) = parse_request_head(head_payload)?;
-        sanitize_request_headers(&mut headers, &self.host_override)?;
+        sanitize_request_headers(
+            &mut headers,
+            &self.host_override,
+            self.websockets.as_ref(),
+            &path,
+        )?;
 
         // Build the outbound URI by combining the target origin with the
         // request path. The path comes from the client verbatim; no
@@ -287,17 +296,37 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
     Ok((method, path, headers))
 }
 
-/// Strip hop-by-hop + provenance headers, reject websocket upgrades,
-/// and pin `Host` to the configured override.
+/// Strip hop-by-hop + provenance headers, reject or defer websocket
+/// upgrades based on the configured allowlist, and pin `Host` to the
+/// configured override.
+///
+/// WebSocket decision tree (spec §4.2):
+/// - `Upgrade: websocket` + path on `websockets.allowed_paths` →
+///   [`ForwardError::WebSocketPending`]. Scope-B daemons can't tunnel
+///   yet, but the operator's config is correct and the log line tells
+///   them so.
+/// - `Upgrade: websocket` + no allowlist, or path not on the
+///   allowlist → [`ForwardError::WebSocketUnsupported`]. The operator
+///   needs to update their config, or the upstream is asking for an
+///   upgrade that shouldn't be forwarded in the first place.
 fn sanitize_request_headers(
     headers: &mut HeaderMap,
     host_override: &str,
+    websockets: Option<&WebSocketConfig>,
+    request_path: &str,
 ) -> Result<(), ForwardError> {
-    // Reject websocket upgrades BEFORE stripping `Upgrade`.
+    // Classify websocket upgrades BEFORE stripping `Upgrade` as
+    // hop-by-hop. Keeps both branches reachable: config absent =>
+    // unconditional reject; config present => allowlist check.
     if let Some(upgrade) = headers.get(http::header::UPGRADE) {
         let v = upgrade.to_str().unwrap_or("").trim();
         if v.eq_ignore_ascii_case("websocket") {
-            return Err(ForwardError::WebSocketUnsupported);
+            return match websockets {
+                Some(cfg) if cfg.is_allowed(request_path) => Err(ForwardError::WebSocketPending {
+                    path: request_path.to_string(),
+                }),
+                _ => Err(ForwardError::WebSocketUnsupported),
+            };
         }
     }
 
@@ -445,7 +474,7 @@ mod tests {
     #[test]
     fn sanitize_strips_all_hop_by_hop_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        sanitize_request_headers(&mut h, "127.0.0.1:8080", None, "/").unwrap();
         for name in HOP_BY_HOP_HEADERS {
             assert!(
                 !h.contains_key(*name),
@@ -457,7 +486,7 @@ mod tests {
     #[test]
     fn sanitize_strips_all_provenance_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        sanitize_request_headers(&mut h, "127.0.0.1:8080", None, "/").unwrap();
         for name in PROVENANCE_HEADERS {
             assert!(
                 !h.contains_key(*name),
@@ -469,7 +498,7 @@ mod tests {
     #[test]
     fn sanitize_preserves_benign_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        sanitize_request_headers(&mut h, "127.0.0.1:8080", None, "/").unwrap();
         assert_eq!(
             h.get("x-custom").map(|v| v.to_str().unwrap()),
             Some("keep-me")
@@ -479,7 +508,7 @@ mod tests {
     #[test]
     fn sanitize_pins_host() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        sanitize_request_headers(&mut h, "127.0.0.1:8080", None, "/").unwrap();
         assert_eq!(
             h.get(http::header::HOST).map(|v| v.to_str().unwrap()),
             Some("127.0.0.1:8080"),
@@ -492,7 +521,70 @@ mod tests {
     fn sanitize_rejects_websocket_upgrade() {
         let mut h = HeaderMap::new();
         h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
-        let err = sanitize_request_headers(&mut h, "x").unwrap_err();
+        let err = sanitize_request_headers(&mut h, "x", None, "/").unwrap_err();
+        assert!(matches!(err, ForwardError::WebSocketUnsupported));
+    }
+
+    fn ws_cfg(paths: &[&str]) -> WebSocketConfig {
+        WebSocketConfig {
+            allowed_paths: paths.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn sanitize_websocket_with_matching_allowlist_returns_pending() {
+        let mut h = HeaderMap::new();
+        h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        let cfg = ws_cfg(&["/ws"]);
+        let err = sanitize_request_headers(&mut h, "x", Some(&cfg), "/ws").unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::WebSocketPending { ref path } if path == "/ws"
+        ));
+    }
+
+    #[test]
+    fn sanitize_websocket_strips_query_before_matching() {
+        let mut h = HeaderMap::new();
+        h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        let cfg = ws_cfg(&["/ws"]);
+        let err = sanitize_request_headers(&mut h, "x", Some(&cfg), "/ws?client=abc").unwrap_err();
+        assert!(
+            matches!(err, ForwardError::WebSocketPending { ref path } if path == "/ws?client=abc"),
+            "path in the error message preserves the query string for operator log clarity; \
+             the ALLOWLIST match strips it, not the error payload",
+        );
+    }
+
+    #[test]
+    fn sanitize_websocket_wildcard_matches_any_path() {
+        let mut h = HeaderMap::new();
+        h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        let cfg = ws_cfg(&["*"]);
+        let err = sanitize_request_headers(&mut h, "x", Some(&cfg), "/anything/deeply/nested")
+            .unwrap_err();
+        assert!(matches!(err, ForwardError::WebSocketPending { .. }));
+    }
+
+    #[test]
+    fn sanitize_websocket_outside_allowlist_is_unsupported() {
+        let mut h = HeaderMap::new();
+        h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        let cfg = ws_cfg(&["/ws"]);
+        let err = sanitize_request_headers(&mut h, "x", Some(&cfg), "/elsewhere").unwrap_err();
+        assert!(matches!(err, ForwardError::WebSocketUnsupported));
+    }
+
+    #[test]
+    fn sanitize_websocket_with_empty_config_option_is_unsupported() {
+        // Belt-and-braces: even with Some(&cfg) where cfg.allowed_paths
+        // is empty, no path can match. Config::validate rejects this
+        // upstream, but the sanitizer should fail-closed if a caller
+        // somehow constructs one.
+        let mut h = HeaderMap::new();
+        h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
+        let cfg = ws_cfg(&[]);
+        let err = sanitize_request_headers(&mut h, "x", Some(&cfg), "/ws").unwrap_err();
         assert!(matches!(err, ForwardError::WebSocketUnsupported));
     }
 
@@ -504,7 +596,7 @@ mod tests {
         // just strip it as hop-by-hop so the upstream never sees it.
         let mut h = HeaderMap::new();
         h.insert(http::header::UPGRADE, HeaderValue::from_static("h2c"));
-        sanitize_request_headers(&mut h, "x").unwrap();
+        sanitize_request_headers(&mut h, "x", None, "/").unwrap();
         assert!(!h.contains_key(http::header::UPGRADE));
     }
 
@@ -581,6 +673,7 @@ mod tests {
             target: None,
             host_override: None,
             max_body_bytes: 1024,
+            websockets: None,
         };
         assert!(Forwarder::from_config(&cfg).unwrap().is_none());
     }
@@ -591,6 +684,7 @@ mod tests {
             target: Some("https://example.com".into()),
             host_override: None,
             max_body_bytes: 1024,
+            websockets: None,
         };
         // `Forwarder` isn't `Debug`, so `unwrap_err()` won't compile —
         // pattern-match the `Result` instead.
@@ -604,6 +698,7 @@ mod tests {
             target: Some("not a url".into()),
             host_override: None,
             max_body_bytes: 1024,
+            websockets: None,
         };
         let result = Forwarder::from_config(&cfg);
         assert!(matches!(result, Err(ForwardError::TargetParse(_))));
@@ -615,6 +710,7 @@ mod tests {
             target: Some("http://127.0.0.1:8080".into()),
             host_override: None,
             max_body_bytes: 1024,
+            websockets: None,
         };
         let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
         assert_eq!(fwd.host_override, "127.0.0.1:8080");
@@ -626,6 +722,7 @@ mod tests {
             target: Some("http://127.0.0.1:8080".into()),
             host_override: Some("my-service.local".into()),
             max_body_bytes: 1024,
+            websockets: None,
         };
         let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
         assert_eq!(fwd.host_override, "my-service.local");

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -46,6 +46,7 @@ fn test_config(dir: &TempDir, upstream_port: u16) -> Config {
             target: Some(format!("http://127.0.0.1:{upstream_port}")),
             host_override: None,
             max_body_bytes: 1024 * 1024,
+            websockets: None,
         }),
         log: LogConfig::default(),
         pairing: Default::default(),

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -339,6 +339,28 @@ When forwarding a request to the loopback HTTP service, the daemon **MUST**:
 - Set the `Host` header to the value configured for the target service.
 - Reject requests whose framing violates the ABNF above (respond with a 0xF0 ERROR frame and tear down the channel).
 
+### 4.2 WebSocket tunnel (policy layer)
+
+Daemons **MAY** be configured to tunnel RFC 6455 WebSocket upgrades for a finite set of upstream paths. The policy surface is the `[forward.websockets]` TOML section:
+
+```toml
+[forward.websockets]
+# Exact path matches (byte-identical before any query string) OR the
+# single-entry wildcard "*". Omitting this section entirely disables
+# WebSocket tunneling — the forwarder rejects every `Upgrade: websocket`
+# request, preserving the pre-v0.2 behaviour.
+allowed_paths = ["/api/websocket", "/live"]
+```
+
+Conformance requirements for the daemon:
+
+- If no `[forward.websockets]` section is configured, **any** `Upgrade: websocket` request **MUST** be rejected at the forwarder boundary (the daemon replies with an application-layer 502 surfaced through the openhost frame codec).
+- If a section is configured but `allowed_paths` is empty, the daemon **MUST** reject the configuration at load time.
+- If a request's path (stripped of its query string) is not on `allowed_paths`, the request **MUST** be rejected exactly as above.
+- The wildcard `"*"` matches every path; operators **SHOULD** enumerate paths explicitly in production.
+
+The **tunnel implementation itself** — the bidirectional byte proxy between the openhost data channel and the upstream TCP socket after a successful 101 response — is the next line item in [`ROADMAP.md`](../ROADMAP.md) post-v0.3. Daemon versions that implement the policy layer but not the tunnel **MUST** distinguish the two cases in diagnostics: a request with a correctly-configured allowlist entry that would have been tunneled surfaces as a "pending" error, so operators can stop checking their config and wait for the tunnel-capable release. The `0x20 WS_UPGRADE` and `0x21 WS_FRAME` frame types above are reserved for the tunnel implementation and **MUST NOT** appear on the wire from policy-only daemons.
+
 ## 5. Error handling
 
 A recipient that cannot decode a frame, or that receives a frame type it does not implement, **MUST** send a 0xF0 ERROR frame with a short diagnostic string and then tear down the data channel.


### PR DESCRIPTION
## Summary

Last Phase 3 PR. Ships the **policy layer** for per-path WebSocket tunneling — operators configure \`[forward.websockets]\` against this release and the config keeps working unchanged when the tunnel implementation lands in a follow-up PR.

### Why policy-first

The full bidirectional tunnel is substantial (hyper upgrade path + listener state-machine change + `tokio-tungstenite` test harness + client ergonomic API). Splitting the policy layer out has two concrete wins:

1. **Operators can land config today.** A Jellyfin / HASS operator adds `allowed_paths = ["/api/websocket"]` to their \`daemon.toml\` now; when the tunnel PR merges, WebSocket just starts working.
2. **Diagnostics distinguish the two failure modes.** A correctly-configured allowlist that *would have* been tunneled surfaces as \`WebSocketPending\` (with the path in the log). A misconfigured allowlist or an absent config surfaces as \`WebSocketUnsupported\` (with a pointer at \`forward.websockets.allowed_paths\`). Operators never mistake "config is wrong" for "feature not implemented".

## What ships

- New \`[forward.websockets]\` config section with \`allowed_paths: Vec<String>\`. \`"*"\` wildcard accepted for dev; \`Config::validate\` rejects a present-but-empty list.
- New \`ForwardError::WebSocketPending { path }\` variant (distinct from the existing \`WebSocketUnsupported\`).
- \`sanitize_request_headers\` grows a three-way decision tree: path on allowlist → Pending; path absent or no config → Unsupported; non-WS upgrade or plain request → continue unchanged.
- Spec §4.2 documents the policy surface, conformance requirements, and that frame types \`0x20 WS_UPGRADE\` / \`0x21 WS_FRAME\` are reserved for the tunnel implementation (policy-only daemons MUST NOT emit them).
- 5 new unit tests cover the decision tree; 2 existing \`ForwardConfig\` literal call-sites updated for the new field.

## Test plan

- [x] \`cargo fmt --all --check\` clean.
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean.
- [x] \`cargo test --workspace --all-features --no-fail-fast\`: **287 tests pass**, 0 failures (+5 over PR #22's 282).

## Spec compatibility

Additive spec change (new §4.2). No wire-format break. Existing v0.2/v0.3 implementations continue to work unchanged; the new config surface is opt-in.

## Out of scope (deferred to a follow-up PR)

- Bidirectional byte tunnel (hyper upgrade integration + listener WebSocket state machine).
- \`tokio-tungstenite\` integration test.
- Client ergonomic \`OpenhostSession::upgrade_websocket()\` API.
- \`openhost-dial --ws\` subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)