### PR TITLE
🛡️ Sentinel: [security improvement] Explicit zeroization of intermediate key material

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Intermediate key material zeroization
+**Vulnerability:** Intermediate buffers (Vec<u8> or [u8; 32]) holding sensitive Ed25519 seeds were not explicitly zeroized after use, potentially leaving key material in memory.
+**Learning:** While the primary SigningKey struct implements ZeroizeOnDrop, temporary copies created via to_bytes() for serialization or derivation are plain byte arrays/vectors that persist until reclaimed by the allocator.
+**Prevention:** Always wrap intermediate buffers containing raw seeds or private keys in zeroize::Zeroizing or manually zeroize them immediately after the required operation (e.g., writing to disk or passing to a KDF).

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -15,6 +15,7 @@ use crate::error::{KeyStoreError, Result as DaemonResult};
 use async_trait::async_trait;
 use openhost_core::identity::{SigningKey, SIGNING_KEY_LEN};
 use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
 
 /// Crate-local result alias for keystore operations.
 pub type Result<T> = core::result::Result<T, KeyStoreError>;
@@ -66,10 +67,12 @@ impl KeyStore for FsKeyStore {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e.into()),
         };
+        let bytes = Zeroizing::new(bytes);
+
         if bytes.len() != SIGNING_KEY_LEN {
             return Err(KeyStoreError::WrongSize { got: bytes.len() });
         }
-        let mut seed = [0u8; SIGNING_KEY_LEN];
+        let mut seed = Zeroizing::new([0u8; SIGNING_KEY_LEN]);
         seed.copy_from_slice(&bytes);
         Ok(Some(SigningKey::from_bytes(&seed)))
     }
@@ -81,8 +84,8 @@ impl KeyStore for FsKeyStore {
             }
         }
 
-        let seed = sk.to_bytes();
-        write_mode_0600(&self.path, &seed).await?;
+        let seed = Zeroizing::new(sk.to_bytes());
+        write_mode_0600(&self.path, seed.as_ref()).await?;
         Ok(())
     }
 }

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -29,6 +29,7 @@ use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use zeroize::Zeroizing;
 
 /// Domain-separation salt for the allowlist-salt derivation. Stable across
 /// openhost protocol versions so a daemon rebooted on the same identity
@@ -73,8 +74,8 @@ impl SharedState {
     /// is derived deterministically from `identity` via HKDF-SHA256 (see
     /// the struct-level doc for the scheme).
     pub fn new(identity: &SigningKey, dtls_fp: [u8; DTLS_FINGERPRINT_LEN]) -> Self {
-        let seed = identity.to_bytes();
-        let hk = Hkdf::<Sha256>::new(Some(ALLOW_SALT_HKDF_SALT), &seed);
+        let seed = Zeroizing::new(identity.to_bytes());
+        let hk = Hkdf::<Sha256>::new(Some(ALLOW_SALT_HKDF_SALT), seed.as_ref());
         let mut salt = [0u8; SALT_LEN];
         hk.expand(&[], &mut salt)
             .expect("HKDF expansion to 32 bytes cannot fail");


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Explicit zeroization of intermediate key material

This PR ensures that intermediate buffers holding sensitive Ed25519 seeds are explicitly zeroized immediately after use. While the primary \`SigningKey\` struct implements \`ZeroizeOnDrop\`, temporary copies created for disk persistence (\`FsKeyStore\`) or salt derivation (\`SharedState\`) were previously left in memory as plain byte arrays/vectors.

### Changes:
- **crates/openhost-daemon/src/identity_store.rs**: Modified \`FsKeyStore::load\` and \`FsKeyStore::store\` to wrap intermediate seed buffers in \`zeroize::Zeroizing\`.
- **crates/openhost-daemon/src/publish.rs**: Modified \`SharedState::new\` to wrap the identity seed in \`zeroize::Zeroizing\` before passing it to \`Hkdf\`.

### Verification:
- Ran \`cargo test --workspace\` to ensure all tests pass.
- Ran \`cargo clippy --workspace\` to verify zeroization patterns and type safety.
- Manually audited \`crates/openhost-client/src/dialer.rs\` and \`crates/openhost-pkarr/src/codec.rs\` to confirm they already correctly use \`Zeroizing\` for sensitive seeds.

---
*PR created automatically by Jules for task [17494988989116162075](https://jules.google.com/task/17494988989116162075) started by @vamzi*