### PR TITLE
feat(webrtc): STUN + candidate hygiene for cross-NAT dials

### DIFF
--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -294,14 +294,15 @@ impl Dialer {
     /// first DC frame. The daemon side (`listener::negotiate`) has
     /// always waited for gather; this brings the client in line.
     ///
-    /// Worry about BEP44 packet size: a realistic gathered offer has
-    /// 2-4 candidates (host LAN + srflx from STUN, maybe mDNS) adding
-    /// ~200-400 bytes. With the base offer SDP at ~220 bytes the
-    /// total sealed offer stays under the 1000-byte `v` cap in every
-    /// ICE topology we've measured. If a future high-candidate-count
-    /// environment trips the cap, eviction will happen at encode time
-    /// and the dial will `PublishOffer` fail loudly rather than
-    /// silently succeed with zero remote candidates.
+    /// BEP44 packet-size caveat: a real-world offer SDP with 1 host
+    /// + 1-2 srflx candidates runs around 500-700 bytes plaintext
+    /// depending on the ice-ufrag / fingerprint values webrtc-rs
+    /// generates. Sealed-box + base64url push that into the 700-950
+    /// byte range — within the 1000-byte `v` cap, but not by much.
+    /// Dual-stack or multi-bridge hosts WILL overflow without the
+    /// IP filter installed in `webrtc_helpers::build_client_api`;
+    /// if the cap is tripped we error with `PublishOffer` rather than
+    /// silently succeed with zero candidates.
     pub async fn build_offer(
         &self,
     ) -> Result<(Arc<RTCPeerConnection>, Arc<RTCDataChannel>, String)> {

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -282,16 +282,42 @@ impl Dialer {
             .map_err(ClientError::from)
     }
 
-    /// Build a fresh WebRTC offer SDP. Deliberately skips
-    /// `gathering_complete_promise` so the SDP stays small enough to
-    /// fit the BEP44 `v` cap. Loopback handshakes succeed with host
-    /// candidates only; wide-area dials will need ICE trickle (post-v0.1).
+    /// Build a fresh WebRTC offer SDP, waiting for full ICE gather
+    /// before returning.
+    ///
+    /// The pre-PR-28.3 version of this function skipped
+    /// `gathering_complete_promise` on the theory that trickle-ICE
+    /// would deliver candidates over the data channel after it
+    /// opened. That never worked in practice: the DC can't open until
+    /// DTLS, DTLS can't start until ICE, ICE needs candidates on both
+    /// sides, and there's no out-of-band trickle channel before the
+    /// first DC frame. The daemon side (`listener::negotiate`) has
+    /// always waited for gather; this brings the client in line.
+    ///
+    /// Worry about BEP44 packet size: a realistic gathered offer has
+    /// 2-4 candidates (host LAN + srflx from STUN, maybe mDNS) adding
+    /// ~200-400 bytes. With the base offer SDP at ~220 bytes the
+    /// total sealed offer stays under the 1000-byte `v` cap in every
+    /// ICE topology we've measured. If a future high-candidate-count
+    /// environment trips the cap, eviction will happen at encode time
+    /// and the dial will `PublishOffer` fail loudly rather than
+    /// silently succeed with zero remote candidates.
     pub async fn build_offer(
         &self,
     ) -> Result<(Arc<RTCPeerConnection>, Arc<RTCDataChannel>, String)> {
+        // STUN servers are mandatory for cross-NAT dials — without
+        // them webrtc-rs gathers only `host`-type candidates and
+        // can't discover the client's public address.
+        let config = RTCConfiguration {
+            ice_servers: vec![webrtc::ice_transport::ice_server::RTCIceServer {
+                urls: vec!["stun:stun.cloudflare.com:3478".to_string()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
         let pc = Arc::new(
             self.api
-                .new_peer_connection(RTCConfiguration::default())
+                .new_peer_connection(config)
                 .await
                 .map_err(|e| ClientError::WebRtcSetup(format!("new_peer_connection: {e}")))?,
         );
@@ -306,6 +332,10 @@ impl Dialer {
         pc.set_local_description(offer)
             .await
             .map_err(|e| ClientError::WebRtcSetup(format!("set_local_description: {e}")))?;
+        // Drain ICE gathering so the returned SDP carries every
+        // candidate the local agent could find.
+        let mut gather = pc.gathering_complete_promise().await;
+        let _ = gather.recv().await;
         let sdp = pc
             .local_description()
             .await

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -294,15 +294,16 @@ impl Dialer {
     /// first DC frame. The daemon side (`listener::negotiate`) has
     /// always waited for gather; this brings the client in line.
     ///
-    /// BEP44 packet-size caveat: a real-world offer SDP with 1 host
-    /// + 1-2 srflx candidates runs around 500-700 bytes plaintext
-    /// depending on the ice-ufrag / fingerprint values webrtc-rs
-    /// generates. Sealed-box + base64url push that into the 700-950
-    /// byte range — within the 1000-byte `v` cap, but not by much.
-    /// Dual-stack or multi-bridge hosts WILL overflow without the
-    /// IP filter installed in `webrtc_helpers::build_client_api`;
-    /// if the cap is tripped we error with `PublishOffer` rather than
-    /// silently succeed with zero candidates.
+    /// BEP44 packet-size caveat: a real-world offer SDP with one host
+    /// candidate and one or two srflx candidates runs around 500-700
+    /// bytes plaintext depending on the ice-ufrag / fingerprint values
+    /// webrtc-rs generates. Sealed-box plus base64url push that into
+    /// the 700-950 byte range, which is within the 1000-byte `v` cap
+    /// but not by much. Dual-stack or multi-bridge hosts WILL overflow
+    /// without the IP filter installed in
+    /// `webrtc_helpers::build_client_api`. If the cap is tripped the
+    /// dial errors with `PublishOffer` rather than silently succeeding
+    /// with zero candidates.
     pub async fn build_offer(
         &self,
     ) -> Result<(Arc<RTCPeerConnection>, Arc<RTCDataChannel>, String)> {

--- a/crates/openhost-client/src/webrtc_helpers.rs
+++ b/crates/openhost-client/src/webrtc_helpers.rs
@@ -8,6 +8,7 @@ use tokio::sync::mpsc;
 use webrtc::api::setting_engine::SettingEngine;
 use webrtc::api::{APIBuilder, API};
 use webrtc::data_channel::RTCDataChannel;
+use webrtc::ice::mdns::MulticastDnsMode;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::RTCPeerConnection;
 
@@ -35,7 +36,45 @@ pub(crate) fn install_crypto_provider_once() {
 /// accepts.
 pub(crate) fn build_client_api() -> Arc<API> {
     install_crypto_provider_once();
-    let engine = SettingEngine::default();
+    let mut engine = SettingEngine::default();
+    // Drop IPv6 link-local (fe80::/10) candidates from ICE gathering.
+    // They're scope-restricted (can't be reached by a remote peer)
+    // and add ~60-100 bytes of SDP per-candidate — pushing the
+    // sealed offer over BEP44's 1000-byte `v` cap on machines with
+    // many interfaces.
+    // IPv4-only for now. Multiple public IPv6 candidates can push
+    // the sealed offer past BEP44's 1000-byte `v` cap on modern
+    // dual-stack hosts. IPv4 with STUN srflx reaches the same peers
+    // in practice. Revisit when the offer encoder switches to multi-
+    // record fragmentation.
+    //
+    // Also reject Docker Desktop's macOS virtual bridges:
+    //   - `bridge100` at 192.168.64.0/24 (default)
+    //   - `bridge101` at 192.168.65.0/24 (Docker Desktop 4.30+)
+    // These are Mac-local interfaces; a remote peer can't reach them.
+    // Gathering them yields "phantom" candidates that ICE burns
+    // connectivity-check time on before giving up. Filter excludes
+    // the specific Docker Desktop ranges rather than a broad RFC 1918
+    // sweep — a real LAN peer on 192.168.64.x would want to keep
+    // those candidates.
+    engine.set_ip_filter(Box::new(|ip: std::net::IpAddr| match ip {
+        std::net::IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            // Exclude Docker Desktop macOS virtual bridges.
+            if octets[0] == 192 && octets[1] == 168 && (octets[2] == 64 || octets[2] == 65) {
+                return false;
+            }
+            true
+        }
+        std::net::IpAddr::V6(_) => false,
+    }));
+    // Disable mDNS gathering (`<uuid>.local` candidates). The raw IP
+    // variant (`MulticastDnsMode::Disabled`) uses real IP addresses
+    // in candidates, which trades a privacy cost (the peer learns
+    // your IP — which it was going to need anyway to connect) for a
+    // ~70 byte savings per candidate. Remote-side mDNS candidates
+    // would fail to resolve cross-host anyway.
+    engine.set_ice_multicast_dns_mode(MulticastDnsMode::Disabled);
     Arc::new(APIBuilder::new().with_setting_engine(engine).build())
 }
 

--- a/crates/openhost-client/src/webrtc_helpers.rs
+++ b/crates/openhost-client/src/webrtc_helpers.rs
@@ -37,27 +37,22 @@ pub(crate) fn install_crypto_provider_once() {
 pub(crate) fn build_client_api() -> Arc<API> {
     install_crypto_provider_once();
     let mut engine = SettingEngine::default();
-    // IP filter applied to every ICE candidate webrtc-rs gathers.
-    // Rejects:
-    //
-    //   1. **All IPv6.** Multi-family candidate sets push the sealed
-    //      offer past BEP44's 1000-byte `v` cap on dual-stack hosts;
-    //      IPv4 with STUN srflx reaches the same peers in practice.
-    //      Covers both link-local (`fe80::/10`, unbind-able without
-    //      scope id) and public IPv6 host candidates. Revisit when
-    //      the offer encoder gains more fragmentation headroom.
-    //
-    //   2. **Docker Desktop macOS virtual bridges.**
-    //      - `bridge100` at `192.168.64.0/24` (Docker Desktop default)
-    //      - `bridge101` at `192.168.65.0/24` (Docker Desktop 4.30+)
-    //      These are Mac-local interfaces unreachable by a remote
-    //      peer; gathering them produces "phantom" candidates that
-    //      ICE burns connectivity-check time on before giving up.
-    //
-    // Narrow ranges (not a broad RFC 1918 sweep): a real LAN peer
-    // legitimately on `192.168.64.x` would want those candidates
-    // kept, so we filter the exact Docker Desktop bridge subnets
-    // rather than carpet-bombing RFC 1918.
+    // IP filter applied to every ICE candidate webrtc-rs gathers. It
+    // rejects all IPv6 and the two Docker Desktop macOS virtual-
+    // bridge subnets. IPv6 is dropped because multi-family candidate
+    // sets push the sealed offer past BEP44's 1000-byte `v` cap on
+    // dual-stack hosts; IPv4 with STUN srflx reaches the same peers
+    // in practice. That covers both link-local (`fe80::/10`,
+    // unbind-able without a scope id) and public IPv6 host
+    // candidates. Revisit when the offer encoder gains more
+    // fragmentation headroom. Docker Desktop's macOS bridges
+    // (`bridge100` at `192.168.64.0/24`, `bridge101` at
+    // `192.168.65.0/24` on Docker Desktop 4.30+) are Mac-local
+    // interfaces unreachable from a remote peer; gathering them
+    // produces phantom candidates that ICE burns connectivity-check
+    // time on. The filter targets those specific subnets rather than
+    // carpet-bombing RFC 1918 so a real LAN peer legitimately on
+    // `192.168.64.x` still gets its host candidates kept.
     engine.set_ip_filter(Box::new(|ip: std::net::IpAddr| match ip {
         std::net::IpAddr::V4(v4) => !is_docker_desktop_bridge_v4(&v4),
         std::net::IpAddr::V6(_) => false,
@@ -77,6 +72,36 @@ pub(crate) fn build_client_api() -> Arc<API> {
 fn is_docker_desktop_bridge_v4(ip: &std::net::Ipv4Addr) -> bool {
     let o = ip.octets();
     o[0] == 192 && o[1] == 168 && (o[2] == 64 || o[2] == 65)
+}
+
+/// Install an `on_peer_connection_state_change` handler that forwards
+/// every transition into an `mpsc::Receiver`. The receiver ends when
+/// the PC is dropped (the handler's clone of the sender goes with it).
+pub(crate) fn state_change_receiver(
+    pc: &Arc<RTCPeerConnection>,
+) -> mpsc::UnboundedReceiver<RTCPeerConnectionState> {
+    let (tx, rx) = mpsc::unbounded_channel();
+    pc.on_peer_connection_state_change(Box::new(move |state| {
+        let _ = tx.send(state);
+        Box::pin(async {})
+    }));
+    rx
+}
+
+/// Install an `on_open` handler that fires a one-shot `Notify` when
+/// the data channel becomes open. Uses `notify_one` so a permit is
+/// stored if `open` fires before any waiter awaits — the next
+/// `notified().await` returns immediately in that case.
+pub(crate) fn dc_open_signal(dc: &Arc<RTCDataChannel>) -> Arc<tokio::sync::Notify> {
+    let notify = Arc::new(tokio::sync::Notify::new());
+    let inner = Arc::clone(&notify);
+    dc.on_open(Box::new(move || {
+        let inner = Arc::clone(&inner);
+        Box::pin(async move {
+            inner.notify_one();
+        })
+    }));
+    notify
 }
 
 #[cfg(test)]
@@ -108,34 +133,4 @@ mod filter_tests {
         // Public unaffected.
         assert!(!is_docker_desktop_bridge_v4(&Ipv4Addr::new(8, 8, 8, 8)));
     }
-}
-
-/// Install an `on_peer_connection_state_change` handler that forwards
-/// every transition into an `mpsc::Receiver`. The receiver ends when
-/// the PC is dropped (the handler's clone of the sender goes with it).
-pub(crate) fn state_change_receiver(
-    pc: &Arc<RTCPeerConnection>,
-) -> mpsc::UnboundedReceiver<RTCPeerConnectionState> {
-    let (tx, rx) = mpsc::unbounded_channel();
-    pc.on_peer_connection_state_change(Box::new(move |state| {
-        let _ = tx.send(state);
-        Box::pin(async {})
-    }));
-    rx
-}
-
-/// Install an `on_open` handler that fires a one-shot `Notify` when
-/// the data channel becomes open. Uses `notify_one` so a permit is
-/// stored if `open` fires before any waiter awaits — the next
-/// `notified().await` returns immediately in that case.
-pub(crate) fn dc_open_signal(dc: &Arc<RTCDataChannel>) -> Arc<tokio::sync::Notify> {
-    let notify = Arc::new(tokio::sync::Notify::new());
-    let inner = Arc::clone(&notify);
-    dc.on_open(Box::new(move || {
-        let inner = Arc::clone(&inner);
-        Box::pin(async move {
-            inner.notify_one();
-        })
-    }));
-    notify
 }

--- a/crates/openhost-client/src/webrtc_helpers.rs
+++ b/crates/openhost-client/src/webrtc_helpers.rs
@@ -37,35 +37,29 @@ pub(crate) fn install_crypto_provider_once() {
 pub(crate) fn build_client_api() -> Arc<API> {
     install_crypto_provider_once();
     let mut engine = SettingEngine::default();
-    // Drop IPv6 link-local (fe80::/10) candidates from ICE gathering.
-    // They're scope-restricted (can't be reached by a remote peer)
-    // and add ~60-100 bytes of SDP per-candidate — pushing the
-    // sealed offer over BEP44's 1000-byte `v` cap on machines with
-    // many interfaces.
-    // IPv4-only for now. Multiple public IPv6 candidates can push
-    // the sealed offer past BEP44's 1000-byte `v` cap on modern
-    // dual-stack hosts. IPv4 with STUN srflx reaches the same peers
-    // in practice. Revisit when the offer encoder switches to multi-
-    // record fragmentation.
+    // IP filter applied to every ICE candidate webrtc-rs gathers.
+    // Rejects:
     //
-    // Also reject Docker Desktop's macOS virtual bridges:
-    //   - `bridge100` at 192.168.64.0/24 (default)
-    //   - `bridge101` at 192.168.65.0/24 (Docker Desktop 4.30+)
-    // These are Mac-local interfaces; a remote peer can't reach them.
-    // Gathering them yields "phantom" candidates that ICE burns
-    // connectivity-check time on before giving up. Filter excludes
-    // the specific Docker Desktop ranges rather than a broad RFC 1918
-    // sweep — a real LAN peer on 192.168.64.x would want to keep
-    // those candidates.
+    //   1. **All IPv6.** Multi-family candidate sets push the sealed
+    //      offer past BEP44's 1000-byte `v` cap on dual-stack hosts;
+    //      IPv4 with STUN srflx reaches the same peers in practice.
+    //      Covers both link-local (`fe80::/10`, unbind-able without
+    //      scope id) and public IPv6 host candidates. Revisit when
+    //      the offer encoder gains more fragmentation headroom.
+    //
+    //   2. **Docker Desktop macOS virtual bridges.**
+    //      - `bridge100` at `192.168.64.0/24` (Docker Desktop default)
+    //      - `bridge101` at `192.168.65.0/24` (Docker Desktop 4.30+)
+    //      These are Mac-local interfaces unreachable by a remote
+    //      peer; gathering them produces "phantom" candidates that
+    //      ICE burns connectivity-check time on before giving up.
+    //
+    // Narrow ranges (not a broad RFC 1918 sweep): a real LAN peer
+    // legitimately on `192.168.64.x` would want those candidates
+    // kept, so we filter the exact Docker Desktop bridge subnets
+    // rather than carpet-bombing RFC 1918.
     engine.set_ip_filter(Box::new(|ip: std::net::IpAddr| match ip {
-        std::net::IpAddr::V4(v4) => {
-            let octets = v4.octets();
-            // Exclude Docker Desktop macOS virtual bridges.
-            if octets[0] == 192 && octets[1] == 168 && (octets[2] == 64 || octets[2] == 65) {
-                return false;
-            }
-            true
-        }
+        std::net::IpAddr::V4(v4) => !is_docker_desktop_bridge_v4(&v4),
         std::net::IpAddr::V6(_) => false,
     }));
     // Disable mDNS gathering (`<uuid>.local` candidates). The raw IP
@@ -76,6 +70,44 @@ pub(crate) fn build_client_api() -> Arc<API> {
     // would fail to resolve cross-host anyway.
     engine.set_ice_multicast_dns_mode(MulticastDnsMode::Disabled);
     Arc::new(APIBuilder::new().with_setting_engine(engine).build())
+}
+
+/// Extracted for unit-test coverage. `true` if `ip` falls inside
+/// either of Docker Desktop's macOS virtual-bridge subnets.
+fn is_docker_desktop_bridge_v4(ip: &std::net::Ipv4Addr) -> bool {
+    let o = ip.octets();
+    o[0] == 192 && o[1] == 168 && (o[2] == 64 || o[2] == 65)
+}
+
+#[cfg(test)]
+mod filter_tests {
+    use super::is_docker_desktop_bridge_v4;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn docker_desktop_ranges_excluded() {
+        assert!(is_docker_desktop_bridge_v4(&Ipv4Addr::new(192, 168, 64, 1)));
+        assert!(is_docker_desktop_bridge_v4(&Ipv4Addr::new(
+            192, 168, 64, 255
+        )));
+        assert!(is_docker_desktop_bridge_v4(&Ipv4Addr::new(192, 168, 65, 5)));
+    }
+
+    #[test]
+    fn real_lan_ranges_preserved() {
+        // A home router on 192.168.1.x should NOT be excluded.
+        assert!(!is_docker_desktop_bridge_v4(&Ipv4Addr::new(
+            192, 168, 1, 154
+        )));
+        // 192.168.66.x is not a Docker Desktop default — keep.
+        assert!(!is_docker_desktop_bridge_v4(&Ipv4Addr::new(
+            192, 168, 66, 7
+        )));
+        // 10/8 private unaffected.
+        assert!(!is_docker_desktop_bridge_v4(&Ipv4Addr::new(10, 0, 0, 1)));
+        // Public unaffected.
+        assert!(!is_docker_desktop_bridge_v4(&Ipv4Addr::new(8, 8, 8, 8)));
+    }
 }
 
 /// Install an `on_peer_connection_state_change` handler that forwards

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -89,6 +89,25 @@ fn pc_key(pc: &Arc<RTCPeerConnection>) -> PcKey {
     Arc::as_ptr(pc) as PcKey
 }
 
+/// Bundled STUN servers used to discover the daemon's server-
+/// reflexive (srflx) ICE candidate. Without at least one STUN server
+/// in `RTCConfiguration.ice_servers`, webrtc-rs produces only
+/// `host`-type candidates — i.e. the local LAN / VPC address — which
+/// is useless for dials from outside the local network. The list is
+/// hardcoded so operators on a fresh daemon don't have to know this.
+/// Prefer Cloudflare over Google for privacy; fall back to Google so
+/// a single relay outage doesn't break ICE entirely.
+fn default_stun_servers() -> Vec<webrtc::ice_transport::ice_server::RTCIceServer> {
+    // One STUN server, not two — each STUN binding response produces
+    // its own `srflx` candidate line, and the sealed answer record's
+    // BEP44 1000-byte `v` cap doesn't have headroom for duplicates.
+    // Cloudflare's STUN is preferred over Google for privacy.
+    vec![webrtc::ice_transport::ice_server::RTCIceServer {
+        urls: vec!["stun:stun.cloudflare.com:3478".to_string()],
+        ..Default::default()
+    }]
+}
+
 /// The daemon's passive WebRTC peer.
 ///
 /// Holds a single `webrtc::api::API` so every inbound offer shares one
@@ -148,6 +167,27 @@ impl PassivePeer {
         // §3.1 says the daemon MUST be passive.
         let mut engine = SettingEngine::default();
         engine.set_answering_dtls_role(DTLSRole::Server)?;
+        // Filter ICE candidate gathering:
+        //   - interface name NOT in {docker0, docker*, br-*, veth*, tap*}.
+        //     These are local bridges with per-host-only routability;
+        //     gathering them crowds out the real LAN interface and
+        //     produces answers that no remote peer can connect to.
+        //   - IP NOT IPv6 link-local (fe80::/10) — scope-required,
+        //     can't be bound raw, and adds ~60-100 bytes of SDP each.
+        engine.set_interface_filter(Box::new(|iface: &str| {
+            !(iface.starts_with("docker")
+                || iface.starts_with("br-")
+                || iface.starts_with("veth")
+                || iface.starts_with("tap"))
+        }));
+        // IPv4-only on the answer side too — mirror client filter
+        // (webrtc_helpers.rs). Multi-family candidate sets blow out
+        // the BEP44 1000-byte `v` cap on the fragmented answer record
+        // and get silently evicted. Revisit when fragmentation has
+        // more headroom (e.g. offer/answer move off the main packet).
+        engine.set_ip_filter(Box::new(|ip: std::net::IpAddr| {
+            matches!(ip, std::net::IpAddr::V4(_))
+        }));
 
         let api = APIBuilder::new().with_setting_engine(engine).build();
 
@@ -243,6 +283,7 @@ impl PassivePeer {
     ) -> Result<String, ListenerError> {
         let config = RTCConfiguration {
             certificates: vec![self.certificate.clone()],
+            ice_servers: default_stun_servers(),
             ..Default::default()
         };
         let pc = Arc::new(self.api.new_peer_connection(config).await?);
@@ -288,13 +329,34 @@ impl PassivePeer {
                 "local description missing after set_local_description",
             ))?;
 
+        // Drop component-2 (RTCP) candidate lines — SCTP data
+        // channels use `a=rtcp-mux` so component 2 is never sent and
+        // the line just bloats the sealed answer record against BEP44's
+        // 1000-byte `v` cap. This halves the per-candidate overhead
+        // (a 5-candidate answer drops from 10 lines to 5) without
+        // breaking any ICE topology.
+        let trimmed_sdp: String = local_desc
+            .sdp
+            .lines()
+            .filter(|line| {
+                if let Some(rest) = line.strip_prefix("a=candidate:") {
+                    let parts: Vec<&str> = rest.split_whitespace().collect();
+                    parts.get(1).copied() != Some("2")
+                } else {
+                    true
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\r\n")
+            + "\r\n";
+
         // Keep the PC alive so the DTLS handshake can complete after we
         // return the answer SDP. The prune hook wired above will remove
         // this entry on Closed / Failed / Disconnected.
         let key = pc_key(&pc);
         self.active.lock().await.insert(key, pc);
 
-        Ok(local_desc.sdp)
+        Ok(trimmed_sdp)
     }
 }
 

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -89,23 +89,101 @@ fn pc_key(pc: &Arc<RTCPeerConnection>) -> PcKey {
     Arc::as_ptr(pc) as PcKey
 }
 
-/// Bundled STUN servers used to discover the daemon's server-
+/// Bundled STUN server used to discover the daemon's server-
 /// reflexive (srflx) ICE candidate. Without at least one STUN server
 /// in `RTCConfiguration.ice_servers`, webrtc-rs produces only
 /// `host`-type candidates — i.e. the local LAN / VPC address — which
-/// is useless for dials from outside the local network. The list is
-/// hardcoded so operators on a fresh daemon don't have to know this.
-/// Prefer Cloudflare over Google for privacy; fall back to Google so
-/// a single relay outage doesn't break ICE entirely.
+/// is useless for dials from outside the local network.
+///
+/// Exactly one STUN server is configured: each binding response from
+/// a different STUN host produces its own `srflx` candidate line, and
+/// the sealed answer record's BEP44 1000-byte `v` cap doesn't have
+/// headroom for duplicates. Cloudflare's STUN is preferred over
+/// Google for privacy. A failover list (with eviction under cap
+/// pressure) is tracked for a later PR.
 fn default_stun_servers() -> Vec<webrtc::ice_transport::ice_server::RTCIceServer> {
-    // One STUN server, not two — each STUN binding response produces
-    // its own `srflx` candidate line, and the sealed answer record's
-    // BEP44 1000-byte `v` cap doesn't have headroom for duplicates.
-    // Cloudflare's STUN is preferred over Google for privacy.
     vec![webrtc::ice_transport::ice_server::RTCIceServer {
         urls: vec!["stun:stun.cloudflare.com:3478".to_string()],
         ..Default::default()
     }]
+}
+
+/// Strip the component-2 (RTCP) `a=candidate:` lines from an SDP.
+/// SCTP data channels use `a=rtcp-mux` so component 2 is never sent;
+/// keeping it only bloats the sealed answer against BEP44's
+/// 1000-byte `v` cap.
+///
+/// Parses conservatively: only drops a line when we can confirm it
+/// starts with `a=candidate:` AND the component field (position 1)
+/// is exactly `"2"`. A malformed candidate line with fewer tokens
+/// than expected is kept verbatim so a webrtc-rs format change
+/// can't silently eat candidates.
+///
+/// Terminates the output with CRLF (SDP convention) even if the
+/// input didn't — `str::lines()` strips terminators on the way in.
+fn trim_rtcp_component_candidates(sdp: &str) -> String {
+    let mut out = String::with_capacity(sdp.len());
+    for line in sdp.lines() {
+        let drop_line = line
+            .strip_prefix("a=candidate:")
+            .and_then(|rest| rest.split_whitespace().nth(1))
+            == Some("2");
+        if !drop_line {
+            out.push_str(line);
+            out.push_str("\r\n");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod sdp_trim_tests {
+    use super::trim_rtcp_component_candidates;
+
+    const SAMPLE: &str = "v=0\r\n\
+                          o=- 0 0 IN IP4 0.0.0.0\r\n\
+                          a=candidate:111 1 udp 2130706431 10.0.0.5 1000 typ host\r\n\
+                          a=candidate:111 2 udp 2130706431 10.0.0.5 1000 typ host\r\n\
+                          a=candidate:222 1 udp 1694498815 1.2.3.4 2000 typ srflx raddr 0.0.0.0 rport 2000\r\n\
+                          a=candidate:222 2 udp 1694498815 1.2.3.4 2000 typ srflx raddr 0.0.0.0 rport 2000\r\n\
+                          a=end-of-candidates\r\n";
+
+    #[test]
+    fn drops_component_2_candidates_only() {
+        let out = trim_rtcp_component_candidates(SAMPLE);
+        let cand_lines: Vec<&str> = out
+            .lines()
+            .filter(|l| l.starts_with("a=candidate:"))
+            .collect();
+        assert_eq!(cand_lines.len(), 2, "should keep only component-1 lines");
+        for line in &cand_lines {
+            assert!(line.contains(" 1 udp "), "line missing component 1: {line}");
+        }
+        assert!(
+            out.contains("a=end-of-candidates"),
+            "non-candidate lines preserved"
+        );
+        assert!(out.ends_with("\r\n"));
+    }
+
+    #[test]
+    fn leaves_malformed_candidate_lines_alone() {
+        // Fewer tokens than expected — the filter keeps them so a
+        // webrtc-rs format drift can't silently eat candidates.
+        let odd = "a=candidate:notenoughtoken\r\n";
+        assert_eq!(
+            trim_rtcp_component_candidates(odd),
+            "a=candidate:notenoughtoken\r\n"
+        );
+    }
+
+    #[test]
+    fn no_candidates_is_pass_through() {
+        let simple = "v=0\r\ns=-\r\n";
+        let out = trim_rtcp_component_candidates(simple);
+        assert!(out.contains("v=0"));
+        assert!(out.contains("s=-"));
+    }
 }
 
 /// The daemon's passive WebRTC peer.
@@ -335,20 +413,7 @@ impl PassivePeer {
         // 1000-byte `v` cap. This halves the per-candidate overhead
         // (a 5-candidate answer drops from 10 lines to 5) without
         // breaking any ICE topology.
-        let trimmed_sdp: String = local_desc
-            .sdp
-            .lines()
-            .filter(|line| {
-                if let Some(rest) = line.strip_prefix("a=candidate:") {
-                    let parts: Vec<&str> = rest.split_whitespace().collect();
-                    parts.get(1).copied() != Some("2")
-                } else {
-                    true
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\r\n")
-            + "\r\n";
+        let trimmed_sdp = trim_rtcp_component_candidates(&local_desc.sdp);
 
         // Keep the PC alive so the DTLS handshake can complete after we
         // return the answer SDP. The prune hook wired above will remove


### PR DESCRIPTION
End-to-end testing (CLI dialer on NATed Mac → daemon on EC2 Mumbai) surfaced four blockers that predate the browser-extension work and affect every cross-network dial. All four fixed here. Residual BEP44 answer-size gap remains (tracked since PR #25) and needs a spec change, not one more knob.

## Four fixes

1. **`Dialer::build_offer` waits for `gathering_complete_promise`**. The pre-PR version skipped it, expecting trickle-ICE to fill candidates post-DC-open. That never worked — DC requires DTLS requires ICE requires candidates on both sides, and there's no trickle back-channel until the DC is open.

2. **STUN server configured on both sides**. `RTCConfiguration::default()` has no `ice_servers`. Without STUN, any agent behind NAT (every CLI client) or on a VPC private IP (every EC2 instance) advertises only its host-local address. Adding `stun:stun.cloudflare.com:3478` to both `Dialer` and `PassivePeer`. Verified on EC2 Mumbai: daemon now advertises `65.2.181.166:PORT typ srflx` instead of its `172.31.33.98` private VPC IP.

3. **Candidate hygiene filters**. Exclude IPv6 link-local (`fe80::/10`, unbind-able), Docker Desktop bridges (`192.168.64/65.0/24`), Linux Docker interfaces (`docker*`, `br-*`, `veth*`, `tap*`), IPv6 host candidates (multi-family bloats sealed offer past BEP44 cap), and mDNS candidates (privacy feature not useful for openhost).

4. **RTCP component-2 stripped from answer SDP**. With `a=rtcp-mux`, component-2 candidate lines are unused but still count against BEP44's 1000-byte `v` cap. Halves per-candidate overhead.

## What's still broken

Even with a single srflx candidate the answer SDP exceeds BEP44's 1000-byte cap because the SDP boilerplate alone (ice-ufrag/pwd/fingerprint/setup/mid/msid/sctp-port/max-message-size) is ~350 bytes and sealed-box + base64url + fragmentation push it over. Tracked as the residual answer-size gap since PR #25. Fix requires moving answers to their own pkarr mutable item under the client's zone — a separate spec-level PR.

## Verification

- `cargo fmt --all` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` all green (260+ tests).
- Live Mac ↔ EC2 Mumbai: offer publishes, daemon receives+processes, STUN-discovered srflx candidate in answer, handshake reaches the "answer evicted at BEP44 cap" boundary (that's the one remaining gap above). Every layer below that now correct.

## Test plan

- [ ] Review commits + merge.
- [ ] Once the answer-size-gap PR lands (separate), this PR + that PR together give a working cross-NAT dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)