### PR TITLE
feat(extension): browser end-to-end dial (oh://) — PR #28.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde-wasm-bindgen",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,6 +2139,7 @@ dependencies = [
  "js-sys",
  "openhost-core",
  "openhost-pkarr",
+ "pkarr",
  "rand 0.8.6",
  "serde",
  "serde-wasm-bindgen",

--- a/crates/openhost-client/src/binding.rs
+++ b/crates/openhost-client/src/binding.rs
@@ -126,6 +126,15 @@ pub enum ClientBindingError {
     #[error("DTLS exporter failed: {0}")]
     Exporter(String),
 
+    /// CLI dialers advertise [`openhost_pkarr::BindingMode::Exporter`]
+    /// in their offer plaintext and MUST NOT negotiate down to the
+    /// `CertFp` variant a browser peer would use. If a future caller
+    /// mis-configures the dialer to emit a weaker binding this error
+    /// surfaces and the dial aborts. See `spec/04-security.md §4.1`
+    /// (channel-binding modes) and the negotiation rules there.
+    #[error("CLI dialer refused to advertise non-Exporter binding mode {0:?}")]
+    DowngradeRejected(openhost_pkarr::BindingMode),
+
     /// The exporter returned the wrong number of bytes.
     #[error("DTLS exporter returned {0} bytes, expected {EXPORTER_SECRET_LEN}")]
     ExporterLength(usize),

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -318,18 +318,20 @@ impl Dialer {
     /// the client's own Ed25519 pubkey carrying the `_offer-<host-hash>`
     /// TXT.
     pub async fn publish_offer(&mut self, daemon_pk: &PublicKey, offer_sdp: &str) -> Result<()> {
-        // CLI always advertises `Exporter`. A CLI that accepted
-        // `CertFp` from a browser-speaking daemon would silently
-        // downgrade its channel binding to the public-cert form; CLI
-        // code paths use `webrtc-rs` with RFC 5705 exporter support
-        // natively, so there's no reason to ever accept the downgrade.
-        // PR #28.3's CLI downgrade-rejection (see
-        // `crates/openhost-client/src/binding.rs`) enforces this on
-        // the answer-parse side.
+        // CLI dialers advertise `Exporter` unconditionally. CertFp is
+        // the browser-only variant from `spec/04-security.md §4.1`; a
+        // CLI that silently downgraded to CertFp would reduce its
+        // channel binding to a value the cert-pin alone already
+        // covers. The constant below is load-bearing — refactors that
+        // thread a runtime-chosen mode into this call site MUST route
+        // through [`assert_cli_binding_mode`] so the CLI cannot ship
+        // a weaker binding than the spec mandates.
+        const CLI_BINDING_MODE: openhost_pkarr::BindingMode = openhost_pkarr::BindingMode::Exporter;
+        assert_cli_binding_mode(CLI_BINDING_MODE)?;
         let plaintext = OfferPlaintext {
             client_pk: self.identity.public_key(),
             offer_sdp: offer_sdp.to_string(),
-            binding_mode: openhost_pkarr::BindingMode::Exporter,
+            binding_mode: CLI_BINDING_MODE,
         };
         let mut rng = rand::rngs::OsRng;
         let offer = OfferRecord::seal(&mut rng, daemon_pk, &plaintext)
@@ -595,4 +597,43 @@ async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<()> {
         .await
         .map_err(|e| ClientError::WebRtcSetup(format!("data channel send: {e}")))?;
     Ok(())
+}
+
+/// Spec §4.1 (`spec/04-security.md`) forbids CLI clients from
+/// advertising a channel-binding mode weaker than
+/// [`openhost_pkarr::BindingMode::Exporter`]. This is the one-line
+/// gate every CLI code path that constructs an `OfferPlaintext` MUST
+/// route through so a refactor can't silently ship a weaker binding.
+/// Browsers run a different code path (the WASM shim) and are NOT
+/// subject to this check — they're mandated to use `CertFp`.
+fn assert_cli_binding_mode(mode: openhost_pkarr::BindingMode) -> Result<()> {
+    match mode {
+        openhost_pkarr::BindingMode::Exporter => Ok(()),
+        other => Err(ClientError::ChannelBinding(
+            ClientBindingError::DowngradeRejected(other),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod downgrade_tests {
+    use super::*;
+
+    #[test]
+    fn cli_rejects_cert_fp_downgrade() {
+        let err = assert_cli_binding_mode(openhost_pkarr::BindingMode::CertFp)
+            .expect_err("CertFp must be refused on the CLI path");
+        assert!(matches!(
+            err,
+            ClientError::ChannelBinding(ClientBindingError::DowngradeRejected(
+                openhost_pkarr::BindingMode::CertFp,
+            ))
+        ));
+    }
+
+    #[test]
+    fn cli_accepts_exporter() {
+        assert_cli_binding_mode(openhost_pkarr::BindingMode::Exporter)
+            .expect("Exporter is the CLI's only supported mode");
+    }
 }

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -318,9 +318,18 @@ impl Dialer {
     /// the client's own Ed25519 pubkey carrying the `_offer-<host-hash>`
     /// TXT.
     pub async fn publish_offer(&mut self, daemon_pk: &PublicKey, offer_sdp: &str) -> Result<()> {
+        // CLI always advertises `Exporter`. A CLI that accepted
+        // `CertFp` from a browser-speaking daemon would silently
+        // downgrade its channel binding to the public-cert form; CLI
+        // code paths use `webrtc-rs` with RFC 5705 exporter support
+        // natively, so there's no reason to ever accept the downgrade.
+        // PR #28.3's CLI downgrade-rejection (see
+        // `crates/openhost-client/src/binding.rs`) enforces this on
+        // the answer-parse side.
         let plaintext = OfferPlaintext {
             client_pk: self.identity.public_key(),
             offer_sdp: offer_sdp.to_string(),
+            binding_mode: openhost_pkarr::BindingMode::Exporter,
         };
         let mut rng = rand::rngs::OsRng;
         let offer = OfferRecord::seal(&mut rng, daemon_pk, &plaintext)

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -94,6 +94,10 @@ fn daemon_config(tmp: &TempDir, watched: Vec<String>, upstream_port: Option<u16>
         dtls: DtlsConfig {
             cert_path: tmp.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: upstream_port.map(|p| ForwardConfig {
             target: Some(format!("http://127.0.0.1:{p}")),

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -193,11 +193,17 @@ impl App {
     }
 
     /// Convenience: hand `offer_sdp` to the listener and return the
-    /// answer SDP. Mirrors what the offer-record poller will call in
-    /// PR #7.
-    pub async fn handle_offer(&self, offer_sdp: &str) -> Result<String> {
+    /// answer SDP. `binding_mode` is the channel-binding variant the
+    /// client advertised in its offer plaintext — the offer poller
+    /// threads it in, direct callers (tests, examples) default to
+    /// [`openhost_pkarr::BindingMode::Exporter`].
+    pub async fn handle_offer(
+        &self,
+        offer_sdp: &str,
+        binding_mode: openhost_pkarr::BindingMode,
+    ) -> Result<String> {
         self.listener
-            .handle_offer(offer_sdp)
+            .handle_offer(offer_sdp, binding_mode)
             .await
             .map_err(Into::into)
     }
@@ -414,6 +420,13 @@ fn build_offer_poller(
             enforce_allowlist: cfg_poll.enforce_allowlist,
             rate_limit_burst: cfg_poll.rate_limit_burst,
             rate_limit_refill_per_sec: 1.0 / cfg_poll.rate_limit_refill_secs,
+            allowed_binding_modes: cfg
+                .dtls
+                .allowed_binding_modes
+                .iter()
+                .copied()
+                .map(openhost_pkarr::BindingMode::from)
+                .collect(),
         },
     ))
 }

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -176,6 +176,47 @@ pub struct DtlsConfig {
     /// Seconds between rotations. Defaults to [`DEFAULT_ROTATE_SECS`].
     #[serde(default = "default_rotate_secs")]
     pub rotate_secs: u64,
+    /// Channel-binding modes the daemon will accept on inbound offers.
+    /// Default: `["exporter", "cert_fp"]` — accept CLI dialers + browser
+    /// dialers. Operators running a CLI-only deployment can lock this
+    /// to `["exporter"]` to reject any browser-originated dial.
+    /// `[]` disables the listener entirely.
+    #[serde(default = "default_allowed_binding_modes")]
+    pub allowed_binding_modes: Vec<BindingModeConfig>,
+}
+
+/// Serializable mirror of [`openhost_pkarr::BindingMode`] for config
+/// files. Uses lowercase TOML strings (`"exporter"`, `"cert_fp"`) so
+/// the config file reads naturally.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BindingModeConfig {
+    /// Corresponds to [`openhost_pkarr::BindingMode::Exporter`].
+    Exporter,
+    /// Corresponds to [`openhost_pkarr::BindingMode::CertFp`].
+    CertFp,
+}
+
+impl From<BindingModeConfig> for openhost_pkarr::BindingMode {
+    fn from(m: BindingModeConfig) -> Self {
+        match m {
+            BindingModeConfig::Exporter => openhost_pkarr::BindingMode::Exporter,
+            BindingModeConfig::CertFp => openhost_pkarr::BindingMode::CertFp,
+        }
+    }
+}
+
+impl From<openhost_pkarr::BindingMode> for BindingModeConfig {
+    fn from(m: openhost_pkarr::BindingMode) -> Self {
+        match m {
+            openhost_pkarr::BindingMode::Exporter => Self::Exporter,
+            openhost_pkarr::BindingMode::CertFp => Self::CertFp,
+        }
+    }
+}
+
+fn default_allowed_binding_modes() -> Vec<BindingModeConfig> {
+    vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp]
 }
 
 /// Localhost forward configuration (PR #6). Spec §7.12 mitigation +
@@ -412,6 +453,7 @@ pub fn seed_config(data_dir: &Path) -> Config {
         dtls: DtlsConfig {
             cert_path: data_dir.join("dtls.pem"),
             rotate_secs: DEFAULT_ROTATE_SECS,
+            allowed_binding_modes: default_allowed_binding_modes(),
         },
         forward: None,
         log: LogConfig::default(),

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,6 +26,8 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
+use openhost_pkarr::BindingMode;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Once};
@@ -201,14 +203,18 @@ impl PassivePeer {
     /// `RTCPeerConnection` is retained inside the `PassivePeer` so the
     /// DTLS handshake can actually complete — callers don't need to
     /// keep it alive themselves.
-    pub async fn handle_offer(&self, offer_sdp: &str) -> Result<String, ListenerError> {
+    pub async fn handle_offer(
+        &self,
+        offer_sdp: &str,
+        binding_mode: BindingMode,
+    ) -> Result<String, ListenerError> {
         // 1. Pre-validate the DTLS role asserted in the offer.
         check_setup_role_is_active(offer_sdp)?;
 
         // 2. Wrap the whole handshake in a timeout so a broken peer
         //    can't wedge the caller.
         let budget = std::time::Duration::from_secs(self.offer_timeout_secs);
-        tokio::time::timeout(budget, self.negotiate(offer_sdp))
+        tokio::time::timeout(budget, self.negotiate(offer_sdp, binding_mode))
             .await
             .map_err(|_| ListenerError::Timeout {
                 secs: self.offer_timeout_secs,
@@ -230,7 +236,11 @@ impl PassivePeer {
         }
     }
 
-    async fn negotiate(&self, offer_sdp: &str) -> Result<String, ListenerError> {
+    async fn negotiate(
+        &self,
+        offer_sdp: &str,
+        binding_mode: BindingMode,
+    ) -> Result<String, ListenerError> {
         let config = RTCConfiguration {
             certificates: vec![self.certificate.clone()],
             ..Default::default()
@@ -248,6 +258,7 @@ impl PassivePeer {
             dtls_transport,
             Arc::clone(&self.binding_timeout_secs),
             self.forwarder.clone(),
+            binding_mode,
         );
         wire_dtls_state_observer(Arc::clone(&pc));
         wire_prune_on_terminal_state(Arc::clone(&pc), Arc::clone(&self.active));
@@ -384,6 +395,7 @@ fn wire_data_channel_handler(
     dtls_transport: Arc<RTCDtlsTransport>,
     binding_timeout_secs: Arc<AtomicU64>,
     forwarder: Option<Arc<Forwarder>>,
+    binding_mode: BindingMode,
 ) {
     pc.on_data_channel(Box::new(move |dc: Arc<RTCDataChannel>| {
         let label = dc.label().to_string();
@@ -392,8 +404,16 @@ fn wire_data_channel_handler(
         let binding_timeout_secs = Arc::clone(&binding_timeout_secs);
         let forwarder = forwarder.clone();
         Box::pin(async move {
-            tracing::debug!(label, "openhostd: data channel opened");
-            wire_frame_loop(dc, binder, dtls_transport, binding_timeout_secs, forwarder).await;
+            tracing::debug!(label, ?binding_mode, "openhostd: data channel opened");
+            wire_frame_loop(
+                dc,
+                binder,
+                dtls_transport,
+                binding_timeout_secs,
+                forwarder,
+                binding_mode,
+            )
+            .await;
         })
     }));
 }
@@ -446,6 +466,7 @@ async fn wire_frame_loop(
     dtls_transport: Arc<RTCDtlsTransport>,
     binding_timeout_secs: Arc<AtomicU64>,
     forwarder: Option<Arc<Forwarder>>,
+    binding_mode: BindingMode,
 ) {
     let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
@@ -552,6 +573,7 @@ async fn wire_frame_loop(
                             &request,
                             &ws_tunnel,
                             forwarder.as_deref(),
+                            binding_mode,
                         )
                         .await;
                         if let FrameOutcome::Teardown = outcome {
@@ -585,6 +607,7 @@ enum FrameOutcome {
 /// binding is `Authenticated`, the ONLY frame accepted from the peer is
 /// `AuthClient`. Anything else produces an `ERROR` frame + teardown.
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_frame(
     frame: &Frame,
     dc: &Arc<RTCDataChannel>,
@@ -595,6 +618,7 @@ async fn dispatch_frame(
     request: &Arc<Mutex<RequestInProgress>>,
     ws_tunnel: &Arc<Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>>,
     forwarder: Option<&Forwarder>,
+    binding_mode: BindingMode,
 ) -> FrameOutcome {
     // Look up binding state, then release the lock before awaiting
     // webrtc I/O (the send + close paths below both await).
@@ -653,6 +677,7 @@ async fn dispatch_frame(
                 binder,
                 dtls_transport,
                 &nonce,
+                binding_mode,
             )
             .await;
         }
@@ -824,6 +849,16 @@ enum BindingSnapshot {
 ///
 /// Any failure (bad payload, bad signature, exporter error) emits an
 /// `ERROR` frame, marks state `Failed`, and requests teardown.
+///
+/// `binding_mode` picks where the 32-byte channel-binding secret
+/// comes from (see `spec/04-security.md §4.1`):
+///
+/// - [`BindingMode::Exporter`]: RFC 5705 DTLS exporter output with
+///   label [`EXPORTER_LABEL`] — the original CLI path.
+/// - [`BindingMode::CertFp`]: SHA-256 over the remote DTLS cert DER
+///   (via `RTCDtlsTransport::get_remote_certificate`) — mandatory
+///   for browser clients, which cannot reach the exporter today.
+#[allow(clippy::too_many_arguments)]
 async fn handle_auth_client(
     frame: &Frame,
     dc: &RTCDataChannel,
@@ -832,32 +867,24 @@ async fn handle_auth_client(
     binder: &ChannelBinder,
     dtls_transport: &RTCDtlsTransport,
     nonce: &[u8; AUTH_NONCE_LEN],
+    binding_mode: BindingMode,
 ) -> FrameOutcome {
-    let exporter = match dtls_transport
-        .export_keying_material(EXPORTER_LABEL, EXPORTER_SECRET_LEN)
-        .await
-    {
+    let binding_secret = match derive_binding_secret(dtls_transport, binding_mode).await {
         Ok(bytes) => bytes,
-        Err(err) => {
-            tracing::warn!(?err, "openhostd: DTLS exporter failed; tearing down");
-            let _ = send_error_frame(dc, "DTLS exporter failed").await;
+        Err(reason) => {
+            tracing::warn!(
+                ?binding_mode,
+                reason,
+                "openhostd: binding-secret derivation failed; tearing down"
+            );
+            let _ = send_error_frame(dc, reason).await;
             *binding.lock().await = BindingState::Failed;
             binding_done.notify_waiters();
             return FrameOutcome::Teardown;
         }
     };
-    if exporter.len() != EXPORTER_SECRET_LEN {
-        tracing::warn!(
-            got = exporter.len(),
-            "openhostd: DTLS exporter returned wrong length; tearing down"
-        );
-        let _ = send_error_frame(dc, "DTLS exporter returned wrong length").await;
-        *binding.lock().await = BindingState::Failed;
-        binding_done.notify_waiters();
-        return FrameOutcome::Teardown;
-    }
 
-    let client_pk = match binder.verify_client_sig(&exporter, nonce, &frame.payload) {
+    let client_pk = match binder.verify_client_sig(&binding_secret, nonce, &frame.payload) {
         Ok(pk) => pk,
         Err(err) => {
             tracing::warn!(
@@ -877,7 +904,7 @@ async fn handle_auth_client(
         }
     };
 
-    let host_sig = match binder.sign_host(&exporter, nonce, &client_pk) {
+    let host_sig = match binder.sign_host(&binding_secret, nonce, &client_pk) {
         Ok(sig) => sig,
         Err(err) => {
             tracing::warn!(?err, "openhostd: sign_host failed; tearing down");
@@ -908,6 +935,46 @@ async fn handle_auth_client(
     *binding.lock().await = BindingState::Authenticated { client_pk };
     binding_done.notify_waiters();
     FrameOutcome::Continue
+}
+
+/// Produce the 32-byte channel-binding secret that feeds
+/// [`ChannelBinder::verify_client_sig`] + [`ChannelBinder::sign_host`],
+/// branching on the client's advertised [`BindingMode`].
+///
+/// Returns a static `&str` reason on failure, suitable for the
+/// `ERROR` frame the caller emits before teardown.
+async fn derive_binding_secret(
+    dtls_transport: &RTCDtlsTransport,
+    binding_mode: BindingMode,
+) -> Result<Vec<u8>, &'static str> {
+    match binding_mode {
+        BindingMode::Exporter => {
+            let exporter = dtls_transport
+                .export_keying_material(EXPORTER_LABEL, EXPORTER_SECRET_LEN)
+                .await
+                .map_err(|_| "DTLS exporter failed")?;
+            if exporter.len() != EXPORTER_SECRET_LEN {
+                return Err("DTLS exporter returned wrong length");
+            }
+            Ok(exporter)
+        }
+        BindingMode::CertFp => {
+            // `get_remote_certificate` returns the DER bytes cached by
+            // the fork's DTLS transport after the handshake. Empty if
+            // the handshake hasn't completed — which would be a
+            // protocol bug since AUTH_CLIENT is sent post-`Connected`.
+            let der = dtls_transport.get_remote_certificate().await;
+            if der.is_empty() {
+                return Err("remote DTLS certificate not available");
+            }
+            let mut hasher = Sha256::new();
+            hasher.update(&der);
+            // Exactly EXPORTER_SECRET_LEN (32) bytes — matches the
+            // HKDF-SHA256 IKM length the binder already uses in the
+            // exporter path, so downstream code stays identical.
+            Ok(hasher.finalize().to_vec())
+        }
+    }
 }
 
 /// Emit a forwarder response as `RESPONSE_HEAD` + `RESPONSE_BODY*` +

--- a/crates/openhost-daemon/src/offer_poller.rs
+++ b/crates/openhost-daemon/src/offer_poller.rs
@@ -54,6 +54,11 @@ pub struct OfferPollerConfig {
     /// Token-bucket refill rate in tokens per second (= 1.0 /
     /// `rate_limit_refill_secs` in the config).
     pub rate_limit_refill_per_sec: f64,
+    /// Channel-binding modes the daemon accepts on incoming offers.
+    /// Offers whose `binding_mode` is absent from this list are
+    /// dropped pre-handshake with a `warn!`. Mirrors
+    /// `[dtls] allowed_binding_modes` from the config file.
+    pub allowed_binding_modes: Vec<openhost_pkarr::BindingMode>,
 }
 
 impl Default for OfferPollerConfig {
@@ -65,6 +70,10 @@ impl Default for OfferPollerConfig {
             enforce_allowlist: true,
             rate_limit_burst: 3,
             rate_limit_refill_per_sec: 1.0 / 5.0,
+            allowed_binding_modes: vec![
+                openhost_pkarr::BindingMode::Exporter,
+                openhost_pkarr::BindingMode::CertFp,
+            ],
         }
     }
 }
@@ -351,6 +360,20 @@ async fn process_client_packet(
         return;
     }
 
+    // PR #28.3 binding-mode gate: drop offers whose advertised mode is
+    // not on the operator's allowlist (e.g. a CLI-only deployment that
+    // explicitly excludes browser cert_fp offers).
+    if !cfg.allowed_binding_modes.contains(&plaintext.binding_mode) {
+        tracing::warn!(
+            client = %client_pk,
+            binding_mode = ?plaintext.binding_mode,
+            "offer poll: binding mode not in [dtls] allowed_binding_modes; skipping",
+        );
+        entry.last_ts = packet_ts_secs;
+        entry.last_processed = Some(now_instant);
+        return;
+    }
+
     // PR #7b rate-limit gate: consume a token. On empty bucket, skip.
     if !entry.bucket.try_consume(now_instant) {
         tracing::warn!(
@@ -366,7 +389,10 @@ async fn process_client_packet(
 
     // Run the handshake. `handle_offer` drains ICE and returns the
     // answer SDP.
-    let answer_sdp = match listener.handle_offer(&plaintext.offer_sdp).await {
+    let answer_sdp = match listener
+        .handle_offer(&plaintext.offer_sdp, plaintext.binding_mode)
+        .await
+    {
         Ok(s) => s,
         Err(err) => {
             tracing::warn!(?err, client = %client_pk, "offer poll: handle_offer failed");

--- a/crates/openhost-daemon/tests/bootstrap.rs
+++ b/crates/openhost-daemon/tests/bootstrap.rs
@@ -47,6 +47,10 @@ fn test_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -41,6 +41,10 @@ fn test_config(dir: &TempDir, upstream_port: u16) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: Some(ForwardConfig {
             target: Some(format!("http://127.0.0.1:{upstream_port}")),

--- a/crates/openhost-daemon/tests/listener.rs
+++ b/crates/openhost-daemon/tests/listener.rs
@@ -36,7 +36,10 @@ async fn offer_with_passive_setup_role_is_rejected_before_any_pc_is_built() -> D
                    m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n\
                    c=IN IP4 0.0.0.0\r\na=setup:passive\r\n";
 
-    let err = app.handle_offer(bad_sdp).await.unwrap_err();
+    let err = app
+        .handle_offer(bad_sdp, openhost_pkarr::BindingMode::Exporter)
+        .await
+        .unwrap_err();
     assert!(matches!(
         err,
         DaemonError::Listener(ListenerError::SetupRoleMismatch { ref found }) if found == "passive"
@@ -51,7 +54,10 @@ async fn offer_missing_setup_line_is_rejected() -> DaemonResult<()> {
     let cfg = test_config_noforward(&tmp);
     let (_tmp, app) = build_noop_daemon_with_config(cfg).await;
     let bad_sdp = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n";
-    let err = app.handle_offer(bad_sdp).await.unwrap_err();
+    let err = app
+        .handle_offer(bad_sdp, openhost_pkarr::BindingMode::Exporter)
+        .await
+        .unwrap_err();
     assert!(matches!(
         err,
         DaemonError::Listener(ListenerError::OfferParse(_))

--- a/crates/openhost-daemon/tests/offer_poll.rs
+++ b/crates/openhost-daemon/tests/offer_poll.rs
@@ -82,6 +82,7 @@ async fn build_client_offer_packet(
     let plaintext = OfferPlaintext {
         client_pk: client_sk.public_key(),
         offer_sdp: offer_sdp.to_string(),
+        binding_mode: openhost_pkarr::BindingMode::Exporter,
     };
     let mut rng = OsRng;
     let offer = OfferRecord::seal(&mut rng, daemon_pk, &plaintext).unwrap();
@@ -335,6 +336,7 @@ async fn daemon_rejects_inner_outer_client_pk_mismatch() -> DaemonResult<()> {
     let plaintext = OfferPlaintext {
         client_pk: client_pk_b,
         offer_sdp: offer_sdp.to_string(),
+        binding_mode: openhost_pkarr::BindingMode::Exporter,
     };
     let mut rng = OsRng;
     let offer = OfferRecord::seal(&mut rng, &daemon_pk, &plaintext).unwrap();

--- a/crates/openhost-daemon/tests/offer_poll.rs
+++ b/crates/openhost-daemon/tests/offer_poll.rs
@@ -64,6 +64,10 @@ fn daemon_config(
         dtls: DtlsConfig {
             cert_path: tmp.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),

--- a/crates/openhost-daemon/tests/pair_watcher.rs
+++ b/crates/openhost-daemon/tests/pair_watcher.rs
@@ -43,6 +43,10 @@ fn build_config(tmp: &TempDir, pair_db_path: std::path::PathBuf) -> Config {
         dtls: DtlsConfig {
             cert_path: tmp.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -82,6 +82,7 @@ async fn build_offer_packet(
     let plaintext = OfferPlaintext {
         client_pk: client_sk.public_key(),
         offer_sdp: offer_sdp.to_string(),
+        binding_mode: openhost_pkarr::BindingMode::Exporter,
     };
     let mut rng = OsRng;
     let offer = OfferRecord::seal(&mut rng, daemon_pk, &plaintext).unwrap();

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -61,6 +61,10 @@ fn build_config(
         dtls: DtlsConfig {
             cert_path: tmp.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -198,6 +198,10 @@ pub fn test_config_noforward(dir: &tempfile::TempDir) -> openhost_daemon::Config
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),
@@ -281,7 +285,10 @@ pub async fn establish_connection_opts(
     let _ = gather.recv().await;
     let offer_sdp = client_pc.local_description().await.unwrap().sdp;
 
-    let answer_sdp = app.handle_offer(&offer_sdp).await.expect("daemon answers");
+    let answer_sdp = app
+        .handle_offer(&offer_sdp, openhost_pkarr::BindingMode::Exporter)
+        .await
+        .expect("daemon answers");
     let answer = RTCSessionDescription::answer(answer_sdp).expect("parse answer");
     client_pc
         .set_remote_description(answer)

--- a/crates/openhost-pkarr-wasm/Cargo.toml
+++ b/crates/openhost-pkarr-wasm/Cargo.toml
@@ -37,6 +37,9 @@ serde-wasm-bindgen = "0.6"
 thiserror = { workspace = true }
 hex = { workspace = true }
 base64 = { workspace = true }
+sha2 = { workspace = true }
+rand = { workspace = true }
+ed25519-dalek = { workspace = true }
 
 # The `rand_core` → `getrandom` chain in `openhost-core` fails to
 # compile for wasm32 unless `getrandom` is built with `features =

--- a/crates/openhost-pkarr-wasm/Cargo.toml
+++ b/crates/openhost-pkarr-wasm/Cargo.toml
@@ -40,6 +40,9 @@ base64 = { workspace = true }
 sha2 = { workspace = true }
 rand = { workspace = true }
 ed25519-dalek = { workspace = true }
+# Phase 6.1: build_offer_packet signs a `SignedPacket` for the Pkarr
+# relay PUT. `signed_packet + keys` pulls the sync-only types.
+pkarr = { workspace = true, default-features = false, features = ["signed_packet", "keys"] }
 
 # The `rand_core` → `getrandom` chain in `openhost-core` fails to
 # compile for wasm32 unless `getrandom` is built with `features =

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -6,10 +6,22 @@
 //! [`crate`] root wraps each of these with a `JsValue` translation
 //! step.
 
-use openhost_core::identity::PublicKey;
+use openhost_core::channel_binding_wire::{
+    AUTH_CLIENT_PAYLOAD_LEN, AUTH_NONCE_LEN, EXPORTER_SECRET_LEN,
+};
+/// Ed25519 signature byte length. Not exported by `channel_binding_wire`
+/// today; pinned here because the browser AUTH_CLIENT + AUTH_HOST
+/// payloads both carry one of these.
+const SIGNATURE_LEN: usize = 64;
+use openhost_core::crypto::auth_bytes_bound;
+use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN, SIGNING_KEY_LEN};
 use openhost_core::pkarr_record::{SignedRecord, SALT_LEN};
-use openhost_pkarr::SignedPacket;
+use openhost_core::wire::{Frame, FrameType};
+use openhost_pkarr::offer::OfferRecord;
+use openhost_pkarr::{AnswerEntry, BindingMode, OfferPlaintext, SignedPacket};
+use rand::rngs::OsRng;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 /// Errors produced by the core tier. The `#[wasm_bindgen]` layer
@@ -38,6 +50,27 @@ pub enum Error {
     /// structural invariant failed.
     #[error("record verify failed: {0}")]
     VerifyFailed(String),
+    /// Input byte slice was the wrong length for a fixed-size array
+    /// parameter (client SK, nonce, etc.).
+    #[error("expected {expected} bytes for {field}, got {got}")]
+    WrongLength {
+        /// Short name identifying the parameter.
+        field: &'static str,
+        /// Byte count required.
+        expected: usize,
+        /// Byte count provided.
+        got: usize,
+    },
+    /// Sealed-box open failed (wrong private key or tampered
+    /// ciphertext).
+    #[error("sealed-box open failed: {0}")]
+    SealedBoxOpen(String),
+    /// Base64url-nopad decode failed on the caller's sealed input.
+    #[error("base64url decode failed: {0}")]
+    Base64(#[from] base64::DecodeError),
+    /// The wire framing codec rejected the caller's bytes.
+    #[error("frame codec: {0}")]
+    Frame(String),
 }
 
 /// Result alias over [`Error`].
@@ -193,3 +226,205 @@ pub fn decode_answer_fragments(
         created_at: e.created_at,
     }))
 }
+
+// ============================================================================
+// Phase 4: browser-dialer primitives (PR #28.3)
+// ============================================================================
+//
+// The browser extension's JS orchestrator owns the RTCPeerConnection.
+// Everything below is the crypto + wire-codec surface the orchestrator
+// calls via wasm-bindgen during a dial:
+//
+//   1. `seal_offer`           — seal the client's offer SDP to the host.
+//   2. (publish via relay)    — JS PUTs the sealed bytes to a Pkarr relay.
+//   3. (poll + decode_answer) — JS calls `decode_answer_fragments` +
+//                               `open_answer` to recover the answer SDP.
+//   4. (apply answer)         — JS drives setRemoteDescription.
+//   5. `compute_cert_fp_binding` + `sign_auth_client` — build the
+//      AUTH_CLIENT payload once DTLS is up.
+//   6. `verify_auth_host`     — validate the daemon's AUTH_HOST reply.
+//   7. `encode_frame` / `decode_frame` — HTTP-over-DataChannel I/O.
+
+/// Decrypted answer plaintext returned to JS. Matches the wire form
+/// from `spec/01-wire-format.md §3.3`.
+#[derive(Debug, Serialize)]
+pub struct OpenedAnswer {
+    /// The responding daemon's Ed25519 pubkey, zbase32. Cross-check
+    /// against the Pkarr signer before trusting the answer.
+    pub daemon_pk_zbase32: String,
+    /// SHA-256 of the UTF-8 offer SDP this answer is bound to, hex.
+    pub offer_sdp_hash_hex: String,
+    /// The daemon's SDP answer text.
+    pub answer_sdp: String,
+}
+
+/// Decoded wire frame returned to JS.
+#[derive(Debug, Serialize)]
+pub struct DecodedFrame {
+    /// Raw frame-type byte (see `spec/01-wire-format.md §4`).
+    pub frame_type: u8,
+    /// Frame payload.
+    pub payload: Vec<u8>,
+    /// Total bytes consumed from the buffer for this frame (header +
+    /// payload). Callers shift their read buffer forward by this count.
+    pub consumed: usize,
+}
+
+fn parse_binding_mode(b: u8) -> Result<BindingMode> {
+    BindingMode::try_from_u8(b).map_err(Error::Pkarr)
+}
+
+fn parse_array<const N: usize>(bytes: &[u8], field: &'static str) -> Result<[u8; N]> {
+    <[u8; N]>::try_from(bytes).map_err(|_| Error::WrongLength {
+        field,
+        expected: N,
+        got: bytes.len(),
+    })
+}
+
+fn sha256_32(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Seal an [`OpenhostPlaintext`-equivalent] client offer to the daemon.
+/// JS hands the returned `Vec<u8>` to a Pkarr relay PUT as the sealed
+/// offer record TXT value (after base64url-nopad encoding, which lives
+/// on the JS side to keep the WASM boundary byte-level).
+///
+/// `binding_mode_u8` MUST be `0x02 CertFp` for browser calls; `0x01
+/// Exporter` is permitted for host-target tests but never emitted by a
+/// production browser build.
+pub fn seal_offer(
+    daemon_pk_zbase32: &str,
+    client_pk_zbase32: &str,
+    offer_sdp: &str,
+    binding_mode_u8: u8,
+) -> Result<Vec<u8>> {
+    let daemon_pk = parse_pubkey(daemon_pk_zbase32)?;
+    let client_pk = parse_pubkey(client_pk_zbase32)?;
+    let binding_mode = parse_binding_mode(binding_mode_u8)?;
+    let plaintext = OfferPlaintext {
+        client_pk,
+        offer_sdp: offer_sdp.to_string(),
+        binding_mode,
+    };
+    let mut rng = OsRng;
+    let record = OfferRecord::seal(&mut rng, &daemon_pk, &plaintext)?;
+    Ok(record.sealed)
+}
+
+/// Open an answer record with the client's 32-byte Ed25519 secret key.
+/// Mirrors `AnswerEntry::open` on the CLI path.
+pub fn open_answer(client_sk_bytes: &[u8], sealed_base64url: &str) -> Result<OpenedAnswer> {
+    let sk_arr: [u8; SIGNING_KEY_LEN] = parse_array(client_sk_bytes, "client_sk")?;
+    let client_sk = SigningKey::from_bytes(&sk_arr);
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let sealed = URL_SAFE_NO_PAD.decode(sealed_base64url.as_bytes())?;
+    // AnswerEntry only needs `sealed` for open(); client_hash +
+    // created_at are ignored, so we synthesize placeholders.
+    let entry = AnswerEntry {
+        client_hash: [0u8; openhost_pkarr::CLIENT_HASH_LEN],
+        sealed,
+        created_at: 0,
+    };
+    let plain = entry
+        .open(&client_sk)
+        .map_err(|e| Error::SealedBoxOpen(e.to_string()))?;
+    Ok(OpenedAnswer {
+        daemon_pk_zbase32: plain.daemon_pk.to_zbase32(),
+        offer_sdp_hash_hex: hex::encode(plain.offer_sdp_hash),
+        answer_sdp: plain.answer_sdp,
+    })
+}
+
+/// Compute the 32-byte AUTH bytes for a browser (CertFp) dial.
+///
+/// The input `cert_der` is the DER-encoded DTLS certificate the browser
+/// reads from `RTCDtlsTransport.getRemoteCertificates()[0]`. The output
+/// feeds the AUTH_CLIENT signature (via [`sign_auth_client`]) and the
+/// AUTH_HOST verify (via [`verify_auth_host`]), matching the daemon's
+/// Phase 2 `derive_binding_secret(CertFp)` path byte-for-byte.
+pub fn compute_cert_fp_binding(
+    cert_der: &[u8],
+    host_pk_zbase32: &str,
+    client_pk_zbase32: &str,
+    nonce_bytes: &[u8],
+) -> Result<[u8; 32]> {
+    let host_pk = parse_pubkey(host_pk_zbase32)?;
+    let client_pk = parse_pubkey(client_pk_zbase32)?;
+    let nonce: [u8; AUTH_NONCE_LEN] = parse_array(nonce_bytes, "nonce")?;
+    if cert_der.is_empty() {
+        return Err(Error::VerifyFailed(
+            "remote DTLS certificate DER is empty".to_string(),
+        ));
+    }
+    let secret = sha256_32(cert_der);
+    debug_assert_eq!(secret.len(), EXPORTER_SECRET_LEN);
+    let auth = auth_bytes_bound(&secret, &host_pk.to_bytes(), &client_pk.to_bytes(), &nonce)
+        .map_err(|e| Error::VerifyFailed(e.to_string()))?;
+    Ok(auth)
+}
+
+/// Produce the 96-byte AUTH_CLIENT payload (32B client_pk ||
+/// 64B Ed25519 signature over `auth_bytes`).
+pub fn sign_auth_client(client_sk_bytes: &[u8], auth_bytes: &[u8]) -> Result<Vec<u8>> {
+    let sk_arr: [u8; SIGNING_KEY_LEN] = parse_array(client_sk_bytes, "client_sk")?;
+    let client_sk = SigningKey::from_bytes(&sk_arr);
+    // auth_bytes is always 32 bytes (AUTH_BYTES_LEN). Enforce up-front
+    // so mis-sized inputs surface as WrongLength instead of a cryptic
+    // downstream verify failure.
+    let _: [u8; 32] = parse_array(auth_bytes, "auth_bytes")?;
+    let sig = client_sk.sign(auth_bytes);
+    let mut out = Vec::with_capacity(AUTH_CLIENT_PAYLOAD_LEN);
+    out.extend_from_slice(&client_sk.public_key().to_bytes());
+    out.extend_from_slice(&sig.to_bytes());
+    Ok(out)
+}
+
+/// Verify the 64-byte AUTH_HOST signature against `auth_bytes` under
+/// `host_pk`. Returns `Ok(true)` on good signature, `Ok(false)` on
+/// bad. Malformed lengths surface as [`Error::WrongLength`].
+pub fn verify_auth_host(
+    host_pk_zbase32: &str,
+    auth_bytes: &[u8],
+    signature_64b: &[u8],
+) -> Result<bool> {
+    let host_pk = parse_pubkey(host_pk_zbase32)?;
+    let _: [u8; 32] = parse_array(auth_bytes, "auth_bytes")?;
+    let sig_arr: [u8; SIGNATURE_LEN] = parse_array(signature_64b, "signature")?;
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    Ok(host_pk.as_dalek().verify_strict(auth_bytes, &sig).is_ok())
+}
+
+/// Encode a wire frame to bytes ready to ship over the data channel.
+/// The frame-type byte matches `spec/01-wire-format.md §4`.
+pub fn encode_frame(frame_type_u8: u8, payload: Vec<u8>) -> Result<Vec<u8>> {
+    let frame_type = FrameType::from_u8(frame_type_u8)
+        .map_err(|e| Error::Frame(format!("unknown frame type 0x{frame_type_u8:02x}: {e}")))?;
+    let frame = Frame::new(frame_type, payload).map_err(|e| Error::Frame(e.to_string()))?;
+    Ok(frame.encode_to_vec())
+}
+
+/// Try to decode one frame from the front of `buf`. Returns `None`
+/// (as an untyped option → JS `null`) if `buf` is incomplete; a
+/// [`DecodedFrame`] otherwise with `consumed` bytes from the front.
+pub fn decode_frame(buf: &[u8]) -> Result<Option<DecodedFrame>> {
+    match Frame::try_decode(buf) {
+        Ok(None) => Ok(None),
+        Ok(Some((frame, consumed))) => Ok(Some(DecodedFrame {
+            frame_type: frame.frame_type.as_u8(),
+            payload: frame.payload,
+            consumed,
+        })),
+        Err(e) => Err(Error::Frame(e.to_string())),
+    }
+}
+
+// Silence the "unused" warnings for constants we only reach through
+// conditional paths (eg. PUBLIC_KEY_LEN is only consumed inside
+// parse_array via the N generic).
+#[allow(dead_code)]
+const _: usize = PUBLIC_KEY_LEN;

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -428,3 +428,59 @@ pub fn decode_frame(buf: &[u8]) -> Result<Option<DecodedFrame>> {
 // parse_array via the N generic).
 #[allow(dead_code)]
 const _: usize = PUBLIC_KEY_LEN;
+
+/// Derive the client's zbase32 Ed25519 pubkey from its 32-byte seed.
+/// The browser extension stores the seed in IndexedDB; JS needs the
+/// pubkey string to address offer records + parse hostRecord
+/// self-check fields without re-implementing Ed25519 scalarmult.
+pub fn client_pubkey_from_seed(seed_bytes: &[u8]) -> Result<String> {
+    let seed: [u8; SIGNING_KEY_LEN] = parse_array(seed_bytes, "client_seed")?;
+    Ok(SigningKey::from_bytes(&seed).public_key().to_zbase32())
+}
+
+/// Assemble a Pkarr `SignedPacket` carrying one `_offer-<host-hash>`
+/// TXT entry, signed by the client's identity key. Returns the raw
+/// wire bytes ready for an HTTP PUT to a Pkarr relay
+/// (`PUT https://<relay>/<client-pk-zbase32>`).
+///
+/// Mirrors `openhost_client::Dialer::publish_offer` byte-for-byte
+/// (see `crates/openhost-client/src/dialer.rs:338-372`) minus the
+/// monotonic-seq bump — callers pass `now_ts` explicitly so a JS
+/// dialer can bump past its own last publish on retry.
+pub fn build_offer_packet(
+    client_sk_bytes: &[u8],
+    daemon_pk_zbase32: &str,
+    sealed_offer: &[u8],
+    now_ts: u64,
+) -> Result<Vec<u8>> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use pkarr::dns::rdata::TXT;
+    use pkarr::dns::Name;
+    use pkarr::{Keypair, SignedPacket, Timestamp};
+
+    let seed: [u8; SIGNING_KEY_LEN] = parse_array(client_sk_bytes, "client_sk")?;
+    let daemon_pk = parse_pubkey(daemon_pk_zbase32)?;
+
+    let txt_value = URL_SAFE_NO_PAD.encode(sealed_offer);
+    let label = openhost_pkarr::host_hash_label(&daemon_pk);
+    let name = format!("{}{label}", openhost_pkarr::OFFER_TXT_PREFIX);
+
+    let keypair = Keypair::from_secret_key(&seed);
+    let ts_micros = now_ts
+        .checked_mul(1_000_000)
+        .ok_or_else(|| Error::VerifyFailed("ts overflow".to_string()))?;
+
+    let packet = SignedPacket::builder()
+        .txt(
+            Name::new_unchecked(&name),
+            TXT::try_from(txt_value.as_str())
+                .map_err(|e| Error::VerifyFailed(format!("txt build: {e}")))?,
+            openhost_pkarr::OFFER_TXT_TTL,
+        )
+        .timestamp(Timestamp::from(ts_micros))
+        .sign(&keypair)
+        .map_err(|e| Error::VerifyFailed(format!("sign: {e}")))?;
+
+    Ok(packet.serialize())
+}

--- a/crates/openhost-pkarr-wasm/src/lib.rs
+++ b/crates/openhost-pkarr-wasm/src/lib.rs
@@ -134,3 +134,82 @@ pub fn decode_answer_fragments(
         .map_err(|e| to_js_err(&e))?;
     to_js(&out)
 }
+
+// ============================================================================
+// Phase 4: browser-dialer primitives (PR #28.3)
+// ============================================================================
+
+/// Seal a client offer plaintext to the daemon's X25519 pubkey.
+/// Returns the raw sealed bytes; JS base64url-encodes them for the
+/// Pkarr relay PUT.
+///
+/// `binding_mode_u8` MUST be `0x02` (CertFp) for browser calls.
+#[wasm_bindgen]
+pub fn seal_offer(
+    daemon_pk_zbase32: &str,
+    client_pk_zbase32: &str,
+    offer_sdp: &str,
+    binding_mode_u8: u8,
+) -> Result<Vec<u8>, JsError> {
+    core::seal_offer(
+        daemon_pk_zbase32,
+        client_pk_zbase32,
+        offer_sdp,
+        binding_mode_u8,
+    )
+    .map_err(|e| to_js_err(&e))
+}
+
+/// Open an answer ciphertext with the client's 32-byte secret key.
+/// Returns an [`OpenedAnswer`][core::OpenedAnswer]-shaped JS object.
+#[wasm_bindgen]
+pub fn open_answer(client_sk_bytes: &[u8], sealed_base64url: &str) -> Result<JsValue, JsError> {
+    let out = core::open_answer(client_sk_bytes, sealed_base64url).map_err(|e| to_js_err(&e))?;
+    to_js(&out)
+}
+
+/// Compute 32 AUTH bytes for a browser dial's CertFp channel binding.
+/// Feeds [`sign_auth_client`] + [`verify_auth_host`].
+#[wasm_bindgen]
+pub fn compute_cert_fp_binding(
+    cert_der: &[u8],
+    host_pk_zbase32: &str,
+    client_pk_zbase32: &str,
+    nonce_bytes: &[u8],
+) -> Result<Vec<u8>, JsError> {
+    core::compute_cert_fp_binding(cert_der, host_pk_zbase32, client_pk_zbase32, nonce_bytes)
+        .map(|arr| arr.to_vec())
+        .map_err(|e| to_js_err(&e))
+}
+
+/// Produce the AUTH_CLIENT payload (96 bytes: 32B client_pk ||
+/// 64B Ed25519 sig over `auth_bytes`).
+#[wasm_bindgen]
+pub fn sign_auth_client(client_sk_bytes: &[u8], auth_bytes: &[u8]) -> Result<Vec<u8>, JsError> {
+    core::sign_auth_client(client_sk_bytes, auth_bytes).map_err(|e| to_js_err(&e))
+}
+
+/// Verify the daemon's AUTH_HOST 64-byte signature against
+/// `auth_bytes` under `host_pk`. Returns a `bool`.
+#[wasm_bindgen]
+pub fn verify_auth_host(
+    host_pk_zbase32: &str,
+    auth_bytes: &[u8],
+    signature_64b: &[u8],
+) -> Result<bool, JsError> {
+    core::verify_auth_host(host_pk_zbase32, auth_bytes, signature_64b).map_err(|e| to_js_err(&e))
+}
+
+/// Encode one wire frame for the data channel.
+#[wasm_bindgen]
+pub fn encode_frame(frame_type_u8: u8, payload: Vec<u8>) -> Result<Vec<u8>, JsError> {
+    core::encode_frame(frame_type_u8, payload).map_err(|e| to_js_err(&e))
+}
+
+/// Try to decode one frame from the front of `buf`. Returns JS `null`
+/// on incomplete buffer; a `DecodedFrame` object otherwise.
+#[wasm_bindgen]
+pub fn decode_frame(buf: &[u8]) -> Result<JsValue, JsError> {
+    let out = core::decode_frame(buf).map_err(|e| to_js_err(&e))?;
+    to_js(&out)
+}

--- a/crates/openhost-pkarr-wasm/src/lib.rs
+++ b/crates/openhost-pkarr-wasm/src/lib.rs
@@ -213,3 +213,22 @@ pub fn decode_frame(buf: &[u8]) -> Result<JsValue, JsError> {
     let out = core::decode_frame(buf).map_err(|e| to_js_err(&e))?;
     to_js(&out)
 }
+
+/// Derive the client's zbase32 Ed25519 pubkey from its 32-byte seed.
+#[wasm_bindgen]
+pub fn client_pubkey_from_seed(seed_bytes: &[u8]) -> Result<String, JsError> {
+    core::client_pubkey_from_seed(seed_bytes).map_err(|e| to_js_err(&e))
+}
+
+/// Assemble a serialized Pkarr `SignedPacket` carrying the client's
+/// offer TXT, ready for `PUT https://<relay>/<client-pk-zbase32>`.
+#[wasm_bindgen]
+pub fn build_offer_packet(
+    client_sk_bytes: &[u8],
+    daemon_pk_zbase32: &str,
+    sealed_offer: &[u8],
+    now_ts: u64,
+) -> Result<Vec<u8>, JsError> {
+    core::build_offer_packet(client_sk_bytes, daemon_pk_zbase32, sealed_offer, now_ts)
+        .map_err(|e| to_js_err(&e))
+}

--- a/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
+++ b/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
@@ -202,3 +202,157 @@ fn decode_answer_fragments_reassembles_published_fragments() {
     let opened = rebuilt.open(&client_sk).expect("sealed bytes open");
     assert_eq!(opened.answer_sdp, plaintext.answer_sdp);
 }
+
+// ============================================================================
+// Phase 4 browser-primitive smoke tests (PR #28.3)
+// ============================================================================
+
+#[test]
+fn seal_offer_roundtrips_via_daemon_open() {
+    use openhost_pkarr::offer::OfferRecord;
+
+    let daemon_sk = SigningKey::from_bytes(&SEED);
+    let daemon_pk_z = daemon_sk.public_key().to_zbase32();
+    let client_sk = SigningKey::from_bytes(&CLIENT_SEED);
+    let client_pk_z = client_sk.public_key().to_zbase32();
+
+    let sealed = core::seal_offer(
+        &daemon_pk_z,
+        &client_pk_z,
+        "v=0\r\na=setup:active\r\n",
+        0x02,
+    )
+    .expect("seal ok");
+
+    // Daemon-side open path: rebuild an OfferRecord from the sealed
+    // bytes and invoke AnswerPlaintext-style open through the CLI's
+    // existing unseal surface.
+    let record = OfferRecord { sealed };
+    let plain = record.open(&daemon_sk).expect("daemon opens sealed offer");
+    assert_eq!(
+        plain.client_pk.to_bytes(),
+        client_sk.public_key().to_bytes()
+    );
+    assert_eq!(plain.offer_sdp, "v=0\r\na=setup:active\r\n");
+    assert_eq!(plain.binding_mode, openhost_pkarr::BindingMode::CertFp);
+}
+
+#[test]
+fn seal_offer_rejects_unknown_binding_mode() {
+    let daemon_pk_z = SigningKey::from_bytes(&SEED).public_key().to_zbase32();
+    let client_pk_z = SigningKey::from_bytes(&CLIENT_SEED)
+        .public_key()
+        .to_zbase32();
+    assert!(matches!(
+        core::seal_offer(&daemon_pk_z, &client_pk_z, "v=0\r\n", 0xFF),
+        Err(core::Error::Pkarr(_))
+    ));
+}
+
+#[test]
+fn open_answer_roundtrips_via_client_sk() {
+    use openhost_pkarr::AnswerEntry;
+    use openhost_pkarr::AnswerPlaintext;
+
+    let daemon_sk = SigningKey::from_bytes(&SEED);
+    let client_sk = SigningKey::from_bytes(&CLIENT_SEED);
+    let client_pk = client_sk.public_key();
+    let salt = [0x22u8; SALT_LEN];
+    let plaintext = AnswerPlaintext {
+        daemon_pk: daemon_sk.public_key(),
+        offer_sdp_hash: openhost_pkarr::hash_offer_sdp("v=0"),
+        answer_sdp: "v=0\r\na=setup:passive\r\n".to_string(),
+    };
+    let mut rng = rand::rngs::OsRng;
+    let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, now_ts()).expect("seal");
+
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    let sealed_b64 = URL_SAFE_NO_PAD.encode(&entry.sealed);
+
+    let opened = core::open_answer(&client_sk.to_bytes(), &sealed_b64).expect("open");
+    assert_eq!(opened.answer_sdp, plaintext.answer_sdp);
+    assert_eq!(
+        opened.daemon_pk_zbase32,
+        daemon_sk.public_key().to_zbase32()
+    );
+}
+
+#[test]
+fn cert_fp_binding_matches_sha256_hkdf_daemon_path() {
+    use openhost_core::crypto::auth_bytes_bound;
+
+    let host_sk = SigningKey::from_bytes(&SEED);
+    let host_pk = host_sk.public_key();
+    let client_sk = SigningKey::from_bytes(&CLIENT_SEED);
+    let client_pk = client_sk.public_key();
+    let cert_der = b"-----FAKE-DTLS-CERT-DER-BYTES-----";
+    let nonce = [0x77u8; 32];
+
+    let wasm_auth = core::compute_cert_fp_binding(
+        cert_der,
+        &host_pk.to_zbase32(),
+        &client_pk.to_zbase32(),
+        &nonce,
+    )
+    .expect("compute");
+
+    // Reproduce the daemon's derive_binding_secret(CertFp) path by
+    // hand: SHA-256(DER) → HKDF-SHA256 with the standard bound
+    // context → 32 auth bytes.
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(cert_der);
+    let secret: [u8; 32] = h.finalize().into();
+    let expect =
+        auth_bytes_bound(&secret, &host_pk.to_bytes(), &client_pk.to_bytes(), &nonce).unwrap();
+    assert_eq!(wasm_auth, expect);
+}
+
+#[test]
+fn sign_auth_client_and_verify_auth_host_roundtrip() {
+    let host_sk = SigningKey::from_bytes(&SEED);
+    let client_sk = SigningKey::from_bytes(&CLIENT_SEED);
+
+    let auth_bytes = [0x42u8; 32];
+    // Sign AUTH_CLIENT (browser path).
+    let payload = core::sign_auth_client(&client_sk.to_bytes(), &auth_bytes).expect("sign");
+    assert_eq!(payload.len(), 32 + 64);
+    assert_eq!(&payload[..32], &client_sk.public_key().to_bytes()[..]);
+
+    // Server signs AUTH_HOST with its own key; client verifies.
+    let host_sig = host_sk.sign(&auth_bytes).to_bytes();
+    let ok = core::verify_auth_host(&host_sk.public_key().to_zbase32(), &auth_bytes, &host_sig)
+        .expect("verify runs");
+    assert!(ok, "valid AUTH_HOST sig must verify");
+
+    // Flip a bit → fails.
+    let mut tampered = host_sig;
+    tampered[0] ^= 0x01;
+    let bad =
+        core::verify_auth_host(&host_sk.public_key().to_zbase32(), &auth_bytes, &tampered).unwrap();
+    assert!(!bad, "tampered signature must fail verify");
+}
+
+#[test]
+fn encode_decode_frame_roundtrip_and_partial_buffer_is_none() {
+    // Happy path: REQUEST_HEAD with a small payload.
+    let req_head_type = 0x01u8;
+    let payload = b"GET / HTTP/1.1\r\nHost: openhost\r\n\r\n".to_vec();
+    let bytes = core::encode_frame(req_head_type, payload.clone()).expect("encode");
+    // Header = 1 + 4 bytes.
+    assert_eq!(bytes.len(), 5 + payload.len());
+
+    let decoded = core::decode_frame(&bytes).expect("decode").expect("some");
+    assert_eq!(decoded.frame_type, req_head_type);
+    assert_eq!(decoded.payload, payload);
+    assert_eq!(decoded.consumed, bytes.len());
+
+    // Partial header (< 5 bytes) → None.
+    let partial = core::decode_frame(&bytes[..3]).expect("decode partial");
+    assert!(partial.is_none());
+
+    // Unknown frame type → Err.
+    let err = core::encode_frame(0xEE, vec![]).expect_err("unknown type rejected");
+    assert!(matches!(err, core::Error::Frame(_)));
+}

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -57,9 +57,10 @@ pub use error::{PkarrError, Result};
 pub use offer::{
     answer_txt_chunk_name, answer_txt_name, client_hash_label, decode_answer_fragments_from_packet,
     decode_offer_from_packet, encode_with_answers, hash_offer_sdp, host_hash, host_hash_label,
-    offer_txt_name, AnswerEntry, AnswerPlaintext, OfferPlaintext, OfferRecord, ANSWER_TXT_PREFIX,
-    CLIENT_HASH_LEN, HOST_HASH_LEN, MAX_FRAGMENT_PAYLOAD_BYTES, MAX_FRAGMENT_TOTAL,
-    OFFER_SDP_HASH_LEN, OFFER_TXT_PREFIX, OFFER_TXT_TTL,
+    offer_txt_name, AnswerEntry, AnswerPlaintext, BindingMode, OfferPlaintext, OfferRecord,
+    ANSWER_TXT_PREFIX, CLIENT_HASH_LEN, HOST_HASH_LEN, MAX_FRAGMENT_PAYLOAD_BYTES,
+    MAX_FRAGMENT_TOTAL, OFFER_INNER_DOMAIN_V1, OFFER_INNER_DOMAIN_V2, OFFER_SDP_HASH_LEN,
+    OFFER_TXT_PREFIX, OFFER_TXT_TTL,
 };
 pub use pkarr::SignedPacket;
 #[cfg(feature = "full")]

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -100,11 +100,70 @@ impl CompressionTag {
 /// exceed this cap.
 const MAX_DECOMPRESSED_PLAINTEXT: usize = 64 * 1024;
 
-/// Domain separator embedded in the offer inner plaintext.
-pub const OFFER_INNER_DOMAIN: &[u8] = b"openhost-offer-inner1";
+/// Domain separator for the v1 offer inner plaintext body. Still
+/// accepted on decode for backwards compatibility; v1 bodies carry no
+/// explicit `binding_mode` byte and default to
+/// [`BindingMode::Exporter`]. New encoders emit v2 via
+/// [`OFFER_INNER_DOMAIN_V2`].
+pub const OFFER_INNER_DOMAIN_V1: &[u8] = b"openhost-offer-inner1";
+
+/// Alias for [`OFFER_INNER_DOMAIN_V1`]. Retained for downstream
+/// diagnostic tooling that referenced the pre-PR-28.3 constant name.
+pub const OFFER_INNER_DOMAIN: &[u8] = OFFER_INNER_DOMAIN_V1;
+
+/// Domain separator for the v2 offer inner plaintext body (PR #28.3+).
+/// v2 appends a 1-byte `binding_mode` field after the SDP so browsers
+/// can advertise cert-fingerprint binding (see [`BindingMode`]).
+pub const OFFER_INNER_DOMAIN_V2: &[u8] = b"openhost-offer-inner2";
 
 /// Domain separator embedded in the answer inner plaintext.
 pub const ANSWER_INNER_DOMAIN: &[u8] = b"openhost-answer-inner1";
+
+/// Channel-binding mode advertised by the client in an offer plaintext.
+///
+/// - [`Exporter`][BindingMode::Exporter]: RFC 5705 DTLS exporter bytes
+///   feed the channel-binding HMAC (the original CLI-to-CLI path).
+///   Spec reference: `spec/04-security.md §7.6` "exporter binding."
+/// - [`CertFp`][BindingMode::CertFp]: SHA-256 of the host's DTLS
+///   certificate DER substitutes for the exporter bytes. Required for
+///   browser clients — `RTCDtlsTransport` does not expose the RFC 5705
+///   exporter today. The cert fingerprint is pinned via Pkarr so an
+///   attacker who forges a matching fingerprint has already broken the
+///   host's Ed25519 identity key; the security delta vs. Exporter is
+///   therefore near-zero for openhost's threat model. See
+///   `spec/04-security.md §7.6` "cert-fingerprint binding."
+///
+/// Wire format: 1 byte. `0x01` = Exporter, `0x02` = CertFp, other
+/// values rejected on decode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum BindingMode {
+    /// RFC 5705 DTLS exporter binding (CLI default).
+    Exporter = 0x01,
+    /// SHA-256-of-cert-DER binding (browser-mandatory).
+    CertFp = 0x02,
+}
+
+impl BindingMode {
+    /// Encode the mode as the single byte that lands on the wire.
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Parse a wire byte into a `BindingMode`. Unknown bytes are a
+    /// hard decode error — the shim must refuse to speak an unknown
+    /// binding protocol.
+    pub fn try_from_u8(b: u8) -> Result<Self> {
+        match b {
+            0x01 => Ok(Self::Exporter),
+            0x02 => Ok(Self::CertFp),
+            _ => Err(PkarrError::MalformedCanonical(
+                "unknown offer binding_mode byte",
+            )),
+        }
+    }
+}
 
 /// Domain separator used when deriving the `_offer.` DNS label from the
 /// daemon's pubkey. Domain-separated from `allowlist_hash` so observers
@@ -298,6 +357,25 @@ pub struct OfferPlaintext {
     pub client_pk: PublicKey,
     /// SDP offer text (UTF-8).
     pub offer_sdp: String,
+    /// Channel-binding mode the client will use on the resulting data
+    /// channel. v1 offer bodies on the wire carry no binding_mode byte
+    /// and decode with [`BindingMode::Exporter`]; v2 bodies (PR #28.3+)
+    /// carry it explicitly.
+    pub binding_mode: BindingMode,
+}
+
+impl OfferPlaintext {
+    /// Convenience constructor matching the pre-PR-28.3 field set;
+    /// `binding_mode` defaults to [`BindingMode::Exporter`], preserving
+    /// the CLI-to-CLI semantics that predated browser support.
+    #[must_use]
+    pub fn new(client_pk: PublicKey, offer_sdp: String) -> Self {
+        Self {
+            client_pk,
+            offer_sdp,
+            binding_mode: BindingMode::Exporter,
+        }
+    }
 }
 
 /// One answer record the daemon has queued for publication. Each entry
@@ -792,30 +870,57 @@ fn collect_single_txt(packet: &SignedPacket, name: &str) -> Result<Option<String
 // Inner plaintext encode / decode
 // ============================================================================
 
-/// Shape of the v1 body: `domain || client_pk || sdp_len(u32be) || sdp`.
-/// No leading compression tag — that's added by
-/// [`encode_offer_plaintext`] / [`parse_offer_plaintext`] around the
-/// compression layer.
+/// Encode an offer body in the v2 shape (PR #28.3+).
+///
+/// Wire layout:
+///
+/// ```text
+/// domain(OFFER_INNER_DOMAIN_V2) || client_pk(32B) ||
+/// sdp_len(u32 BE) || sdp || binding_mode(u8)
+/// ```
+///
+/// Decoders MUST accept both v1 and v2 shapes (see
+/// [`parse_offer_body`]); encoders MUST emit v2 so every offer
+/// advertises its binding mode explicitly.
+///
+/// The surrounding [`encode_offer_plaintext`] wraps the body with a
+/// compression tag byte — this function only produces the body.
 fn encode_offer_body(p: &OfferPlaintext) -> Vec<u8> {
     let sdp = p.offer_sdp.as_bytes();
-    let mut out = Vec::with_capacity(OFFER_INNER_DOMAIN.len() + PUBLIC_KEY_LEN + 4 + sdp.len());
-    out.extend_from_slice(OFFER_INNER_DOMAIN);
+    let mut out =
+        Vec::with_capacity(OFFER_INNER_DOMAIN_V2.len() + PUBLIC_KEY_LEN + 4 + sdp.len() + 1);
+    out.extend_from_slice(OFFER_INNER_DOMAIN_V2);
     out.extend_from_slice(&p.client_pk.to_bytes());
     let len = u32::try_from(sdp.len())
         .expect("SDP length bounded well below u32::MAX by BEP44 1000-byte cap");
     out.extend_from_slice(&len.to_be_bytes());
     out.extend_from_slice(sdp);
+    out.push(p.binding_mode.as_u8());
     out
 }
 
+/// Parse an offer body. Accepts v1 (`openhost-offer-inner1`, no
+/// binding_mode byte — defaults to [`BindingMode::Exporter`]) and v2
+/// (`openhost-offer-inner2`, trailing binding_mode byte required).
 fn parse_offer_body(body: &[u8]) -> Result<OfferPlaintext> {
-    let mut r = InnerCursor::new(body);
-    let domain = r.take(OFFER_INNER_DOMAIN.len())?;
-    if domain != OFFER_INNER_DOMAIN {
+    // Peek the domain to pick a parser.
+    if body.len() < OFFER_INNER_DOMAIN_V1.len() {
         return Err(PkarrError::MalformedCanonical(
-            "missing openhost-offer-inner1 domain separator",
+            "offer plaintext shorter than domain separator",
         ));
     }
+    let domain = &body[..OFFER_INNER_DOMAIN_V1.len()];
+    let is_v2 = domain == OFFER_INNER_DOMAIN_V2;
+    let is_v1 = domain == OFFER_INNER_DOMAIN_V1;
+    if !is_v1 && !is_v2 {
+        return Err(PkarrError::MalformedCanonical(
+            "unknown openhost-offer-inner domain separator",
+        ));
+    }
+
+    let mut r = InnerCursor::new(body);
+    // Consume the domain; we already validated it above.
+    let _domain = r.take(OFFER_INNER_DOMAIN_V1.len())?;
     let mut pk_bytes = [0u8; PUBLIC_KEY_LEN];
     pk_bytes.copy_from_slice(r.take(PUBLIC_KEY_LEN)?);
     let client_pk = PublicKey::from_bytes(&pk_bytes).map_err(PkarrError::Core)?;
@@ -824,6 +929,12 @@ fn parse_offer_body(body: &[u8]) -> Result<OfferPlaintext> {
     let offer_sdp = core::str::from_utf8(sdp_bytes)
         .map_err(|_| PkarrError::MalformedCanonical("offer SDP is not valid UTF-8"))?
         .to_string();
+    let binding_mode = if is_v2 {
+        let b = r.u8()?;
+        BindingMode::try_from_u8(b)?
+    } else {
+        BindingMode::Exporter
+    };
     if !r.is_empty() {
         return Err(PkarrError::MalformedCanonical(
             "trailing bytes after offer plaintext",
@@ -832,6 +943,7 @@ fn parse_offer_body(body: &[u8]) -> Result<OfferPlaintext> {
     Ok(OfferPlaintext {
         client_pk,
         offer_sdp,
+        binding_mode,
     })
 }
 
@@ -1095,6 +1207,7 @@ mod tests {
         let p = OfferPlaintext {
             client_pk,
             offer_sdp: SAMPLE_OFFER_SDP.to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let enc = encode_offer_plaintext(&p);
         let dec = parse_offer_plaintext(&enc).unwrap();
@@ -1106,6 +1219,7 @@ mod tests {
         let p = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: "v=0".to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let mut enc = encode_offer_plaintext(&p);
         enc[0] = 0xFF;
@@ -1123,6 +1237,7 @@ mod tests {
         let p = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: "v=0".to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let enc = encode_offer_plaintext(&p);
         assert!(matches!(
@@ -1131,21 +1246,96 @@ mod tests {
         ));
     }
 
-    /// Hand-craft a v1 (uncompressed) offer plaintext and confirm the
-    /// new v2 decoder accepts it. Locks the legacy wire layout against
+    /// Hand-craft a legacy v1 *body* (the pre-PR-28.3 shape: v1 domain
+    /// separator, no trailing `binding_mode` byte) wrapped in the
+    /// Uncompressed compression tag, and confirm the new v2-aware
+    /// decoder accepts it with `binding_mode = Exporter` as the
+    /// documented default. Locks the legacy wire layout against
     /// accidental encoder breakage.
     #[test]
-    fn offer_plaintext_accepts_v1_uncompressed_for_backcompat() {
-        let p = OfferPlaintext {
-            client_pk: client_sk().public_key(),
-            offer_sdp: SAMPLE_OFFER_SDP.to_string(),
-        };
-        let body = encode_offer_body(&p);
-        let mut v1 = Vec::with_capacity(1 + body.len());
-        v1.push(0x01);
-        v1.extend_from_slice(&body);
-        let dec = parse_offer_plaintext(&v1).unwrap();
-        assert_eq!(dec, p);
+    fn offer_plaintext_accepts_v1_uncompressed_body_for_backcompat() {
+        let client_pk = client_sk().public_key();
+        let sdp = SAMPLE_OFFER_SDP.as_bytes();
+        // Handroll the v1 body verbatim — do NOT route through
+        // encode_offer_body, which now emits v2.
+        let mut body =
+            Vec::with_capacity(OFFER_INNER_DOMAIN_V1.len() + PUBLIC_KEY_LEN + 4 + sdp.len());
+        body.extend_from_slice(OFFER_INNER_DOMAIN_V1);
+        body.extend_from_slice(&client_pk.to_bytes());
+        body.extend_from_slice(&u32::try_from(sdp.len()).unwrap().to_be_bytes());
+        body.extend_from_slice(sdp);
+
+        let mut wrapped = Vec::with_capacity(1 + body.len());
+        wrapped.push(CompressionTag::Uncompressed as u8);
+        wrapped.extend_from_slice(&body);
+
+        let dec = parse_offer_plaintext(&wrapped).unwrap();
+        assert_eq!(dec.client_pk, client_pk);
+        assert_eq!(dec.offer_sdp, SAMPLE_OFFER_SDP);
+        assert_eq!(
+            dec.binding_mode,
+            BindingMode::Exporter,
+            "v1 bodies must default to Exporter binding",
+        );
+    }
+
+    /// v2 bodies MUST round-trip both binding modes byte-for-byte.
+    #[test]
+    fn offer_plaintext_v2_roundtrips_both_binding_modes() {
+        for mode in [BindingMode::Exporter, BindingMode::CertFp] {
+            let p = OfferPlaintext {
+                client_pk: client_sk().public_key(),
+                offer_sdp: SAMPLE_OFFER_SDP.to_string(),
+                binding_mode: mode,
+            };
+            let enc = encode_offer_plaintext(&p);
+            let dec = parse_offer_plaintext(&enc).unwrap();
+            assert_eq!(dec, p, "roundtrip failed for {mode:?}");
+        }
+    }
+
+    /// A v2 body with a garbage binding_mode byte must be rejected as
+    /// malformed — we never silently downgrade to a default mode when
+    /// the explicit byte is present but unknown.
+    #[test]
+    fn offer_plaintext_v2_rejects_unknown_binding_mode_byte() {
+        let client_pk = client_sk().public_key();
+        let sdp = SAMPLE_OFFER_SDP.as_bytes();
+        let mut body =
+            Vec::with_capacity(OFFER_INNER_DOMAIN_V2.len() + PUBLIC_KEY_LEN + 4 + sdp.len() + 1);
+        body.extend_from_slice(OFFER_INNER_DOMAIN_V2);
+        body.extend_from_slice(&client_pk.to_bytes());
+        body.extend_from_slice(&u32::try_from(sdp.len()).unwrap().to_be_bytes());
+        body.extend_from_slice(sdp);
+        body.push(0xFF); // garbage binding_mode
+
+        let mut wrapped = Vec::with_capacity(1 + body.len());
+        wrapped.push(CompressionTag::Uncompressed as u8);
+        wrapped.extend_from_slice(&body);
+
+        assert!(matches!(
+            parse_offer_plaintext(&wrapped),
+            Err(PkarrError::MalformedCanonical(
+                "unknown offer binding_mode byte"
+            )),
+        ));
+    }
+
+    #[test]
+    fn binding_mode_try_from_rejects_unknown_bytes() {
+        assert!(matches!(
+            BindingMode::try_from_u8(0x00),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+        assert!(matches!(
+            BindingMode::try_from_u8(0xFF),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+        assert_eq!(
+            BindingMode::try_from_u8(0x01).unwrap(),
+            BindingMode::Exporter
+        );
+        assert_eq!(BindingMode::try_from_u8(0x02).unwrap(), BindingMode::CertFp);
     }
 
     /// Zlib compression MUST strictly shrink a realistic-sized SDP
@@ -1164,6 +1354,7 @@ mod tests {
         let p = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: sdp.clone(),
+            binding_mode: BindingMode::Exporter,
         };
         let v1_body = encode_offer_body(&p);
         let v1_total = 1 + v1_body.len();
@@ -1200,6 +1391,7 @@ mod tests {
         let p = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: String::new(),
+            binding_mode: BindingMode::Exporter,
         };
         let enc = encode_offer_plaintext(&p);
         let dec = parse_offer_plaintext(&enc).unwrap();
@@ -1244,6 +1436,7 @@ mod tests {
         let plaintext = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: SAMPLE_OFFER_SDP.to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let mut rng = deterministic_rng();
         let record = OfferRecord::seal(&mut rng, &daemon_pk, &plaintext).unwrap();
@@ -1257,6 +1450,7 @@ mod tests {
         let plaintext = OfferPlaintext {
             client_pk: client_sk().public_key(),
             offer_sdp: SAMPLE_OFFER_SDP.to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let mut rng = deterministic_rng();
         let record = OfferRecord::seal(&mut rng, &daemon_pk, &plaintext).unwrap();
@@ -1702,6 +1896,7 @@ mod tests {
         let plaintext = OfferPlaintext {
             client_pk: client_sk.public_key(),
             offer_sdp: SAMPLE_OFFER_SDP.to_string(),
+            binding_mode: BindingMode::Exporter,
         };
         let mut rng = deterministic_rng();
         let offer = OfferRecord::seal(&mut rng, &daemon_pk, &plaintext).unwrap();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,13 @@
 {
   "manifest_version": 3,
   "name": "openhost",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Your home server. Reachable. Nothing else in between. Resolve oh://<pubkey>/ URLs over end-to-end encrypted WebRTC.",
-  "permissions": [],
+  "permissions": [
+    "webNavigation",
+    "tabs",
+    "storage"
+  ],
   "host_permissions": [
     "https://relay.pkarr.org/*",
     "https://pkarr.pubky.app/*",
@@ -16,6 +20,12 @@
   "action": {
     "default_title": "openhost"
   },
+  "web_accessible_resources": [
+    {
+      "resources": ["viewer.html", "src/*", "wasm/pkg/*"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   }

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -1,34 +1,29 @@
 // openhost extension service worker (MV3).
 //
-// PR #28.2 ships the first real code alongside this stub: a WASM
-// build of openhost-pkarr's resolver read path. The service worker
-// stays passive by default so the installed extension does not make
-// any network requests without an operator opt-in. Uncomment the
-// probe wiring at the bottom of this file to exercise the four
-// resolver exports.
+// PR #28.3 Phase 6 wires up the URL handler: the service worker
+// listens for navigations to `oh://<pk>/...`, cancels them, and opens
+// the extension-served viewer tab which then runs the dial.
 //
-// PR #28.3 will replace the probe-wiring scaffolding here with the
-// WASM-compiled Dialer state machine. PR #28.4 will register the
-// `oh://` URL handler. Until then, loading the extension just prints
-// a single roadmap line to the service-worker devtools console.
+// The resolver probe from PR #28.2 is kept; to exercise it directly
+// (without going through a tab) uncomment the block at the bottom.
+
+import { installOhNavigationHandler } from "./url_handler/oh_navigator.js";
 
 console.log(
-  "openhost extension: scaffolding only; see extension/README.md for the roadmap",
+  "openhost extension: service worker booted; arming oh:// handler",
 );
 
+installOhNavigationHandler();
+
 // ---------------------------------------------------------------------------
-// PR #28.2 resolver probe — dev-only.
+// PR #28.2 resolver probe — dev-only, stays opt-in.
 //
-// To exercise the four wasm-bindgen exports (parse_host_record,
-// decode_and_verify, decode_offer, decode_answer_fragments):
+// To exercise the four WASM decode exports without the full dial:
 //
 //   1. Build the WASM pkg:  `./extension/scripts/build-wasm.sh`
 //   2. Uncomment the lines below; replace <pubkey> with a 52-char
-//      zbase32 pubkey of a running openhost daemon. Your own daemon's
-//      pubkey is the easiest — read it from openhostd's logs.
+//      zbase32 pubkey of a running openhost daemon.
 //   3. Reload the unpacked extension in chrome://extensions.
-//   4. Inspect the service-worker devtools console; you should see
-//      four `[probe] …` log lines.
 //
 // import { runResolverProbe } from "./dev/resolver-probe.js";
 // runResolverProbe("<pubkey-zbase32>");

--- a/extension/src/dialer/openhost_session.js
+++ b/extension/src/dialer/openhost_session.js
@@ -158,6 +158,14 @@ export async function dialOhUrl(ohUrl, opts = {}) {
   // 1. Resolve + verify host record.
   const hostPacket = await fetchHostPacket(daemonPkZ);
   const hostRecord = decode_and_verify(hostPacket, daemonPkZ, nowTsBig);
+  if (hostRecord.pubkey_zbase32 !== daemonPkZ) {
+    // decode_and_verify already passed, so this is belt-and-suspenders —
+    // the WASM layer pins the pubkey it was asked about into the DTO.
+    // A mismatch here means something upstream re-shaped the struct.
+    throw new Error(
+      `host-record pubkey mismatch: asked ${daemonPkZ}, got ${hostRecord.pubkey_zbase32}`,
+    );
+  }
   const daemonSalt = hexToBytes(hostRecord.salt_hex);
 
   // 2. Client identity.
@@ -262,13 +270,21 @@ function waitForDcOpen(dc, timeoutMs) {
 async function readRemoteCertDer(pc) {
   // RTCDtlsTransport.getRemoteCertificates() returns an ArrayBuffer[]
   // (Chromium). Only the first cert is the peer's leaf.
+  //
+  // On some Chromium builds the cert array is populated *just after*
+  // connectionState flips to "connected"; a short retry loop avoids a
+  // false AUTH_NONCE-before-cert race on fast local connections.
   const transport = pc.sctp?.transport;
   if (!transport || typeof transport.getRemoteCertificates !== "function") {
     throw new Error("RTCDtlsTransport.getRemoteCertificates() unavailable");
   }
-  const certs = transport.getRemoteCertificates();
-  if (!certs || certs.length === 0) throw new Error("remote DTLS cert not available yet");
-  return new Uint8Array(certs[0]);
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    const certs = transport.getRemoteCertificates();
+    if (certs && certs.length > 0) return new Uint8Array(certs[0]);
+    await new Promise(r => setTimeout(r, 25));
+  }
+  throw new Error("remote DTLS cert not available 1s after DC open");
 }
 
 async function publishOfferPacket(clientPkZ, packetBytes) {

--- a/extension/src/dialer/openhost_session.js
+++ b/extension/src/dialer/openhost_session.js
@@ -1,32 +1,24 @@
-// Browser-side OpenhostSession skeleton (PR #28.3 Phase 6).
+// Browser-side OpenhostSession (PR #28.3 Phase 6 + 6.1).
 //
-// Owns an RTCPeerConnection and drives the dial handshake by calling
-// into `openhost-pkarr-wasm` for sealing / cert-fp binding / frame
-// codec. JS never touches the client Ed25519 secret directly; it
-// lives in IndexedDB and is passed as raw bytes into WASM only.
+// Owns an RTCPeerConnection and drives the full dial handshake by
+// calling into `openhost-pkarr-wasm` for sealing / cert-fp binding /
+// frame codec / pkarr packet signing. JS never touches the client
+// Ed25519 secret directly; it lives in IndexedDB and is passed as
+// raw bytes into WASM only.
 //
-// ## Status — what ships in PR #28.3
-//
-// This file establishes the class shape + wires the resolver (PR
-// #28.2) + the WASM primitives (Phase 4) into a single entry point
-// `dialOhUrl(ohUrl)`. The actual publish-offer step is deferred to
-// **PR #28.3.1** because it requires two things not available yet:
-//
-//   1. A WASM-exported `client_pubkey_from_seed(seed) -> zbase32` so
-//      JS can compute its own identity pubkey without re-implementing
-//      Ed25519 point multiplication in JS. Cheap follow-up.
-//   2. A WASM-exported `build_offer_packet(client_sk, daemon_pk, sealed)
-//      -> Uint8Array` that returns the serialized pkarr `SignedPacket`
-//      bytes ready for a Pkarr relay PUT. Today the relay API expects
-//      a full BEP44 mutable-item body (Ed25519 signature + DNS wire
-//      format). Shipping it as WASM reuses the existing
-//      `openhost_pkarr::encode_with_answers` path with no client-side
-//      wire-format duplication.
-//
-// Both gaps are small, scoped follow-ups on the same branch. The
-// rest of the extension (URL handler, viewer, manifest, service
-// worker) is wired up in this PR so the review surface stays
-// digestible.
+// End-to-end flow:
+//   1. Resolve host packet (fetch from a Pkarr relay, WASM-verify).
+//   2. Load or create a per-install client seed (IndexedDB).
+//   3. Build RTCPeerConnection + data channel, create offer SDP.
+//   4. WASM `seal_offer` → `build_offer_packet` (Ed25519-signed
+//      BEP44 body) → HTTP PUT to a Pkarr relay.
+//   5. Poll host zone for `_answer-<client-hash>-*` fragments; WASM
+//      `decode_answer_fragments` + `open_answer`.
+//   6. Apply answer SDP; await DTLS `connected` + DC `open`.
+//   7. Channel binding: AUTH_NONCE → compute cert-fp binding →
+//      sign_auth_client → send AUTH_CLIENT → verify AUTH_HOST.
+//   8. Return a live OpenhostSession; caller issues HTTP via
+//      session.request("GET", "/path").
 
 import init, {
   decode_and_verify,
@@ -37,6 +29,8 @@ import init, {
   sign_auth_client,
   verify_auth_host,
   encode_frame,
+  client_pubkey_from_seed,
+  build_offer_packet,
 } from "../../wasm/pkg/openhost_pkarr.js";
 import { FrameReader } from "../session/frame_reader.js";
 
@@ -154,30 +148,162 @@ export class OpenhostSession {
   }
 }
 
-// Full dial. **Not runnable end-to-end in PR #28.3** — see the status
-// block at the top of this file for the Phase 6.1 gap.
-export async function dialOhUrl(ohUrl) {
+// Full dial: resolve → seal + publish offer → poll answer → WebRTC
+// connect → cert-fp binding handshake → return a live session.
+export async function dialOhUrl(ohUrl, opts = {}) {
   await ensureWasmInit();
   const { daemonPkZ, path } = parseOhUrl(ohUrl);
-  const nowTs = BigInt(Math.floor(Date.now() / 1000));
+  const nowTsBig = BigInt(Math.floor(Date.now() / 1000));
 
-  // 1. Resolve + verify host record via the PR #28.2 WASM path.
+  // 1. Resolve + verify host record.
   const hostPacket = await fetchHostPacket(daemonPkZ);
-  const hostRecord = decode_and_verify(hostPacket, daemonPkZ, nowTs);
+  const hostRecord = decode_and_verify(hostPacket, daemonPkZ, nowTsBig);
+  const daemonSalt = hexToBytes(hostRecord.salt_hex);
 
   // 2. Client identity.
   const clientSeed = await loadOrCreateClientSeed();
+  const clientPkZ = client_pubkey_from_seed(clientSeed);
 
-  // 3-12: handshake wiring. Marked as a deliberate throw until the
-  // publish bridge (WASM `build_offer_packet` + `client_pubkey_from_seed`)
-  // lands in PR #28.3.1. The resolver probe in
-  // `extension/src/dev/resolver-probe.js` still exercises the
-  // already-shipped WASM surface end-to-end.
-  throw new Error(
-    `openhost extension: dial pipeline wired up through WASM seal/binding/framing, ` +
-    `but the Pkarr publish bridge is pending PR #28.3.1 (need WASM ` +
-    `build_offer_packet + client_pubkey_from_seed). Target: ${daemonPkZ}${path}. ` +
-    `Host fingerprint: ${hostRecord.dtls_fingerprint_hex}. ` +
-    `Client seed is persisted in IndexedDB (32 bytes).`
-  );
+  // 3. Build RTCPeerConnection + data channel.
+  const pc = new RTCPeerConnection({ iceServers: STUN });
+  const dc = pc.createDataChannel("openhost", { ordered: true });
+  const reader = new FrameReader();
+  dc.binaryType = "arraybuffer";
+  dc.onmessage = e => reader.push(e.data);
+  dc.onerror = e => reader.fail(new Error(`DC error: ${e}`));
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  await waitForIceComplete(pc);
+  const offerSdp = pc.localDescription.sdp;
+
+  // 4. Seal + publish offer.
+  const sealed = seal_offer(daemonPkZ, clientPkZ, offerSdp, BINDING_MODE_CERT_FP);
+  const packet = build_offer_packet(clientSeed, daemonPkZ, sealed, BigInt(Math.floor(Date.now() / 1000)));
+  await publishOfferPacket(clientPkZ, packet);
+
+  // 5. Poll answer fragments on the daemon's zone.
+  const answerSdp = await pollAnswer({ daemonPkZ, daemonSalt, clientPkZ, clientSeed,
+                                       timeoutMs: opts.answerTimeoutMs ?? 30_000 });
+
+  // 6. Apply answer + wait for DTLS Connected.
+  await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+  await waitForPcConnected(pc, opts.connectTimeoutMs ?? 10_000);
+  await waitForDcOpen(dc, opts.connectTimeoutMs ?? 10_000);
+
+  // 7. Channel-binding handshake.
+  const nonceFrame = await reader.next(opts.bindingTimeoutMs ?? 10_000);
+  if (nonceFrame.frame_type !== FRAME.AUTH_NONCE) {
+    throw new Error(`expected AUTH_NONCE, got 0x${nonceFrame.frame_type.toString(16)}`);
+  }
+  const nonce = new Uint8Array(nonceFrame.payload);
+  const certDer = await readRemoteCertDer(pc);
+  const authBytes = compute_cert_fp_binding(certDer, daemonPkZ, clientPkZ, nonce);
+  const authClientPayload = sign_auth_client(clientSeed, authBytes);
+  dc.send(encode_frame(FRAME.AUTH_CLIENT, Array.from(authClientPayload)));
+
+  const hostFrame = await reader.next(opts.bindingTimeoutMs ?? 10_000);
+  if (hostFrame.frame_type !== FRAME.AUTH_HOST) {
+    throw new Error(`expected AUTH_HOST, got 0x${hostFrame.frame_type.toString(16)}`);
+  }
+  const ok = verify_auth_host(daemonPkZ, authBytes, new Uint8Array(hostFrame.payload));
+  if (!ok) {
+    pc.close();
+    throw new Error("AUTH_HOST signature did not verify — aborting session");
+  }
+
+  return new OpenhostSession({ pc, dc, reader, hostRecord, clientPkZ, daemonPkZ });
+}
+
+// ---- helpers ----
+
+function hexToBytes(hex) {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+
+function waitForIceComplete(pc) {
+  return new Promise(res => {
+    if (pc.iceGatheringState === "complete") return res();
+    const check = () => {
+      if (pc.iceGatheringState === "complete") {
+        pc.removeEventListener("icegatheringstatechange", check);
+        res();
+      }
+    };
+    pc.addEventListener("icegatheringstatechange", check);
+  });
+}
+
+function waitForPcConnected(pc, timeoutMs) {
+  return new Promise((res, rej) => {
+    if (pc.connectionState === "connected") return res();
+    const timer = setTimeout(() => rej(new Error(`PC connect timeout (${timeoutMs}ms)`)), timeoutMs);
+    const check = () => {
+      if (pc.connectionState === "connected") { clearTimeout(timer); res(); }
+      else if (["failed","closed","disconnected"].includes(pc.connectionState)) {
+        clearTimeout(timer); rej(new Error(`PC state: ${pc.connectionState}`));
+      }
+    };
+    pc.addEventListener("connectionstatechange", check);
+  });
+}
+
+function waitForDcOpen(dc, timeoutMs) {
+  return new Promise((res, rej) => {
+    if (dc.readyState === "open") return res();
+    const timer = setTimeout(() => rej(new Error(`DC open timeout (${timeoutMs}ms)`)), timeoutMs);
+    dc.addEventListener("open", () => { clearTimeout(timer); res(); }, { once: true });
+    dc.addEventListener("error", e => { clearTimeout(timer); rej(new Error(`DC error: ${e}`)); }, { once: true });
+  });
+}
+
+async function readRemoteCertDer(pc) {
+  // RTCDtlsTransport.getRemoteCertificates() returns an ArrayBuffer[]
+  // (Chromium). Only the first cert is the peer's leaf.
+  const transport = pc.sctp?.transport;
+  if (!transport || typeof transport.getRemoteCertificates !== "function") {
+    throw new Error("RTCDtlsTransport.getRemoteCertificates() unavailable");
+  }
+  const certs = transport.getRemoteCertificates();
+  if (!certs || certs.length === 0) throw new Error("remote DTLS cert not available yet");
+  return new Uint8Array(certs[0]);
+}
+
+async function publishOfferPacket(clientPkZ, packetBytes) {
+  let lastErr;
+  for (const r of RELAYS) {
+    try {
+      const resp = await fetch(`${r}/${clientPkZ}`, {
+        method: "PUT", body: packetBytes,
+        headers: { "Content-Type": "application/pkarr.org.relays.v1+octet" },
+      });
+      if (resp.ok) return;
+      lastErr = new Error(`${r} → ${resp.status}`);
+    } catch (e) { lastErr = e; }
+  }
+  throw new Error(`all relays rejected offer publish: ${lastErr?.message ?? "unknown"}`);
+}
+
+async function pollAnswer({ daemonPkZ, daemonSalt, clientPkZ, clientSeed, timeoutMs }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const packet = await fetchHostPacket(daemonPkZ);
+      const ans = decode_answer_fragments(packet, daemonSalt, clientPkZ);
+      if (ans) {
+        const opened = open_answer(clientSeed, ans.sealed_base64url);
+        if (opened.daemon_pk_zbase32 !== daemonPkZ) {
+          throw new Error("answer's inner daemon_pk does not match the packet signer");
+        }
+        return opened.answer_sdp;
+      }
+    } catch (e) {
+      // Keep polling on transient decode / relay errors.
+      if (e?.message && /verify|disagree|malformed|mismatch/i.test(e.message)) throw e;
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  throw new Error(`answer poll timed out after ${timeoutMs}ms`);
 }

--- a/extension/src/dialer/openhost_session.js
+++ b/extension/src/dialer/openhost_session.js
@@ -1,0 +1,183 @@
+// Browser-side OpenhostSession skeleton (PR #28.3 Phase 6).
+//
+// Owns an RTCPeerConnection and drives the dial handshake by calling
+// into `openhost-pkarr-wasm` for sealing / cert-fp binding / frame
+// codec. JS never touches the client Ed25519 secret directly; it
+// lives in IndexedDB and is passed as raw bytes into WASM only.
+//
+// ## Status — what ships in PR #28.3
+//
+// This file establishes the class shape + wires the resolver (PR
+// #28.2) + the WASM primitives (Phase 4) into a single entry point
+// `dialOhUrl(ohUrl)`. The actual publish-offer step is deferred to
+// **PR #28.3.1** because it requires two things not available yet:
+//
+//   1. A WASM-exported `client_pubkey_from_seed(seed) -> zbase32` so
+//      JS can compute its own identity pubkey without re-implementing
+//      Ed25519 point multiplication in JS. Cheap follow-up.
+//   2. A WASM-exported `build_offer_packet(client_sk, daemon_pk, sealed)
+//      -> Uint8Array` that returns the serialized pkarr `SignedPacket`
+//      bytes ready for a Pkarr relay PUT. Today the relay API expects
+//      a full BEP44 mutable-item body (Ed25519 signature + DNS wire
+//      format). Shipping it as WASM reuses the existing
+//      `openhost_pkarr::encode_with_answers` path with no client-side
+//      wire-format duplication.
+//
+// Both gaps are small, scoped follow-ups on the same branch. The
+// rest of the extension (URL handler, viewer, manifest, service
+// worker) is wired up in this PR so the review surface stays
+// digestible.
+
+import init, {
+  decode_and_verify,
+  decode_answer_fragments,
+  seal_offer,
+  open_answer,
+  compute_cert_fp_binding,
+  sign_auth_client,
+  verify_auth_host,
+  encode_frame,
+} from "../../wasm/pkg/openhost_pkarr.js";
+import { FrameReader } from "../session/frame_reader.js";
+
+// Wire constants (mirror `openhost_core::wire::FrameType` + spec §4).
+export const FRAME = Object.freeze({
+  REQUEST_HEAD: 0x01, REQUEST_BODY: 0x02, REQUEST_END: 0x03,
+  RESPONSE_HEAD: 0x11, RESPONSE_BODY: 0x12, RESPONSE_END: 0x13,
+  AUTH_NONCE: 0x30, AUTH_CLIENT: 0x31, AUTH_HOST: 0x32,
+  ERROR: 0xF0, PING: 0xFE, PONG: 0xFF,
+});
+
+export const BINDING_MODE_CERT_FP = 0x02;
+
+const RELAYS = [
+  "https://relay.pkarr.org",
+  "https://pkarr.pubky.app",
+  "https://pkarr.pubky.org",
+];
+const STUN = [{ urls: "stun:stun.l.google.com:19302" }];
+
+let initPromise = null;
+export function ensureWasmInit() {
+  if (!initPromise) initPromise = init();
+  return initPromise;
+}
+
+export function parseOhUrl(ohUrl) {
+  const m = /^oh:\/\/([a-z0-9]{52})(\/.*)?$/i.exec(ohUrl);
+  if (!m) throw new Error(`invalid oh:// URL: ${ohUrl}`);
+  return { daemonPkZ: m[1].toLowerCase(), path: m[2] || "/" };
+}
+
+export async function fetchHostPacket(daemonPkZ) {
+  for (const r of RELAYS) {
+    try {
+      const resp = await fetch(`${r}/${daemonPkZ}`);
+      if (resp.ok) return new Uint8Array(await resp.arrayBuffer());
+    } catch {}
+  }
+  throw new Error(`no relay returned a packet for ${daemonPkZ}`);
+}
+
+// Per-install client identity. 32-byte Ed25519 seed lives in
+// IndexedDB; `indexedDB` is available in MV3 service workers since
+// Chrome 85+ (2020). PR #28.5 adds pairing + backup UX; for now the
+// seed is generated on first use and never surfaced.
+export async function loadOrCreateClientSeed() {
+  const db = await new Promise((res, rej) => {
+    const r = indexedDB.open("openhost", 1);
+    r.onupgradeneeded = () => r.result.createObjectStore("identity");
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+  const tx = db.transaction("identity", "readwrite");
+  const store = tx.objectStore("identity");
+  let seed = await new Promise((res, rej) => {
+    const g = store.get("client_seed");
+    g.onsuccess = () => res(g.result);
+    g.onerror = () => rej(g.error);
+  });
+  if (!seed) {
+    seed = new Uint8Array(32);
+    crypto.getRandomValues(seed);
+    await new Promise((res, rej) => {
+      const p = store.put(seed, "client_seed");
+      p.onsuccess = () => res();
+      p.onerror = () => rej(p.error);
+    });
+  }
+  return seed instanceof Uint8Array ? seed : new Uint8Array(seed);
+}
+
+// A live WebRTC session — post-binding, ready for HTTP round-trips.
+// Constructed internally by `dialOhUrl`; opaque to callers.
+export class OpenhostSession {
+  constructor({ pc, dc, reader, hostRecord, clientPkZ, daemonPkZ }) {
+    this._pc = pc; this._dc = dc; this._reader = reader;
+    this.hostRecord = hostRecord;
+    this.clientPkZ = clientPkZ; this.daemonPkZ = daemonPkZ;
+  }
+
+  // Send one HTTP/1.1 request, return a Response-shaped object.
+  async request(method, path, headers = {}, body = null) {
+    const headLines = [`${method} ${path} HTTP/1.1`, "Host: openhost"];
+    for (const [k, v] of Object.entries(headers)) headLines.push(`${k}: ${v}`);
+    const headBytes = new TextEncoder().encode(headLines.join("\r\n") + "\r\n\r\n");
+    this._dc.send(encode_frame(FRAME.REQUEST_HEAD, Array.from(headBytes)));
+    if (body) this._dc.send(encode_frame(FRAME.REQUEST_BODY, Array.from(body)));
+    this._dc.send(encode_frame(FRAME.REQUEST_END, []));
+
+    const headFrame = await this._reader.next();
+    if (headFrame.frame_type !== FRAME.RESPONSE_HEAD) {
+      throw new Error(`expected RESPONSE_HEAD, got 0x${headFrame.frame_type.toString(16)}`);
+    }
+    const respHead = new TextDecoder().decode(new Uint8Array(headFrame.payload));
+    const bodyChunks = [];
+    while (true) {
+      const f = await this._reader.next();
+      if (f.frame_type === FRAME.RESPONSE_BODY) bodyChunks.push(new Uint8Array(f.payload));
+      else if (f.frame_type === FRAME.RESPONSE_END) break;
+      else if (f.frame_type === FRAME.ERROR) {
+        throw new Error(`daemon error: ${new TextDecoder().decode(new Uint8Array(f.payload))}`);
+      } else throw new Error(`unexpected frame 0x${f.frame_type.toString(16)}`);
+    }
+    const total = bodyChunks.reduce((n, c) => n + c.length, 0);
+    const body_out = new Uint8Array(total);
+    let off = 0;
+    for (const c of bodyChunks) { body_out.set(c, off); off += c.length; }
+    return { head: respHead, body: body_out };
+  }
+
+  close() {
+    try { this._dc.close(); } catch {}
+    try { this._pc.close(); } catch {}
+  }
+}
+
+// Full dial. **Not runnable end-to-end in PR #28.3** — see the status
+// block at the top of this file for the Phase 6.1 gap.
+export async function dialOhUrl(ohUrl) {
+  await ensureWasmInit();
+  const { daemonPkZ, path } = parseOhUrl(ohUrl);
+  const nowTs = BigInt(Math.floor(Date.now() / 1000));
+
+  // 1. Resolve + verify host record via the PR #28.2 WASM path.
+  const hostPacket = await fetchHostPacket(daemonPkZ);
+  const hostRecord = decode_and_verify(hostPacket, daemonPkZ, nowTs);
+
+  // 2. Client identity.
+  const clientSeed = await loadOrCreateClientSeed();
+
+  // 3-12: handshake wiring. Marked as a deliberate throw until the
+  // publish bridge (WASM `build_offer_packet` + `client_pubkey_from_seed`)
+  // lands in PR #28.3.1. The resolver probe in
+  // `extension/src/dev/resolver-probe.js` still exercises the
+  // already-shipped WASM surface end-to-end.
+  throw new Error(
+    `openhost extension: dial pipeline wired up through WASM seal/binding/framing, ` +
+    `but the Pkarr publish bridge is pending PR #28.3.1 (need WASM ` +
+    `build_offer_packet + client_pubkey_from_seed). Target: ${daemonPkZ}${path}. ` +
+    `Host fingerprint: ${hostRecord.dtls_fingerprint_hex}. ` +
+    `Client seed is persisted in IndexedDB (32 bytes).`
+  );
+}

--- a/extension/src/session/frame_reader.js
+++ b/extension/src/session/frame_reader.js
@@ -1,10 +1,16 @@
 // Per-DataChannel frame buffer. Chrome delivers RTCDataChannel.onmessage
 // as arbitrary-sized chunks; openhost frames can span chunks.
+//
+// Storage is a chunk list, not a single growing Uint8Array: a 10 MB
+// response body arriving in 256 KB chunks would be O(N²) under a
+// copy-on-append design. We concatenate lazily when `decode_frame`
+// demands a contiguous prefix.
 import { decode_frame } from "../../wasm/pkg/openhost_pkarr.js";
 
 export class FrameReader {
   constructor() {
-    this._buf = new Uint8Array(0);
+    this._chunks = []; // Uint8Array[]
+    this._total = 0;
     this._waiters = []; // { resolve, reject }
   }
 
@@ -12,10 +18,8 @@ export class FrameReader {
     const bytes = chunk instanceof ArrayBuffer ? new Uint8Array(chunk)
                 : chunk instanceof Uint8Array ? chunk
                 : new Uint8Array(chunk);
-    const grown = new Uint8Array(this._buf.length + bytes.length);
-    grown.set(this._buf, 0);
-    grown.set(bytes, this._buf.length);
-    this._buf = grown;
+    this._chunks.push(bytes);
+    this._total += bytes.length;
     this._pump();
   }
 
@@ -39,13 +43,33 @@ export class FrameReader {
     });
   }
 
+  _flatView() {
+    if (this._chunks.length === 1) return this._chunks[0];
+    const out = new Uint8Array(this._total);
+    let off = 0;
+    for (const c of this._chunks) { out.set(c, off); off += c.length; }
+    this._chunks = [out]; // cache the flattened view
+    return out;
+  }
+
+  _drop(n) {
+    // Advance past `n` bytes of frontmost data. Keeps the chunk list
+    // coherent by slicing or popping frontmost chunks as needed.
+    while (n > 0 && this._chunks.length > 0) {
+      const head = this._chunks[0];
+      if (head.length <= n) { n -= head.length; this._total -= head.length; this._chunks.shift(); }
+      else { this._chunks[0] = head.subarray(n); this._total -= n; n = 0; }
+    }
+  }
+
   _pump() {
-    while (this._waiters.length > 0 && this._buf.length > 0) {
+    while (this._waiters.length > 0 && this._total > 0) {
+      const view = this._flatView();
       let decoded;
-      try { decoded = decode_frame(this._buf); }
+      try { decoded = decode_frame(view); }
       catch (e) { const w = this._waiters.shift(); w.reject(e); continue; }
       if (!decoded) return; // partial; wait for more bytes
-      this._buf = this._buf.slice(decoded.consumed);
+      this._drop(decoded.consumed);
       const w = this._waiters.shift();
       w.resolve(decoded);
     }

--- a/extension/src/session/frame_reader.js
+++ b/extension/src/session/frame_reader.js
@@ -1,0 +1,53 @@
+// Per-DataChannel frame buffer. Chrome delivers RTCDataChannel.onmessage
+// as arbitrary-sized chunks; openhost frames can span chunks.
+import { decode_frame } from "../../wasm/pkg/openhost_pkarr.js";
+
+export class FrameReader {
+  constructor() {
+    this._buf = new Uint8Array(0);
+    this._waiters = []; // { resolve, reject }
+  }
+
+  push(chunk) {
+    const bytes = chunk instanceof ArrayBuffer ? new Uint8Array(chunk)
+                : chunk instanceof Uint8Array ? chunk
+                : new Uint8Array(chunk);
+    const grown = new Uint8Array(this._buf.length + bytes.length);
+    grown.set(this._buf, 0);
+    grown.set(bytes, this._buf.length);
+    this._buf = grown;
+    this._pump();
+  }
+
+  fail(err) {
+    this._waiters.forEach(w => w.reject(err));
+    this._waiters = [];
+  }
+
+  next(timeoutMs = 15000) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const i = this._waiters.findIndex(w => w.resolve === resolve);
+        if (i >= 0) this._waiters.splice(i, 1);
+        reject(new Error(`frame read timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this._waiters.push({
+        resolve: v => { clearTimeout(timer); resolve(v); },
+        reject: e => { clearTimeout(timer); reject(e); },
+      });
+      this._pump();
+    });
+  }
+
+  _pump() {
+    while (this._waiters.length > 0 && this._buf.length > 0) {
+      let decoded;
+      try { decoded = decode_frame(this._buf); }
+      catch (e) { const w = this._waiters.shift(); w.reject(e); continue; }
+      if (!decoded) return; // partial; wait for more bytes
+      this._buf = this._buf.slice(decoded.consumed);
+      const w = this._waiters.shift();
+      w.resolve(decoded);
+    }
+  }
+}

--- a/extension/src/url_handler/oh_navigator.js
+++ b/extension/src/url_handler/oh_navigator.js
@@ -1,0 +1,35 @@
+// `oh://` URL handler (PR #28.3 Phase 5 decision: webNavigation).
+//
+// Chrome MV3 has no native custom-scheme registration; the survey in
+// `~/.claude/plans/tender-popping-kahn.md` §6 evaluated three candidates:
+//
+//   (a) `webNavigation.onBeforeNavigate` + programmatic redirect to
+//       `chrome-extension://.../viewer.html?oh=...` — **chosen**.
+//   (b) `declarativeNetRequest` rewrite on `https://openhost.invalid/...`
+//       — requires users to type a non-`oh://` URL; UX regression.
+//   (c) `registerProtocolHandler("oh", ...)` — Chromium's allowlist
+//       rejects non-stdlib schemes; not shippable.
+//
+// `webNavigation.onBeforeNavigate` fires pre-DNS-resolution so we can
+// cancel the URL-bar navigation and replace it with our extension tab.
+// Redirecting at this stage avoids the "can't resolve oh://" error
+// the omnibox would otherwise show, and costs only the
+// `webNavigation` permission (no broad host access).
+
+const VIEWER_URL = chrome.runtime.getURL("viewer.html");
+
+export function installOhNavigationHandler() {
+  if (!chrome.webNavigation) {
+    console.warn("openhost: chrome.webNavigation unavailable — oh:// URLs will not intercept");
+    return;
+  }
+  chrome.webNavigation.onBeforeNavigate.addListener(
+    (details) => {
+      if (!details.url.startsWith("oh://")) return;
+      const target = `${VIEWER_URL}?oh=${encodeURIComponent(details.url)}`;
+      chrome.tabs.update(details.tabId, { url: target });
+    },
+    { url: [{ schemes: ["oh"] }] },
+  );
+  console.log("openhost: oh:// URL handler armed");
+}

--- a/extension/src/viewer.js
+++ b/extension/src/viewer.js
@@ -1,0 +1,78 @@
+// PR #28.3 Phase 6 viewer tab. Opens the `oh://<pk>/path` URL passed
+// in via `?oh=…` query string, runs the dial, renders the response.
+//
+// Rendering strategy: sniff Content-Type, pick the simplest HTMLElement
+// that can display it. Media types become <video>/<audio>/<img>;
+// text/html renders in a sandboxed iframe; everything else is offered
+// as a download link.
+import { dialOhUrl, parseOhUrl } from "./dialer/openhost_session.js";
+
+const statusEl = document.getElementById("status");
+const contentEl = document.getElementById("content");
+const targetEl = document.getElementById("target");
+
+function setStatus(msg, isError = false) {
+  statusEl.textContent = msg;
+  statusEl.classList.toggle("error", isError);
+}
+
+const params = new URLSearchParams(window.location.search);
+const ohUrl = params.get("oh");
+if (!ohUrl) {
+  setStatus("no oh:// URL supplied via ?oh= param", true);
+} else {
+  targetEl.textContent = ohUrl;
+  run(ohUrl).catch(e => setStatus(`dial failed: ${e.message || e}`, true));
+}
+
+async function run(ohUrl) {
+  const { daemonPkZ, path } = parseOhUrl(ohUrl);
+  setStatus(`resolving ${daemonPkZ}…`);
+  let session;
+  try {
+    session = await dialOhUrl(ohUrl);
+  } catch (e) {
+    setStatus(
+      `dial failed: ${e.message}\n\n` +
+      `PR #28.3 Phase 6 wired up the browser-side dialer skeleton + WASM ` +
+      `primitives; the publish-offer bridge to Pkarr relays is deferred to ` +
+      `PR #28.3.1. The WASM resolver probe at extension/src/dev/resolver-probe.js ` +
+      `still works end-to-end — use that to smoke-test the resolver path today.`,
+      true,
+    );
+    return;
+  }
+
+  setStatus(`dialed ${daemonPkZ}; GET ${path}…`);
+  const resp = await session.request("GET", path);
+  setStatus(`response head:\n${resp.head}`);
+  await renderBody(resp);
+  session.close();
+}
+
+async function renderBody({ head, body }) {
+  const headerLine = head.split("\r\n").find(l => l.toLowerCase().startsWith("content-type:"));
+  const contentType = headerLine ? headerLine.split(":", 2)[1].trim().split(";")[0].trim() : "";
+  const blob = new Blob([body], { type: contentType || "application/octet-stream" });
+  const url = URL.createObjectURL(blob);
+
+  if (contentType.startsWith("video/")) {
+    const v = document.createElement("video");
+    v.controls = true; v.src = url; contentEl.appendChild(v);
+  } else if (contentType.startsWith("audio/")) {
+    const a = document.createElement("audio");
+    a.controls = true; a.src = url; contentEl.appendChild(a);
+  } else if (contentType.startsWith("image/")) {
+    const img = document.createElement("img"); img.src = url; contentEl.appendChild(img);
+  } else if (contentType === "text/html") {
+    const iframe = document.createElement("iframe");
+    iframe.sandbox = "allow-same-origin";
+    iframe.srcdoc = new TextDecoder().decode(body);
+    iframe.style.width = "100%"; iframe.style.height = "80vh"; iframe.style.border = "1px solid #ddd";
+    contentEl.appendChild(iframe);
+  } else {
+    const a = document.createElement("a");
+    a.href = url; a.download = "openhost-response"; a.textContent = `download (${body.length} bytes)`;
+    contentEl.appendChild(a);
+  }
+}

--- a/extension/viewer.html
+++ b/extension/viewer.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>openhost</title>
+  <style>
+    body { font-family: system-ui, -apple-system, sans-serif; margin: 2rem; max-width: 48rem; color: #222; }
+    header { display: flex; align-items: baseline; gap: 0.75rem; border-bottom: 1px solid #ddd; padding-bottom: 0.75rem; margin-bottom: 1rem; }
+    h1 { margin: 0; font-size: 1.1rem; color: #666; font-weight: 600; }
+    code { font-size: 0.85rem; color: #0055aa; }
+    #status { padding: 1rem; background: #f5f5f5; border-radius: 6px; font-family: ui-monospace, Menlo, monospace; font-size: 0.85rem; white-space: pre-wrap; }
+    #content { margin-top: 1rem; }
+    #content video, #content audio, #content img { max-width: 100%; }
+    .error { color: #b00; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>openhost</h1><code id="target"></code>
+  </header>
+  <div id="status">Initializing…</div>
+  <div id="content"></div>
+  <script type="module" src="./src/viewer.js"></script>
+</body>
+</html>

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -194,11 +194,38 @@ offer_plaintext = compression_tag || body
              oversized inputs.
       Other values MUST be rejected as malformed.
 
-  body =  "openhost-offer-inner1"  (21 bytes)
-       || client_pk                 (32 bytes)
-       || sdp_len                   (u32 big-endian)
-       || offer_sdp_utf8            (sdp_len bytes)
+  body =
+    // Choose ONE of the two shapes below based on the leading domain
+    // separator. v2 (PR #28.3+) adds a trailing `binding_mode` byte
+    // so clients can advertise browser-only channel binding.
+
+    v1 legacy shape (pre-PR-28.3; still accepted on decode):
+         "openhost-offer-inner1"      (21 bytes)
+       || client_pk                   (32 bytes)
+       || sdp_len                     (u32 big-endian)
+       || offer_sdp_utf8              (sdp_len bytes)
+
+    v2 shape (PR #28.3+; all new encoders MUST emit this form):
+         "openhost-offer-inner2"      (21 bytes)
+       || client_pk                   (32 bytes)
+       || sdp_len                     (u32 big-endian)
+       || offer_sdp_utf8              (sdp_len bytes)
+       || binding_mode                (u8; see §7.6 for semantics)
 ```
+
+**Binding mode byte** (v2 only). One of:
+
+- `0x01 = Exporter` — client will drive channel binding via the RFC
+  5705 DTLS exporter. The original CLI-to-CLI path.
+- `0x02 = CertFp` — client will drive channel binding via SHA-256
+  over the host's DTLS certificate DER. Mandatory when the client is a
+  browser (browsers do not expose the RFC 5705 exporter on
+  `RTCDtlsTransport`). See `spec/04-security.md §7.6`.
+- Other values MUST be rejected as malformed.
+
+v1 bodies carry no explicit binding byte and decode as if
+`binding_mode = 0x01 Exporter`. This preserves the pre-PR-28.3
+CLI-to-CLI semantics verbatim.
 
 v0.1+ encoders **MUST** emit `compression_tag = 0x02`. v0.1+ decoders
 **MUST** accept both `0x01` and `0x02` for backward compatibility

--- a/spec/04-security.md
+++ b/spec/04-security.md
@@ -69,12 +69,31 @@ openhost uses only well-audited, standard primitives:
 |---|---|---|
 | Identity signatures | Ed25519 (RFC 8032, strict verification) | `ed25519-dalek` v2 |
 | Sealed-box encryption (per-client ICE blobs) | libsodium `crypto_box_seal` (X25519 + XSalsa20-Poly1305) | `crypto_box` with `seal` feature |
-| Channel binding | HKDF-SHA256 over TLS exporter (RFC 5705) | `hkdf`, `sha2` |
+| Channel binding (CLI peers) | HKDF-SHA256 over RFC 5705 DTLS exporter | `hkdf`, `sha2` |
+| Channel binding (browser peers, PR #28.3+) | HKDF-SHA256 over SHA-256(remote DTLS cert DER) | `hkdf`, `sha2` |
 | HMAC for allowlist hashing | HMAC-SHA256 | `hmac`, `sha2` |
 | Transport encryption | DTLS 1.3 | provided by the WebRTC implementation |
 | Public key display | z-base-32 | `zbase32` |
 
 No custom cryptography is defined anywhere in the openhost protocol. Any apparent departure from these primitives is a bug.
+
+### 4.1 Channel-binding modes
+
+The channel-binding HMAC (attack 7.1 above) feeds HKDF-SHA256 with a session-specific secret plus both peer pubkeys plus a per-session nonce. Two modes are defined; the client selects one via the `binding_mode` byte on the v2 offer plaintext (see `spec/01-wire-format.md §3.3`).
+
+**`Exporter` (0x01, CLI default).** The session secret is the first 32 bytes of the RFC 5705 DTLS exporter output with label `"EXPORTER-openhost-auth-v1"` and an empty context. This is the original CLI-to-CLI path and provides the strongest UKS (RFC 8844) defense because it binds over session-unique secret bits that an attacker cannot extract without breaking the DTLS key exchange.
+
+**`CertFp` (0x02, browser-mandatory).** The session secret is SHA-256 over the DER encoding of the host's DTLS certificate (the one whose fingerprint is pinned in the Pkarr `_openhost` record). Browser WebRTC implementations do NOT expose `RTCDtlsTransport.exportKeyingMaterial` today; `getRemoteCertificates()` is the only published hook into the DTLS session. Substituting SHA-256(cert DER) for the exporter bytes preserves the UKS defense in openhost's specific threat model because **the cert fingerprint is already pinned by the host's Ed25519 signature on the Pkarr record** — an attacker who could present a matching fingerprint has already broken the host's identity key, which is the attack the fingerprint pin was built to defend against.
+
+**Negotiation rules.**
+
+1. CLI clients MUST advertise `Exporter`. A CLI MUST reject an answer that references `CertFp` (the client's binding-mode byte in the offer plaintext is authoritative for its own path; a daemon should never downgrade the client).
+2. Browser clients MUST advertise `CertFp`. Browsers have no mechanism to compute the `Exporter` variant.
+3. Daemons MUST support both modes by default. Operators who want a CLI-only deployment can set `[dtls] allowed_binding_modes = ["exporter"]` in the daemon config.
+4. Daemons MUST compute the HMAC with whichever mode the client advertised. A daemon that speaks CertFp to a client that advertised Exporter (or vice versa) is a protocol error — the channel binding would not match and the session tears down.
+5. Pre-PR-28.3 offers (v1 offer bodies, no `binding_mode` byte) decode as `Exporter` for backwards compatibility.
+
+libp2p's browser WebRTC transport (shipped in production across IPFS + Filecoin) uses an analogous cert-fingerprint binding in place of RFC 5705 for the same reason. openhost's CertFp variant is the same design pattern.
 
 ## 5. Security response
 


### PR DESCRIPTION
End-to-end browser dial of \`oh://<pubkey>/path\` URLs in Chrome. Six phases, six commits, one branch. A user types \`oh://<mac-mini-pk>/sample.mp4\` in Chrome on their MacBook; the extension resolves the host via Pkarr, opens a WebRTC data channel to the Mac mini's openhostd, runs a libp2p-style cert-fingerprint channel-binding handshake, and streams the video back.

## Commits

| Phase | Commit | Scope |
|---|---|---|
| 1 | \`dae5bd0\` | Spec + \`BindingMode\` enum in \`openhost-pkarr\`; v2 offer body with \`binding_mode\` byte |
| 2 | \`37f8ce0\` | Daemon cert_fp binding path + \`[dtls] allowed_binding_modes\` config |
| 3 | \`b9f6876\` | CLI downgrade-rejection guard |
| 4 | \`f0e7ec7\` | 7 new WASM exports (seal/open/bind/sign/verify/frame codec) |
| 5+6 | \`41e72fa\` | JS \`OpenhostSession\` + \`oh://\` URL handler + viewer tab |
| 6.1 | \`7e7488d\` | Full dial pipeline (publish-offer bridge + live handshake) |

## Architectural decision (load-bearing)

Browser WebRTC doesn't expose the RFC 5705 DTLS exporter. After researching three paths (propose the API upstream / WASM DTLS stack / cert-fingerprint binding) and one aside on forking Chromium, we went with **libp2p-style cert-fingerprint binding** + a Tauri desktop wrapper queued for later. The cert fingerprint is already pinned by the host's Ed25519 sig on the Pkarr record, so the UKS defense (RFC 8844) is preserved. Spec docs in \`spec/04-security.md §4.1\`.

## Wire format

Backwards-compatible. v1 offer bodies (\`openhost-offer-inner1\`) still decode, defaulting \`binding_mode\` to \`Exporter\`. New v2 bodies (\`openhost-offer-inner2\`) carry an explicit \`binding_mode: u8\` byte. CLI dialers continue to emit Exporter; browsers emit \`CertFp\`. Daemons support both per \`[dtls] allowed_binding_modes\`.

## WASM shim surface

\`openhost-pkarr-wasm\` now exports 11 functions: 4 resolver (PR #28.2) + 7 dialer (this PR) + 2 packet builders (Phase 6.1). Binary size 560 KB un-opt (wasm-opt stays disabled until wasm-pack refreshes its bundled opt).

## Test coverage

- 14 host-target smoke tests on \`openhost-pkarr-wasm\` (resolver + dialer primitives, including cert-fp binding byte-for-byte vs. the daemon path).
- Daemon \`cargo test --workspace\` all green (260+ tests, including the \`allowed_binding_modes\` and cert-fp binding paths).
- \`cargo check -p openhost-pkarr-wasm --target wasm32-unknown-unknown\` clean.

## Test plan (requires two machines)

- [ ] Check out the branch, run \`cargo test --workspace\`.
- [ ] On Mac mini: \`openhostd run\` with \`forward.target = http://localhost:8096/\`; run \`python3 -m http.server 8096\` in \`~/Movies/\`.
- [ ] Build WASM: \`./extension/scripts/build-wasm.sh\` (produces \`extension/wasm/pkg/\`).
- [ ] On MacBook: \`chrome://extensions\` → Load unpacked → select \`extension/\`.
- [ ] Read MacBook client pubkey from service-worker devtools console.
- [ ] Back on Mac mini: \`openhostd pair add <that pubkey>\`.
- [ ] In MacBook Chrome: type \`oh://<mac-mini-pubkey>/sample.mp4\`.
- [ ] Verify the viewer tab opens and the video plays.

## Known limitations

- \`wasm-opt\` disabled per PR #28.2 Cargo metadata; re-enable once upstream wasm-pack refreshes its bundled optimizer.
- Viewer buffers the full response before rendering. Byte-range / \`MediaSource Extensions\` streaming is a scoped follow-up (PR #28.3.2).
- Firefox parity deferred to PR #28.6.
- Chrome Web Store submission deferred to PR #28.6.
- Tauri desktop wrapper (for non-Chrome users) queued as PR #28.7.

## Spec compatibility

Additive — v1 offer bodies still decode. Existing CLI ↔ CLI dials unchanged. Browser ↔ daemon is the new capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)