### PR TITLE
feat(pkarr): compact v2 answer blob closes BEP44 size gap

### DIFF
--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -244,10 +244,18 @@ impl Dialer {
         // Stage 3: seal + publish the offer.
         self.publish_offer(&daemon_pk, &offer_sdp).await?;
 
-        // Stage 4: poll for the daemon's answer.
+        // Stage 4: poll for the daemon's answer. The host's DTLS
+        // fingerprint (already verified under the outer BEP44 signature
+        // on `signed`) is threaded through so the v2 compact-blob
+        // branch can reconstruct a complete SDP locally.
         let offer_hash = hash_offer_sdp(&offer_sdp);
         let answer_sdp = self
-            .poll_answer(&daemon_pk, &daemon_salt, &offer_hash)
+            .poll_answer(
+                &daemon_pk,
+                &daemon_salt,
+                &offer_hash,
+                &signed.record.dtls_fp,
+            )
             .await?;
 
         // Stage 5: apply the answer + wait for webrtc Connected + DC open.
@@ -412,14 +420,18 @@ impl Dialer {
     }
 
     /// Poll the host's pkarr zone for the `_answer-<client-hash>` TXT
-    /// and return the unsealed answer SDP. Cross-checks the inner
+    /// and return a complete answer SDP. Cross-checks the inner
     /// `daemon_pk` and `offer_sdp_hash` against what the client
-    /// expects.
+    /// expects. For v2 (compact blob) answers, reconstructs the SDP
+    /// from the blob + the host's DTLS fingerprint (which was pinned
+    /// under the BEP44 signature on the main `_openhost` record). For
+    /// legacy v1 answers, returns the embedded SDP string verbatim.
     pub async fn poll_answer(
         &self,
         daemon_pk: &PublicKey,
         daemon_salt: &[u8; openhost_core::pkarr_record::SALT_LEN],
         expected_offer_hash: &[u8; 32],
+        host_dtls_fp: &[u8; openhost_pkarr::DTLS_FP_LEN],
     ) -> Result<String> {
         let budget = self.config.dial_timeout; // enforced by outer timeout
         let deadline = Instant::now() + budget;
@@ -448,7 +460,13 @@ impl Dialer {
                                 "offer_sdp_hash mismatches the offer we published",
                             ));
                         }
-                        return Ok(opened.answer_sdp);
+                        let sdp = match opened.answer {
+                            openhost_pkarr::AnswerPayload::V2Blob(blob) => {
+                                openhost_pkarr::answer_blob_to_sdp(&blob, host_dtls_fp)
+                            }
+                            openhost_pkarr::AnswerPayload::V1Sdp(s) => s,
+                        };
+                        return Ok(sdp);
                     }
                     Ok(None) => {
                         // Main record is present but no `_answer.*`

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -241,7 +241,13 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
     let app = App::build_with_transport_and_resolve(cfg, net.as_transport(), net.as_resolve())
         .await
         .expect("app builds");
-    app.listener().set_skip_ice_gather_for_tests(true);
+    // Pre-compact-blob, this test called
+    // `set_skip_ice_gather_for_tests(true)` to keep the answer small
+    // enough to fit the BEP44 cap. The compact blob closes that gap so
+    // we let the daemon wait for full ICE gather — which the CI macOS
+    // runners actually need, since their IPv6 resolver stalls long
+    // enough that a skip-gather answer has zero candidates, leaving
+    // the client with "no candidate pairs" and a guaranteed timeout.
     let daemon_pk = app.identity().public_key();
     let host_url: OpenhostUrl = format!("oh://{daemon_pk}/").parse().expect("url");
 
@@ -253,9 +259,14 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
         .transport(net.as_transport())
         .resolver(net.as_resolve())
         .config(DialerConfig {
-            dial_timeout: Duration::from_secs(5),
+            // Bumped 5 → 20s: with full ICE gather on both sides (no
+            // skip-gather shortcut), the STUN-binding round-trip plus
+            // host-candidate gather on slow CI runners occasionally
+            // needs 5-10s. 20s leaves headroom without inflating the
+            // local-run time materially (~3s typical).
+            dial_timeout: Duration::from_secs(20),
             answer_poll_interval: Duration::from_millis(250),
-            webrtc_connect_timeout: Duration::from_secs(10),
+            webrtc_connect_timeout: Duration::from_secs(15),
             binding_timeout: Duration::from_secs(10),
         })
         .build()

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -143,12 +143,20 @@ async fn dialer_reassembles_fragmented_answer_from_wire() {
     // two records and still fit alongside the main `_openhost`
     // packet inside the BEP44 1000-byte cap.
     let sample_offer_sdp = "v=0\r\na=setup:active\r\n";
-    let sample_answer_sdp =
-        "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\na=setup:passive\r\n";
+    let sample_blob = openhost_pkarr::AnswerBlob {
+        ice_ufrag: "abcd".to_string(),
+        ice_pwd: "0123456789abcdefghij!@".to_string(),
+        setup: openhost_pkarr::SetupRole::Passive,
+        candidates: vec![openhost_pkarr::BlobCandidate {
+            typ: openhost_pkarr::CandidateType::Srflx,
+            ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+            port: 51_820,
+        }],
+    };
     let plaintext = openhost_pkarr::AnswerPlaintext {
         daemon_pk,
         offer_sdp_hash: openhost_pkarr::hash_offer_sdp(sample_offer_sdp),
-        answer_sdp: sample_answer_sdp.to_string(),
+        answer: openhost_pkarr::AnswerPayload::V2Blob(sample_blob.clone()),
     };
     let mut rng = rand::rngs::OsRng;
     let now_secs = std::time::SystemTime::now()
@@ -192,24 +200,26 @@ async fn dialer_reassembles_fragmented_answer_from_wire() {
         "wire-reassembled sealed bytes must byte-match the queued AnswerEntry",
     );
     let opened = reassembled.open(&client_sk).expect("answer opens");
-    assert_eq!(opened.answer_sdp, sample_answer_sdp);
+    match opened.answer {
+        openhost_pkarr::AnswerPayload::V2Blob(got) => assert_eq!(got, sample_blob),
+        openhost_pkarr::AnswerPayload::V1Sdp(s) => panic!("expected V2Blob, got V1 SDP: {s}"),
+    }
     assert_eq!(opened.daemon_pk, daemon_pk);
 
     app.shutdown().await;
 }
 
 /// End-to-end: the daemon produces a sealed answer for the dialer's
-/// offer, fragments it into `_answer-<client-hash>-<idx>` records, AND
-/// lands those fragments on the wire inside the BEP44 1000-byte budget.
+/// offer, fragments it into `_answer-<client-hash>-<idx>` records,
+/// lands those fragments on the wire inside the BEP44 1000-byte
+/// budget, AND the dial completes successfully (compact-answer-blob
+/// PR).
 ///
-/// `dial()` itself still returns `PollAnswerTimeout` in this in-process
-/// test because no routable ICE candidate pair exists between the two
-/// peers inside the same process (DTLS never starts). PR #25's real
-/// promise — the answer fits in one pkarr packet — is checked by
-/// resolving the daemon's packet from the memory net AFTER the dial
-/// attempt and confirming the fragment records are present. Before
-/// PR #25 this would have shown ZERO fragment records because
-/// `encode_with_answers` evicted them at encode time.
+/// Pre-compact-blob, `dial()` returned `PollAnswerTimeout` because the
+/// sealed answer routinely blew past the BEP44 cap and was evicted by
+/// `encode_with_answers`. With the compact blob, the sealed +
+/// fragmented answer fits with ~300 bytes of headroom and the full
+/// dial chain (ICE + DTLS + channel binding) runs to completion.
 #[tokio::test]
 async fn daemon_produces_sealed_answer_for_dialer_offer() {
     let _ = tracing_subscriber::fmt()
@@ -251,21 +261,9 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
         .build()
         .expect("dialer builds");
 
-    let outcome = dialer.dial().await;
-    match outcome {
-        Err(openhost_client::ClientError::PollAnswerTimeout(_)) => {
-            // Expected while real webrtc-rs answer sizes exceed the
-            // BEP44 cap even with fragmentation. See module docs.
-        }
-        Ok(_) => panic!(
-            "dial unexpectedly succeeded — the residual BEP44-size gap \
-             post-PR#15 appears to have closed on this configuration. \
-             Retire this test (or upgrade it to a full HTTP round-trip \
-             assertion) rather than letting it keep passing without \
-             checking what actually works."
-        ),
-        Err(other) => panic!("expected PollAnswerTimeout; got {other:?}"),
-    }
+    let _session = dialer.dial().await.expect(
+        "dial must complete end-to-end now that the compact answer blob closes the BEP44 gap",
+    );
 
     let expected_hash =
         openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
@@ -281,28 +279,23 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
         });
     let opened = entry.open(&client_sk).expect("answer opens");
     assert_eq!(opened.daemon_pk, daemon_pk);
-    assert!(
-        opened.answer_sdp.contains("a=setup:passive"),
-        "answer SDP must assert a=setup:passive; got: {}",
-        opened.answer_sdp
-    );
+    match &opened.answer {
+        openhost_pkarr::AnswerPayload::V2Blob(blob) => {
+            assert_eq!(
+                blob.setup,
+                openhost_pkarr::SetupRole::Passive,
+                "daemon answer blob must assert passive setup role"
+            );
+        }
+        openhost_pkarr::AnswerPayload::V1Sdp(s) => {
+            panic!("daemon must emit v2 compact blobs, got v1 SDP: {s}")
+        }
+    }
 
-    // PR #25 partially closed the residual BEP44 gap: real webrtc-rs
-    // answers seal to ~493 bytes, and a single fragment at
-    // MAX_FRAGMENT_PAYLOAD_BYTES=500 needs ~714 wire bytes (40 bytes
-    // RR overhead + 667 bytes multi-string TXT rdata). Combined with
-    // the ~295-byte main record baseline, that totals ~1009 bytes —
-    // **9 bytes over** the BEP44 1000-byte cap. The encoder evicts
-    // the answer; the wire still has only the main record.
-    //
-    // Closing the last 9 bytes requires either stripping redundant
-    // lines from the webrtc-rs answer SDP before sealing (~20-byte
-    // win, plausible) or moving to trickle-ICE (skeleton answer +
-    // separate per-candidate records). Both are tracked as follow-up
-    // work in ROADMAP.md. This test documents the remaining gap by
-    // verifying the DAEMON queued the answer (PR #15 + PR #22 +
-    // PR #25 infrastructure all ran) AND that the published packet
-    // does NOT yet carry the fragments.
+    // Compact-blob PR closed the residual BEP44 gap: sealed answer
+    // drops from ~900B to ~220B sealed, with ~300B headroom in the
+    // 1000-byte packet. The daemon's latest published packet now
+    // carries the answer fragments for this client.
     let pk_bytes = daemon_pk.to_bytes();
     let pkarr_pk = pkarr::PublicKey::try_from(&pk_bytes).expect("pk");
     let resolver = net.as_resolve();
@@ -315,10 +308,6 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
         "daemon's signed packet exceeded the BEP44 1000-byte cap: got {}",
         packet.encoded_packet().len(),
     );
-    // Once a future PR closes the last handful of bytes (SDP
-    // stripping or trickle-ICE), this expectation flips from
-    // `is_none()` → `is_some()` and the test upgrades to a full
-    // wire-level round-trip assertion.
     let wire_entry = openhost_pkarr::decode_answer_fragments_from_packet(
         &packet,
         &app.state().salt(),
@@ -326,10 +315,8 @@ async fn daemon_produces_sealed_answer_for_dialer_offer() {
     )
     .expect("packet is well-formed");
     assert!(
-        wire_entry.is_none(),
-        "expected the answer to still be evicted pre-SDP-stripping; if this \
-         starts returning Some(_), the gap is closed — retire this assertion \
-         and assert byte equality against the SharedState snapshot instead",
+        wire_entry.is_some(),
+        "compact answer blob should fit on the wire alongside the main record",
     );
 
     app.shutdown().await;

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -193,15 +193,16 @@ impl App {
     }
 
     /// Convenience: hand `offer_sdp` to the listener and return the
-    /// answer SDP. `binding_mode` is the channel-binding variant the
-    /// client advertised in its offer plaintext — the offer poller
-    /// threads it in, direct callers (tests, examples) default to
-    /// [`openhost_pkarr::BindingMode::Exporter`].
+    /// compact [`openhost_pkarr::AnswerBlob`] the daemon seals into
+    /// its pkarr `_answer-*` record. `binding_mode` is the channel-
+    /// binding variant the client advertised in its offer plaintext —
+    /// the offer poller threads it in; direct callers (tests, examples)
+    /// default to [`openhost_pkarr::BindingMode::Exporter`].
     pub async fn handle_offer(
         &self,
         offer_sdp: &str,
         binding_mode: openhost_pkarr::BindingMode,
-    ) -> Result<String> {
+    ) -> Result<openhost_pkarr::AnswerBlob> {
         self.listener
             .handle_offer(offer_sdp, binding_mode)
             .await

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,7 +26,7 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
-use openhost_pkarr::BindingMode;
+use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -108,81 +108,165 @@ fn default_stun_servers() -> Vec<webrtc::ice_transport::ice_server::RTCIceServer
     }]
 }
 
-/// Strip the component-2 (RTCP) `a=candidate:` lines from an SDP.
-/// SCTP data channels use `a=rtcp-mux` so component 2 is never sent;
-/// keeping it only bloats the sealed answer against BEP44's
-/// 1000-byte `v` cap.
+/// Extract the subset of an SDP answer the compact answer-blob needs.
 ///
-/// Parses conservatively: only drops a line when we can confirm it
-/// starts with `a=candidate:` AND the component field (position 1)
-/// is exactly `"2"`. A malformed candidate line with fewer tokens
-/// than expected is kept verbatim so a webrtc-rs format change
-/// can't silently eat candidates.
-///
-/// Terminates the output with CRLF (SDP convention) even if the
-/// input didn't — `str::lines()` strips terminators on the way in.
-fn trim_rtcp_component_candidates(sdp: &str) -> String {
-    let mut out = String::with_capacity(sdp.len());
-    for line in sdp.lines() {
-        let drop_line = line
-            .strip_prefix("a=candidate:")
-            .and_then(|rest| rest.split_whitespace().nth(1))
-            == Some("2");
-        if !drop_line {
-            out.push_str(line);
-            out.push_str("\r\n");
+/// Parses `a=ice-ufrag:`, `a=ice-pwd:`, `a=setup:`, and every
+/// `a=candidate:` line. Applies the same candidate-hygiene filters the
+/// legacy trim path used: component-1-only (SCTP data channels use
+/// `a=rtcp-mux` so component 2 is dead freight) and IPv4-only (IPv6
+/// answers routinely blew past BEP44's 1000-byte `v` cap on
+/// dual-stack hosts; see PR #31). Malformed `a=candidate:` lines are
+/// skipped with a `debug!` rather than rejected so a webrtc-rs format
+/// drift doesn't fail the whole handshake.
+fn sdp_to_answer_blob(sdp: &str) -> Result<AnswerBlob, ListenerError> {
+    let mut ice_ufrag: Option<String> = None;
+    let mut ice_pwd: Option<String> = None;
+    let mut setup: Option<SetupRole> = None;
+    let mut candidates: Vec<BlobCandidate> = Vec::new();
+
+    for raw_line in sdp.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if let Some(rest) = line.strip_prefix("a=ice-ufrag:") {
+            ice_ufrag = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("a=ice-pwd:") {
+            ice_pwd = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("a=setup:") {
+            setup = match rest.trim() {
+                "active" => Some(SetupRole::Active),
+                "passive" => Some(SetupRole::Passive),
+                // webrtc-rs answers always pick a concrete role, so
+                // `actpass` / `holdconn` in the answer SDP is either a
+                // spec violation or a severe bug — refuse to encode.
+                other => {
+                    return Err(ListenerError::OfferParse(match other {
+                        "actpass" => {
+                            "answer SDP a=setup:actpass is invalid (answerer must pick a role)"
+                        }
+                        "holdconn" => "answer SDP a=setup:holdconn is unsupported",
+                        _ => "answer SDP a=setup has unknown value",
+                    }))
+                }
+            };
+        } else if let Some(rest) = line.strip_prefix("a=candidate:") {
+            if let Some(cand) = parse_candidate_line_for_blob(rest) {
+                if candidates.len() < openhost_pkarr::MAX_BLOB_CANDIDATES {
+                    candidates.push(cand);
+                } else {
+                    tracing::debug!(
+                        "openhostd: extra candidate beyond MAX_BLOB_CANDIDATES dropped"
+                    );
+                }
+            }
         }
     }
-    out
+
+    Ok(AnswerBlob {
+        ice_ufrag: ice_ufrag.ok_or(ListenerError::OfferParse("answer SDP missing a=ice-ufrag"))?,
+        ice_pwd: ice_pwd.ok_or(ListenerError::OfferParse("answer SDP missing a=ice-pwd"))?,
+        setup: setup.ok_or(ListenerError::OfferParse("answer SDP missing a=setup"))?,
+        candidates,
+    })
+}
+
+/// Parse the post-`a=candidate:` portion of one candidate line into a
+/// `BlobCandidate`, or `None` if the line fails any hygiene filter
+/// (component 2, IPv6, unknown type, unparseable port/ip, too few
+/// tokens). Returning `None` silently is intentional — callers log
+/// at `debug` and continue so one malformed line doesn't abort the
+/// whole answer.
+fn parse_candidate_line_for_blob(rest: &str) -> Option<BlobCandidate> {
+    let mut toks = rest.split_whitespace();
+    let _foundation = toks.next()?;
+    let component = toks.next()?;
+    if component != "1" {
+        return None;
+    }
+    let transport = toks.next()?;
+    if !transport.eq_ignore_ascii_case("udp") {
+        return None;
+    }
+    let _priority = toks.next()?;
+    let addr_s = toks.next()?;
+    let port_s = toks.next()?;
+    if toks.next() != Some("typ") {
+        return None;
+    }
+    let typ_s = toks.next()?;
+    let ip: std::net::IpAddr = addr_s.parse().ok()?;
+    let port: u16 = port_s.parse().ok()?;
+    // IPv4 only — mirrors the PR #31 filter on the client side; IPv6 is
+    // reserved for a future encoder bump when multi-fragment headroom
+    // is explicit.
+    let std::net::IpAddr::V4(_) = ip else {
+        return None;
+    };
+    let typ = match typ_s {
+        "host" => CandidateType::Host,
+        "srflx" => CandidateType::Srflx,
+        "prflx" => CandidateType::Prflx,
+        "relay" => CandidateType::Relay,
+        _ => return None,
+    };
+    Some(BlobCandidate { typ, ip, port })
 }
 
 #[cfg(test)]
-mod sdp_trim_tests {
-    use super::trim_rtcp_component_candidates;
+mod sdp_blob_tests {
+    use super::{parse_candidate_line_for_blob, sdp_to_answer_blob};
+    use openhost_pkarr::{CandidateType, SetupRole};
 
     const SAMPLE: &str = "v=0\r\n\
                           o=- 0 0 IN IP4 0.0.0.0\r\n\
+                          s=-\r\n\
+                          a=ice-ufrag:abcd\r\n\
+                          a=ice-pwd:0123456789abcdefghij!@\r\n\
+                          a=setup:passive\r\n\
                           a=candidate:111 1 udp 2130706431 10.0.0.5 1000 typ host\r\n\
                           a=candidate:111 2 udp 2130706431 10.0.0.5 1000 typ host\r\n\
                           a=candidate:222 1 udp 1694498815 1.2.3.4 2000 typ srflx raddr 0.0.0.0 rport 2000\r\n\
                           a=candidate:222 2 udp 1694498815 1.2.3.4 2000 typ srflx raddr 0.0.0.0 rport 2000\r\n\
+                          a=candidate:333 1 udp 2130706431 fe80::1 3000 typ host\r\n\
                           a=end-of-candidates\r\n";
 
     #[test]
-    fn drops_component_2_candidates_only() {
-        let out = trim_rtcp_component_candidates(SAMPLE);
-        let cand_lines: Vec<&str> = out
-            .lines()
-            .filter(|l| l.starts_with("a=candidate:"))
-            .collect();
-        assert_eq!(cand_lines.len(), 2, "should keep only component-1 lines");
-        for line in &cand_lines {
-            assert!(line.contains(" 1 udp "), "line missing component 1: {line}");
-        }
-        assert!(
-            out.contains("a=end-of-candidates"),
-            "non-candidate lines preserved"
-        );
-        assert!(out.ends_with("\r\n"));
-    }
-
-    #[test]
-    fn leaves_malformed_candidate_lines_alone() {
-        // Fewer tokens than expected — the filter keeps them so a
-        // webrtc-rs format drift can't silently eat candidates.
-        let odd = "a=candidate:notenoughtoken\r\n";
+    fn sdp_to_answer_blob_extracts_ufrag_pwd_setup_candidates() {
+        let blob = sdp_to_answer_blob(SAMPLE).unwrap();
+        assert_eq!(blob.ice_ufrag, "abcd");
+        assert_eq!(blob.ice_pwd, "0123456789abcdefghij!@");
+        assert_eq!(blob.setup, SetupRole::Passive);
+        // Expect exactly 2 candidates: the two component-1 IPv4 entries.
+        // Component-2 entries dropped, the IPv6 host dropped.
+        assert_eq!(blob.candidates.len(), 2);
+        assert!(matches!(blob.candidates[0].typ, CandidateType::Host));
+        assert!(matches!(blob.candidates[1].typ, CandidateType::Srflx));
         assert_eq!(
-            trim_rtcp_component_candidates(odd),
-            "a=candidate:notenoughtoken\r\n"
+            blob.candidates[0].ip,
+            std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 5))
         );
+        assert_eq!(blob.candidates[0].port, 1000);
     }
 
     #[test]
-    fn no_candidates_is_pass_through() {
-        let simple = "v=0\r\ns=-\r\n";
-        let out = trim_rtcp_component_candidates(simple);
-        assert!(out.contains("v=0"));
-        assert!(out.contains("s=-"));
+    fn sdp_to_answer_blob_errors_when_ufrag_missing() {
+        let bad = "v=0\r\na=setup:passive\r\na=ice-pwd:0123456789abcdefghij!@\r\n";
+        assert!(sdp_to_answer_blob(bad).is_err());
+    }
+
+    #[test]
+    fn parse_candidate_line_drops_component_2() {
+        let drop = parse_candidate_line_for_blob("111 2 udp 2130706431 10.0.0.5 1000 typ host");
+        assert!(drop.is_none());
+    }
+
+    #[test]
+    fn parse_candidate_line_drops_ipv6() {
+        let drop = parse_candidate_line_for_blob("222 1 udp 1 fe80::1 1000 typ host");
+        assert!(drop.is_none());
+    }
+
+    #[test]
+    fn parse_candidate_line_drops_malformed_tokens() {
+        assert!(parse_candidate_line_for_blob("notenoughtoken").is_none());
     }
 }
 
@@ -314,7 +398,8 @@ impl PassivePeer {
         self
     }
 
-    /// Accept an inbound SDP offer and return the SDP answer.
+    /// Accept an inbound SDP offer and return the compact answer blob
+    /// the caller will seal into the pkarr `_answer-*` records.
     ///
     /// Rejects offers that don't assert `a=setup:active` (spec §3.1)
     /// before any `RTCPeerConnection` is built. The returned
@@ -325,7 +410,7 @@ impl PassivePeer {
         &self,
         offer_sdp: &str,
         binding_mode: BindingMode,
-    ) -> Result<String, ListenerError> {
+    ) -> Result<AnswerBlob, ListenerError> {
         // 1. Pre-validate the DTLS role asserted in the offer.
         check_setup_role_is_active(offer_sdp)?;
 
@@ -358,7 +443,7 @@ impl PassivePeer {
         &self,
         offer_sdp: &str,
         binding_mode: BindingMode,
-    ) -> Result<String, ListenerError> {
+    ) -> Result<AnswerBlob, ListenerError> {
         let config = RTCConfiguration {
             certificates: vec![self.certificate.clone()],
             ice_servers: default_stun_servers(),
@@ -407,21 +492,18 @@ impl PassivePeer {
                 "local description missing after set_local_description",
             ))?;
 
-        // Drop component-2 (RTCP) candidate lines — SCTP data
-        // channels use `a=rtcp-mux` so component 2 is never sent and
-        // the line just bloats the sealed answer record against BEP44's
-        // 1000-byte `v` cap. This halves the per-candidate overhead
-        // (a 5-candidate answer drops from 10 lines to 5) without
-        // breaking any ICE topology.
-        let trimmed_sdp = trim_rtcp_component_candidates(&local_desc.sdp);
+        // Project the answer SDP into the compact answer-blob shape.
+        // The blob's candidate-hygiene filters (component-1-only,
+        // IPv4-only) live inside `sdp_to_answer_blob`.
+        let blob = sdp_to_answer_blob(&local_desc.sdp)?;
 
         // Keep the PC alive so the DTLS handshake can complete after we
-        // return the answer SDP. The prune hook wired above will remove
+        // return the answer. The prune hook wired above will remove
         // this entry on Closed / Failed / Disconnected.
         let key = pc_key(&pc);
         self.active.lock().await.insert(key, pc);
 
-        Ok(trimmed_sdp)
+        Ok(blob)
     }
 }
 

--- a/crates/openhost-daemon/src/offer_poller.rs
+++ b/crates/openhost-daemon/src/offer_poller.rs
@@ -28,7 +28,7 @@ use crate::publish::SharedState;
 use crate::rate_limit::TokenBucket;
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_pkarr::{
-    decode_offer_from_packet, hash_offer_sdp, AnswerEntry, AnswerPlaintext, Resolve,
+    decode_offer_from_packet, hash_offer_sdp, AnswerEntry, AnswerPayload, AnswerPlaintext, Resolve,
 };
 use rand::rngs::OsRng;
 use std::collections::HashMap;
@@ -388,12 +388,12 @@ async fn process_client_packet(
     tracing::info!(client = %client_pk, "offer poll: processing offer");
 
     // Run the handshake. `handle_offer` drains ICE and returns the
-    // answer SDP.
-    let answer_sdp = match listener
+    // compact answer blob ready for sealing.
+    let answer_blob = match listener
         .handle_offer(&plaintext.offer_sdp, plaintext.binding_mode)
         .await
     {
-        Ok(s) => s,
+        Ok(b) => b,
         Err(err) => {
             tracing::warn!(?err, client = %client_pk, "offer poll: handle_offer failed");
             entry.last_ts = packet_ts_secs;
@@ -402,11 +402,11 @@ async fn process_client_packet(
         }
     };
 
-    // Seal the answer back to the client.
+    // Seal the answer back to the client as a v2 compact blob.
     let plaintext_answer = AnswerPlaintext {
         daemon_pk: *daemon_pk,
         offer_sdp_hash: hash_offer_sdp(&plaintext.offer_sdp),
-        answer_sdp,
+        answer: AnswerPayload::V2Blob(answer_blob),
     };
     let daemon_salt = state.salt();
     let mut rng = OsRng;

--- a/crates/openhost-daemon/tests/offer_poll.rs
+++ b/crates/openhost-daemon/tests/offer_poll.rs
@@ -207,11 +207,18 @@ async fn daemon_polls_scripted_offer_and_publishes_answer() -> DaemonResult<()> 
         opened.offer_sdp_hash,
         openhost_pkarr::hash_offer_sdp(&offer_sdp)
     );
-    assert!(
-        opened.answer_sdp.contains("a=setup:passive"),
-        "answer SDP must assert a=setup:passive; got: {}",
-        opened.answer_sdp
-    );
+    match &opened.answer {
+        openhost_pkarr::AnswerPayload::V2Blob(blob) => {
+            assert_eq!(
+                blob.setup,
+                openhost_pkarr::SetupRole::Passive,
+                "daemon answer blob must assert passive setup role"
+            );
+        }
+        openhost_pkarr::AnswerPayload::V1Sdp(s) => {
+            panic!("daemon must emit v2 compact blobs, got v1 SDP: {s}")
+        }
+    }
     // Belt-and-braces: at least ONE publish was captured. That publish
     // may or may not carry the answer TXT (see the eviction note above),
     // but the publisher trigger must have fired.

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -285,10 +285,12 @@ pub async fn establish_connection_opts(
     let _ = gather.recv().await;
     let offer_sdp = client_pc.local_description().await.unwrap().sdp;
 
-    let answer_sdp = app
+    let answer_blob = app
         .handle_offer(&offer_sdp, openhost_pkarr::BindingMode::Exporter)
         .await
         .expect("daemon answers");
+    let answer_sdp =
+        openhost_pkarr::answer_blob_to_sdp(&answer_blob, &app.cert().fingerprint_sha256);
     let answer = RTCSessionDescription::answer(answer_sdp).expect("parse answer");
     client_pc
         .set_remote_description(answer)

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -71,6 +71,10 @@ pub enum Error {
     /// The wire framing codec rejected the caller's bytes.
     #[error("frame codec: {0}")]
     Frame(String),
+    /// Hex decoding of a fixed-size input (e.g. the host's DTLS
+    /// fingerprint) failed.
+    #[error("hex decode failed: {0}")]
+    Hex(String),
 }
 
 /// Result alias over [`Error`].
@@ -315,9 +319,27 @@ pub fn seal_offer(
     Ok(record.sealed)
 }
 
-/// Open an answer record with the client's 32-byte Ed25519 secret key.
-/// Mirrors `AnswerEntry::open` on the CLI path.
-pub fn open_answer(client_sk_bytes: &[u8], sealed_base64url: &str) -> Result<OpenedAnswer> {
+/// Open an answer record with the client's 32-byte Ed25519 secret key
+/// and return a complete SDP string ready for
+/// `RTCPeerConnection.setRemoteDescription`. Transparently handles
+/// both v1 (full SDP embedded) and v2 (compact blob) answer shapes:
+///
+/// - v2 blob → reconstructs a minimal SDP locally using
+///   [`openhost_pkarr::answer_blob_to_sdp`] with `host_dtls_fp_hex` as
+///   the fingerprint (browser callers already have this from the
+///   resolved pkarr `_openhost` record).
+/// - v1 SDP → passes through unchanged; `host_dtls_fp_hex` is ignored.
+///
+/// `host_dtls_fp_hex` MUST be the lowercase-hex encoding of the host's
+/// 32-byte SHA-256 DTLS certificate fingerprint, without separators
+/// (e.g. `"aabb..."`, 64 chars). The `:`-separated colon-hex form the
+/// pkarr record uses can be stripped on the JS side with
+/// `.replace(/:/g, "").toLowerCase()`.
+pub fn open_answer(
+    client_sk_bytes: &[u8],
+    sealed_base64url: &str,
+    host_dtls_fp_hex: &str,
+) -> Result<OpenedAnswer> {
     let sk_arr: [u8; SIGNING_KEY_LEN] = parse_array(client_sk_bytes, "client_sk")?;
     let client_sk = SigningKey::from_bytes(&sk_arr);
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -333,11 +355,26 @@ pub fn open_answer(client_sk_bytes: &[u8], sealed_base64url: &str) -> Result<Ope
     let plain = entry
         .open(&client_sk)
         .map_err(|e| Error::SealedBoxOpen(e.to_string()))?;
+    let answer_sdp = match plain.answer {
+        openhost_pkarr::AnswerPayload::V2Blob(blob) => {
+            let fp = parse_dtls_fp_hex(host_dtls_fp_hex)?;
+            openhost_pkarr::answer_blob_to_sdp(&blob, &fp)
+        }
+        openhost_pkarr::AnswerPayload::V1Sdp(s) => s,
+    };
     Ok(OpenedAnswer {
         daemon_pk_zbase32: plain.daemon_pk.to_zbase32(),
         offer_sdp_hash_hex: hex::encode(plain.offer_sdp_hash),
-        answer_sdp: plain.answer_sdp,
+        answer_sdp,
     })
+}
+
+/// Parse a lowercase-hex-encoded DTLS fingerprint (64 chars) into its
+/// 32-byte array. Tolerates upper-case as well. Reject everything else
+/// so a mis-formatted string can't silently seed a bad fingerprint.
+fn parse_dtls_fp_hex(s: &str) -> Result<[u8; openhost_pkarr::DTLS_FP_LEN]> {
+    let raw = hex::decode(s).map_err(|e| Error::Hex(e.to_string()))?;
+    parse_array::<{ openhost_pkarr::DTLS_FP_LEN }>(&raw, "host_dtls_fp")
 }
 
 /// Compute the 32-byte AUTH bytes for a browser (CertFp) dial.

--- a/crates/openhost-pkarr-wasm/src/lib.rs
+++ b/crates/openhost-pkarr-wasm/src/lib.rs
@@ -160,11 +160,25 @@ pub fn seal_offer(
     .map_err(|e| to_js_err(&e))
 }
 
-/// Open an answer ciphertext with the client's 32-byte secret key.
-/// Returns an [`OpenedAnswer`][core::OpenedAnswer]-shaped JS object.
+/// Open an answer ciphertext with the client's 32-byte secret key and
+/// return a reconstructed SDP ready for
+/// `RTCPeerConnection.setRemoteDescription`. Handles both v1 and v2
+/// answer shapes transparently — see [`core::open_answer`] for the
+/// format description.
+///
+/// `host_dtls_fp_hex` is the lowercase-hex 64-char encoding of the
+/// host's SHA-256 DTLS certificate fingerprint, derived from the
+/// already-resolved pkarr `_openhost` record on the JS side
+/// (`record.dtls_fingerprint_hex`). Ignored for legacy v1 answers;
+/// required for v2.
 #[wasm_bindgen]
-pub fn open_answer(client_sk_bytes: &[u8], sealed_base64url: &str) -> Result<JsValue, JsError> {
-    let out = core::open_answer(client_sk_bytes, sealed_base64url).map_err(|e| to_js_err(&e))?;
+pub fn open_answer(
+    client_sk_bytes: &[u8],
+    sealed_base64url: &str,
+    host_dtls_fp_hex: &str,
+) -> Result<JsValue, JsError> {
+    let out = core::open_answer(client_sk_bytes, sealed_base64url, host_dtls_fp_hex)
+        .map_err(|e| to_js_err(&e))?;
     to_js(&out)
 }
 

--- a/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
+++ b/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
@@ -159,10 +159,20 @@ fn decode_answer_fragments_reassembles_published_fragments() {
     let client_pk = client_sk.public_key();
     let salt = [0x22u8; SALT_LEN];
 
+    let blob = openhost_pkarr::AnswerBlob {
+        ice_ufrag: "abcd".to_string(),
+        ice_pwd: "0123456789abcdefghij!@".to_string(),
+        setup: openhost_pkarr::SetupRole::Passive,
+        candidates: vec![openhost_pkarr::BlobCandidate {
+            typ: openhost_pkarr::CandidateType::Srflx,
+            ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+            port: 51_820,
+        }],
+    };
     let plaintext = AnswerPlaintext {
         daemon_pk: sk.public_key(),
         offer_sdp_hash: openhost_pkarr::hash_offer_sdp("v=0\r\n"),
-        answer_sdp: "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n".to_string(),
+        answer: openhost_pkarr::AnswerPayload::V2Blob(blob.clone()),
     };
     let mut rng = rand::rngs::OsRng;
     let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, ts).unwrap();
@@ -200,7 +210,10 @@ fn decode_answer_fragments_reassembles_published_fragments() {
         created_at: entry.created_at,
     };
     let opened = rebuilt.open(&client_sk).expect("sealed bytes open");
-    assert_eq!(opened.answer_sdp, plaintext.answer_sdp);
+    match opened.answer {
+        openhost_pkarr::AnswerPayload::V2Blob(got) => assert_eq!(got, blob),
+        openhost_pkarr::AnswerPayload::V1Sdp(s) => panic!("expected V2Blob, got V1 SDP: {s}"),
+    }
 }
 
 // ============================================================================
@@ -250,18 +263,30 @@ fn seal_offer_rejects_unknown_binding_mode() {
 }
 
 #[test]
-fn open_answer_roundtrips_via_client_sk() {
-    use openhost_pkarr::AnswerEntry;
-    use openhost_pkarr::AnswerPlaintext;
+fn open_answer_roundtrips_v2_blob_via_client_sk() {
+    use openhost_pkarr::{
+        AnswerBlob, AnswerEntry, AnswerPayload, AnswerPlaintext, BlobCandidate, CandidateType,
+        SetupRole,
+    };
 
     let daemon_sk = SigningKey::from_bytes(&SEED);
     let client_sk = SigningKey::from_bytes(&CLIENT_SEED);
     let client_pk = client_sk.public_key();
     let salt = [0x22u8; SALT_LEN];
+    let blob = AnswerBlob {
+        ice_ufrag: "abcd".to_string(),
+        ice_pwd: "0123456789abcdefghij!@".to_string(),
+        setup: SetupRole::Passive,
+        candidates: vec![BlobCandidate {
+            typ: CandidateType::Srflx,
+            ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+            port: 51_820,
+        }],
+    };
     let plaintext = AnswerPlaintext {
         daemon_pk: daemon_sk.public_key(),
         offer_sdp_hash: openhost_pkarr::hash_offer_sdp("v=0"),
-        answer_sdp: "v=0\r\na=setup:passive\r\n".to_string(),
+        answer: AnswerPayload::V2Blob(blob.clone()),
     };
     let mut rng = rand::rngs::OsRng;
     let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, now_ts()).expect("seal");
@@ -270,8 +295,21 @@ fn open_answer_roundtrips_via_client_sk() {
     use base64::Engine;
     let sealed_b64 = URL_SAFE_NO_PAD.encode(&entry.sealed);
 
-    let opened = core::open_answer(&client_sk.to_bytes(), &sealed_b64).expect("open");
-    assert_eq!(opened.answer_sdp, plaintext.answer_sdp);
+    let dtls_fp = [0xAAu8; openhost_pkarr::DTLS_FP_LEN];
+    let dtls_fp_hex = hex::encode(dtls_fp);
+    let opened = core::open_answer(&client_sk.to_bytes(), &sealed_b64, &dtls_fp_hex).expect("open");
+
+    // The reconstructed SDP must contain the blob's ufrag, pwd,
+    // setup role, candidate, and the fingerprint we passed in.
+    assert!(opened.answer_sdp.contains("a=ice-ufrag:abcd"));
+    assert!(opened
+        .answer_sdp
+        .contains("a=ice-pwd:0123456789abcdefghij!@"));
+    assert!(opened.answer_sdp.contains("a=setup:passive"));
+    assert!(opened.answer_sdp.contains("203.0.113.7 51820"));
+    assert!(opened
+        .answer_sdp
+        .contains(&openhost_pkarr::answer_blob_to_sdp(&blob, &dtls_fp)[..]));
     assert_eq!(
         opened.daemon_pk_zbase32,
         daemon_sk.public_key().to_zbase32()

--- a/crates/openhost-pkarr/src/lib.rs
+++ b/crates/openhost-pkarr/src/lib.rs
@@ -55,12 +55,15 @@ pub use codec::{
 // just to name the `SignedPacket` parameter type.
 pub use error::{PkarrError, Result};
 pub use offer::{
-    answer_txt_chunk_name, answer_txt_name, client_hash_label, decode_answer_fragments_from_packet,
-    decode_offer_from_packet, encode_with_answers, hash_offer_sdp, host_hash, host_hash_label,
-    offer_txt_name, AnswerEntry, AnswerPlaintext, BindingMode, OfferPlaintext, OfferRecord,
-    ANSWER_TXT_PREFIX, CLIENT_HASH_LEN, HOST_HASH_LEN, MAX_FRAGMENT_PAYLOAD_BYTES,
-    MAX_FRAGMENT_TOTAL, OFFER_INNER_DOMAIN_V1, OFFER_INNER_DOMAIN_V2, OFFER_SDP_HASH_LEN,
-    OFFER_TXT_PREFIX, OFFER_TXT_TTL,
+    answer_blob_to_sdp, answer_txt_chunk_name, answer_txt_name, client_hash_label,
+    decode_answer_fragments_from_packet, decode_offer_from_packet, encode_answer_blob,
+    encode_with_answers, hash_offer_sdp, host_hash, host_hash_label, offer_txt_name,
+    parse_answer_blob, AnswerBlob, AnswerEntry, AnswerPayload, AnswerPlaintext, BindingMode,
+    BlobCandidate, CandidateType, OfferPlaintext, OfferRecord, SetupRole, ANSWER_INNER_DOMAIN_V1,
+    ANSWER_INNER_DOMAIN_V2, ANSWER_TXT_PREFIX, CLIENT_HASH_LEN, DTLS_FP_LEN, HOST_HASH_LEN,
+    MAX_ANSWER_BLOB_LEN, MAX_BLOB_CANDIDATES, MAX_FRAGMENT_PAYLOAD_BYTES, MAX_FRAGMENT_TOTAL,
+    OFFER_INNER_DOMAIN_V1, OFFER_INNER_DOMAIN_V2, OFFER_SDP_HASH_LEN, OFFER_TXT_PREFIX,
+    OFFER_TXT_TTL,
 };
 pub use pkarr::SignedPacket;
 #[cfg(feature = "full")]

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -116,8 +116,23 @@ pub const OFFER_INNER_DOMAIN: &[u8] = OFFER_INNER_DOMAIN_V1;
 /// can advertise cert-fingerprint binding (see [`BindingMode`]).
 pub const OFFER_INNER_DOMAIN_V2: &[u8] = b"openhost-offer-inner2";
 
-/// Domain separator embedded in the answer inner plaintext.
-pub const ANSWER_INNER_DOMAIN: &[u8] = b"openhost-answer-inner1";
+/// Domain separator for the v1 answer inner plaintext body. Still
+/// accepted on decode (legacy daemons publishing full SDPs); new
+/// encoders emit v2 via [`ANSWER_INNER_DOMAIN_V2`].
+pub const ANSWER_INNER_DOMAIN_V1: &[u8] = b"openhost-answer-inner1";
+
+/// Alias for [`ANSWER_INNER_DOMAIN_V1`]. Retained for downstream
+/// diagnostic tooling that referenced the pre-PR-32 constant name.
+pub const ANSWER_INNER_DOMAIN: &[u8] = ANSWER_INNER_DOMAIN_V1;
+
+/// Domain separator for the v2 answer inner plaintext body (PR #32+).
+/// v2 replaces the full SDP with a compact binary [`AnswerBlob`] so the
+/// sealed + fragmented packet fits inside BEP44's 1000-byte `v` cap
+/// alongside the main `_openhost` record. Clients reconstruct a
+/// minimal-but-valid SDP at consumption time using the host's DTLS
+/// fingerprint (already pinned under the outer BEP44 signature via the
+/// main record).
+pub const ANSWER_INNER_DOMAIN_V2: &[u8] = b"openhost-answer-inner2";
 
 /// Channel-binding mode advertised by the client in an offer plaintext.
 ///
@@ -164,6 +179,159 @@ impl BindingMode {
         }
     }
 }
+
+/// DTLS `a=setup:` role carried in the v2 answer blob. Restricted to
+/// the two values the daemon actually emits (`active` when the daemon
+/// answered a browser offer that picked `actpass`, `passive` in every
+/// other case). `holdconn` and `actpass` are rejected on decode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SetupRole {
+    /// `a=setup:active` — the side that initiates the DTLS handshake.
+    Active = 0,
+    /// `a=setup:passive` — the side that waits for DTLS ClientHello.
+    Passive = 1,
+}
+
+impl SetupRole {
+    /// SDP-textual form (`"active"` or `"passive"`) used when
+    /// reconstructing the minimal SDP on the client side.
+    #[must_use]
+    pub fn as_sdp_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Passive => "passive",
+        }
+    }
+}
+
+/// ICE candidate type. Mirrors the lowercase strings that appear in
+/// SDP `a=candidate:` lines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CandidateType {
+    /// Local interface address.
+    Host = 0,
+    /// Server-reflexive (learned via STUN).
+    Srflx = 1,
+    /// Peer-reflexive (learned via an inbound connectivity check).
+    Prflx = 2,
+    /// Relayed (TURN).
+    Relay = 3,
+}
+
+impl CandidateType {
+    /// SDP `typ` string used when reconstructing `a=candidate:` lines.
+    #[must_use]
+    pub fn as_sdp_str(self) -> &'static str {
+        match self {
+            Self::Host => "host",
+            Self::Srflx => "srflx",
+            Self::Prflx => "prflx",
+            Self::Relay => "relay",
+        }
+    }
+
+    fn from_u8(b: u8) -> Result<Self> {
+        match b {
+            0 => Ok(Self::Host),
+            1 => Ok(Self::Srflx),
+            2 => Ok(Self::Prflx),
+            3 => Ok(Self::Relay),
+            _ => Err(PkarrError::MalformedCanonical(
+                "unknown answer-blob candidate type",
+            )),
+        }
+    }
+}
+
+/// One ICE candidate carried inside an [`AnswerBlob`]. The blob omits
+/// foundation, priority, component, and transport: at consumption time
+/// the client synthesises a stable placeholder foundation (`1`),
+/// priority (`1`), component (`1`), and transport (`udp`), since the
+/// openhost handshake only ever uses UDP and a single RTP component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobCandidate {
+    /// Candidate type (host/srflx/prflx/relay).
+    pub typ: CandidateType,
+    /// IPv4 or IPv6 address. v2 encoders MUST emit only IPv4 (mirrors
+    /// the PR #31 candidate-hygiene filter); IPv6 is reserved for a
+    /// future encoder bump when multi-fragment headroom is explicit.
+    pub ip: std::net::IpAddr,
+    /// UDP port.
+    pub port: u16,
+}
+
+/// Compact binary representation of a WebRTC answer. Replaces the full
+/// SDP in v2 answer records. The client reconstructs a minimal valid
+/// SDP from these fields plus the host's DTLS fingerprint.
+///
+/// Wire layout (inside the v2 answer body, after the 22-byte domain,
+/// 32-byte `daemon_pk`, 32-byte `offer_sdp_hash`, and a `u16` blob
+/// length prefix):
+///
+/// ```text
+/// version      : u8 (0x01)
+/// flags        : u8  (bit 0 = setup_role: 0=active, 1=passive; rest MUST be 0)
+/// ufrag_len    : u8  (4..=32 per RFC 8445 §5.3)
+/// ufrag        : <ufrag_len> ASCII bytes
+/// pwd_len      : u8  (22..=32 per RFC 8445 §5.3)
+/// pwd          : <pwd_len> ASCII bytes
+/// cand_count   : u8  (0..=MAX_BLOB_CANDIDATES)
+/// candidates[] : cand_count entries of:
+///                  typ    : u8   (CandidateType)
+///                  family : u8   (4 | 6)
+///                  addr   : 4 or 16 bytes
+///                  port   : u16 big-endian
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnswerBlob {
+    /// ICE ufrag — MUST be 4..=32 ASCII bytes (RFC 8445 §5.3).
+    pub ice_ufrag: String,
+    /// ICE pwd — MUST be 22..=32 ASCII bytes (RFC 8445 §5.3).
+    pub ice_pwd: String,
+    /// Setup role emitted by the daemon.
+    pub setup: SetupRole,
+    /// Post-gather-complete candidate list. Length bounded by
+    /// [`MAX_BLOB_CANDIDATES`].
+    pub candidates: Vec<BlobCandidate>,
+}
+
+/// Plaintext answer payload carried inside an [`AnswerPlaintext`].
+/// v1 is decode-only (legacy daemons shipping a full SDP); all v2+
+/// emitters MUST produce [`AnswerPayload::V2Blob`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AnswerPayload {
+    /// v1 answer body: the daemon's full SDP as a string. Post-PR-32
+    /// emitters never produce this variant; it exists so clients can
+    /// still consume answers from pre-PR-32 daemons during rollout.
+    V1Sdp(String),
+    /// v2 answer body: compact binary blob (see [`AnswerBlob`]).
+    V2Blob(AnswerBlob),
+}
+
+/// Version byte at the front of the v2 answer blob body.
+const ANSWER_BLOB_VERSION: u8 = 0x01;
+
+/// Ceiling on the blob byte length carried in the `u16` length prefix.
+/// A fully-packed blob with 8 IPv4 candidates, a 32-byte ufrag, and a
+/// 32-byte pwd weighs ~140 bytes; 512 gives ~3.5× headroom against
+/// future encoder drift without allowing a malicious decoder DoS.
+pub const MAX_ANSWER_BLOB_LEN: usize = 512;
+
+/// Ceiling on the per-blob candidate count. Post-PR-31 filters reduce
+/// a typical answer to 1 srflx + 0-3 host candidates; 8 still leaves
+/// room for multi-interface hosts.
+pub const MAX_BLOB_CANDIDATES: usize = 8;
+
+/// Minimum ICE ufrag length per RFC 8445 §5.3.
+pub const MIN_ICE_UFRAG_LEN: usize = 4;
+/// Maximum ICE ufrag length per RFC 8445 §5.3.
+pub const MAX_ICE_UFRAG_LEN: usize = 32;
+/// Minimum ICE pwd length per RFC 8445 §5.3.
+pub const MIN_ICE_PWD_LEN: usize = 22;
+/// Maximum ICE pwd length per RFC 8445 §5.3.
+pub const MAX_ICE_PWD_LEN: usize = 32;
 
 /// Domain separator used when deriving the `_offer.` DNS label from the
 /// daemon's pubkey. Domain-separated from `allowlist_hash` so observers
@@ -404,8 +572,43 @@ pub struct AnswerPlaintext {
     /// a racing adversary from re-binding a valid answer onto a different
     /// offer.
     pub offer_sdp_hash: [u8; OFFER_SDP_HASH_LEN],
-    /// SDP answer text (UTF-8).
-    pub answer_sdp: String,
+    /// Carried answer, either the v1 full-SDP form (decode-only) or
+    /// the v2 compact binary blob (the only form new emitters produce).
+    pub answer: AnswerPayload,
+}
+
+impl AnswerPlaintext {
+    /// Convenience constructor matching the pre-PR-32 field set; the
+    /// passed-in SDP string is stored as [`AnswerPayload::V1Sdp`]. Used
+    /// by tests that still want to exercise the legacy decode path
+    /// without hand-constructing an `AnswerPayload`.
+    #[must_use]
+    pub fn new_v1(
+        daemon_pk: PublicKey,
+        offer_sdp_hash: [u8; OFFER_SDP_HASH_LEN],
+        answer_sdp: String,
+    ) -> Self {
+        Self {
+            daemon_pk,
+            offer_sdp_hash,
+            answer: AnswerPayload::V1Sdp(answer_sdp),
+        }
+    }
+
+    /// Convenience constructor for the v2 compact-blob answer — the
+    /// form every post-PR-32 emitter produces.
+    #[must_use]
+    pub fn new_v2(
+        daemon_pk: PublicKey,
+        offer_sdp_hash: [u8; OFFER_SDP_HASH_LEN],
+        blob: AnswerBlob,
+    ) -> Self {
+        Self {
+            daemon_pk,
+            offer_sdp_hash,
+            answer: AnswerPayload::V2Blob(blob),
+        }
+    }
 }
 
 // ============================================================================
@@ -511,7 +714,7 @@ impl AnswerEntry {
         plaintext: &AnswerPlaintext,
         created_at: u64,
     ) -> Result<Self> {
-        let inner = encode_answer_plaintext(plaintext);
+        let inner = encode_answer_plaintext(plaintext)?;
         let recipient = public_key_to_x25519(client_pk).map_err(PkarrError::Core)?;
         let sealed = sealed_box_seal(rng, &recipient, &inner);
         let client_hash = allowlist_hash(daemon_salt, &client_pk.to_bytes());
@@ -973,30 +1176,223 @@ fn parse_offer_plaintext(bytes: &[u8]) -> Result<OfferPlaintext> {
     parse_offer_body(body)
 }
 
-/// Shape of the v1 answer body.
-fn encode_answer_body(p: &AnswerPlaintext) -> Vec<u8> {
-    let sdp = p.answer_sdp.as_bytes();
+/// Encode an answer body. v2 (compact blob, `openhost-answer-inner2`)
+/// is the only shape emitters produce; v1 is decode-only and
+/// [`encode_answer_body`] will panic in debug builds if handed a
+/// [`AnswerPayload::V1Sdp`] — use a v2 blob.
+///
+/// Wire layout for v2:
+///
+/// ```text
+/// domain(ANSWER_INNER_DOMAIN_V2) || daemon_pk(32B) ||
+/// offer_sdp_hash(32B) || blob_len(u16 BE, ≤ MAX_ANSWER_BLOB_LEN) || blob(blob_len bytes)
+/// ```
+fn encode_answer_body(p: &AnswerPlaintext) -> Result<Vec<u8>> {
+    let blob = match &p.answer {
+        AnswerPayload::V2Blob(b) => b,
+        AnswerPayload::V1Sdp(_) => {
+            debug_assert!(
+                false,
+                "openhost-pkarr: emitters MUST produce v2 AnswerBlob; V1Sdp is decode-only",
+            );
+            return Err(PkarrError::MalformedCanonical(
+                "encoders MUST emit v2 answer blobs — AnswerPayload::V1Sdp is decode-only",
+            ));
+        }
+    };
+    let blob_bytes = encode_answer_blob(blob)?;
     let mut out = Vec::with_capacity(
-        ANSWER_INNER_DOMAIN.len() + PUBLIC_KEY_LEN + OFFER_SDP_HASH_LEN + 4 + sdp.len(),
+        ANSWER_INNER_DOMAIN_V2.len() + PUBLIC_KEY_LEN + OFFER_SDP_HASH_LEN + 2 + blob_bytes.len(),
     );
-    out.extend_from_slice(ANSWER_INNER_DOMAIN);
+    out.extend_from_slice(ANSWER_INNER_DOMAIN_V2);
     out.extend_from_slice(&p.daemon_pk.to_bytes());
     out.extend_from_slice(&p.offer_sdp_hash);
-    let len = u32::try_from(sdp.len())
-        .expect("SDP length bounded well below u32::MAX by BEP44 1000-byte cap");
+    let len = u16::try_from(blob_bytes.len()).expect("blob_bytes ≤ MAX_ANSWER_BLOB_LEN < u16::MAX");
     out.extend_from_slice(&len.to_be_bytes());
-    out.extend_from_slice(sdp);
-    out
+    out.extend_from_slice(&blob_bytes);
+    Ok(out)
 }
 
-/// Encode a v2 (zlib-compressed) answer inner plaintext.
-fn encode_answer_plaintext(p: &AnswerPlaintext) -> Vec<u8> {
-    let body = encode_answer_body(p);
+/// Serialise an [`AnswerBlob`] to its on-wire byte form. Validates
+/// RFC 8445 §5.3 ufrag/pwd length bounds, the reserved-flag-bits
+/// invariant, and the per-blob candidate ceiling.
+pub fn encode_answer_blob(b: &AnswerBlob) -> Result<Vec<u8>> {
+    let ufrag_bytes = b.ice_ufrag.as_bytes();
+    if ufrag_bytes.len() < MIN_ICE_UFRAG_LEN || ufrag_bytes.len() > MAX_ICE_UFRAG_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "AnswerBlob ice_ufrag length violates RFC 8445 §5.3 bounds",
+        ));
+    }
+    if !b.ice_ufrag.is_ascii() {
+        return Err(PkarrError::MalformedCanonical(
+            "AnswerBlob ice_ufrag must be ASCII",
+        ));
+    }
+    let pwd_bytes = b.ice_pwd.as_bytes();
+    if pwd_bytes.len() < MIN_ICE_PWD_LEN || pwd_bytes.len() > MAX_ICE_PWD_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "AnswerBlob ice_pwd length violates RFC 8445 §5.3 bounds",
+        ));
+    }
+    if !b.ice_pwd.is_ascii() {
+        return Err(PkarrError::MalformedCanonical(
+            "AnswerBlob ice_pwd must be ASCII",
+        ));
+    }
+    if b.candidates.len() > MAX_BLOB_CANDIDATES {
+        return Err(PkarrError::MalformedCanonical(
+            "AnswerBlob candidates exceed MAX_BLOB_CANDIDATES",
+        ));
+    }
+
+    let mut out = Vec::with_capacity(32);
+    out.push(ANSWER_BLOB_VERSION);
+    // Flags byte: only bit 0 is allocated to setup_role (0=active, 1=passive);
+    // remaining bits MUST be zero on the wire (enforced on decode).
+    let flags: u8 = match b.setup {
+        SetupRole::Active => 0b0000_0000,
+        SetupRole::Passive => 0b0000_0001,
+    };
+    out.push(flags);
+    out.push(ufrag_bytes.len() as u8);
+    out.extend_from_slice(ufrag_bytes);
+    out.push(pwd_bytes.len() as u8);
+    out.extend_from_slice(pwd_bytes);
+    out.push(b.candidates.len() as u8);
+    for cand in &b.candidates {
+        out.push(cand.typ as u8);
+        match cand.ip {
+            std::net::IpAddr::V4(v4) => {
+                out.push(4);
+                out.extend_from_slice(&v4.octets());
+            }
+            std::net::IpAddr::V6(v6) => {
+                out.push(6);
+                out.extend_from_slice(&v6.octets());
+            }
+        }
+        out.extend_from_slice(&cand.port.to_be_bytes());
+    }
+    if out.len() > MAX_ANSWER_BLOB_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "encoded AnswerBlob exceeds MAX_ANSWER_BLOB_LEN",
+        ));
+    }
+    Ok(out)
+}
+
+/// Parse an [`AnswerBlob`] from its on-wire byte form. Strict inverse
+/// of [`encode_answer_blob`]: unknown versions, reserved-flag-bits,
+/// candidate types, address families, or length bounds all produce
+/// [`PkarrError::MalformedCanonical`].
+pub fn parse_answer_blob(bytes: &[u8]) -> Result<AnswerBlob> {
+    if bytes.len() > MAX_ANSWER_BLOB_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "answer blob exceeds MAX_ANSWER_BLOB_LEN",
+        ));
+    }
+    let mut r = InnerCursor::new(bytes);
+    let version = r.u8()?;
+    if version != ANSWER_BLOB_VERSION {
+        return Err(PkarrError::MalformedCanonical(
+            "unknown answer-blob version",
+        ));
+    }
+    let flags = r.u8()?;
+    // Only bit 0 is defined; any other bit set is a hard decode error
+    // so future encoder versions don't silently get ignored.
+    if flags & 0b1111_1110 != 0 {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob reserved flag bits must be zero",
+        ));
+    }
+    let setup = if flags & 0b0000_0001 == 0 {
+        SetupRole::Active
+    } else {
+        SetupRole::Passive
+    };
+    let ufrag_len = r.u8()? as usize;
+    if !(MIN_ICE_UFRAG_LEN..=MAX_ICE_UFRAG_LEN).contains(&ufrag_len) {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob ice_ufrag length violates RFC 8445 §5.3 bounds",
+        ));
+    }
+    let ufrag_bytes = r.take(ufrag_len)?;
+    if !ufrag_bytes.is_ascii() {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob ice_ufrag must be ASCII",
+        ));
+    }
+    let ice_ufrag = core::str::from_utf8(ufrag_bytes)
+        .map_err(|_| PkarrError::MalformedCanonical("answer-blob ice_ufrag is not UTF-8"))?
+        .to_string();
+    let pwd_len = r.u8()? as usize;
+    if !(MIN_ICE_PWD_LEN..=MAX_ICE_PWD_LEN).contains(&pwd_len) {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob ice_pwd length violates RFC 8445 §5.3 bounds",
+        ));
+    }
+    let pwd_bytes = r.take(pwd_len)?;
+    if !pwd_bytes.is_ascii() {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob ice_pwd must be ASCII",
+        ));
+    }
+    let ice_pwd = core::str::from_utf8(pwd_bytes)
+        .map_err(|_| PkarrError::MalformedCanonical("answer-blob ice_pwd is not UTF-8"))?
+        .to_string();
+    let cand_count = r.u8()? as usize;
+    if cand_count > MAX_BLOB_CANDIDATES {
+        return Err(PkarrError::MalformedCanonical(
+            "answer-blob candidate count exceeds MAX_BLOB_CANDIDATES",
+        ));
+    }
+    let mut candidates = Vec::with_capacity(cand_count);
+    for _ in 0..cand_count {
+        let typ = CandidateType::from_u8(r.u8()?)?;
+        let family = r.u8()?;
+        let ip = match family {
+            4 => {
+                let b = r.take(4)?;
+                std::net::IpAddr::V4(std::net::Ipv4Addr::new(b[0], b[1], b[2], b[3]))
+            }
+            6 => {
+                let b = r.take(16)?;
+                let mut arr = [0u8; 16];
+                arr.copy_from_slice(b);
+                std::net::IpAddr::V6(std::net::Ipv6Addr::from(arr))
+            }
+            _ => {
+                return Err(PkarrError::MalformedCanonical(
+                    "answer-blob candidate family must be 4 or 6",
+                ));
+            }
+        };
+        let port = r.u16_be()?;
+        candidates.push(BlobCandidate { typ, ip, port });
+    }
+    if !r.is_empty() {
+        return Err(PkarrError::MalformedCanonical(
+            "trailing bytes after answer blob",
+        ));
+    }
+    Ok(AnswerBlob {
+        ice_ufrag,
+        ice_pwd,
+        setup,
+        candidates,
+    })
+}
+
+/// Encode a zlib-compressed answer inner plaintext. The body emitted
+/// here is the v2 compact-blob form; v1 is decode-only.
+fn encode_answer_plaintext(p: &AnswerPlaintext) -> Result<Vec<u8>> {
+    let body = encode_answer_body(p)?;
     let compressed = zlib_compress(&body);
     let mut out = Vec::with_capacity(1 + compressed.len());
     out.push(CompressionTag::Zlib as u8);
     out.extend_from_slice(&compressed);
-    out
+    Ok(out)
 }
 
 fn parse_answer_plaintext(bytes: &[u8]) -> Result<AnswerPlaintext> {
@@ -1013,14 +1409,31 @@ fn parse_answer_plaintext(bytes: &[u8]) -> Result<AnswerPlaintext> {
     parse_answer_body(body)
 }
 
+/// Parse an answer body. Dispatches on the domain-separator prefix:
+/// `openhost-answer-inner1` yields a v1 [`AnswerPayload::V1Sdp`] with
+/// a full SDP string (legacy); `openhost-answer-inner2` yields a v2
+/// [`AnswerPayload::V2Blob`] with a compact binary blob.
 fn parse_answer_body(body: &[u8]) -> Result<AnswerPlaintext> {
-    let mut r = InnerCursor::new(body);
-    let domain = r.take(ANSWER_INNER_DOMAIN.len())?;
-    if domain != ANSWER_INNER_DOMAIN {
+    if body.len() < ANSWER_INNER_DOMAIN_V1.len() {
         return Err(PkarrError::MalformedCanonical(
-            "missing openhost-answer-inner1 domain separator",
+            "answer plaintext shorter than domain separator",
         ));
     }
+    let domain = &body[..ANSWER_INNER_DOMAIN_V1.len()];
+    if domain == ANSWER_INNER_DOMAIN_V2 {
+        parse_answer_body_v2(body)
+    } else if domain == ANSWER_INNER_DOMAIN_V1 {
+        parse_answer_body_v1(body)
+    } else {
+        Err(PkarrError::MalformedCanonical(
+            "unknown openhost-answer-inner domain separator",
+        ))
+    }
+}
+
+fn parse_answer_body_v1(body: &[u8]) -> Result<AnswerPlaintext> {
+    let mut r = InnerCursor::new(body);
+    let _domain = r.take(ANSWER_INNER_DOMAIN_V1.len())?;
     let mut pk_bytes = [0u8; PUBLIC_KEY_LEN];
     pk_bytes.copy_from_slice(r.take(PUBLIC_KEY_LEN)?);
     let daemon_pk = PublicKey::from_bytes(&pk_bytes).map_err(PkarrError::Core)?;
@@ -1033,13 +1446,41 @@ fn parse_answer_body(body: &[u8]) -> Result<AnswerPlaintext> {
         .to_string();
     if !r.is_empty() {
         return Err(PkarrError::MalformedCanonical(
-            "trailing bytes after answer plaintext",
+            "trailing bytes after v1 answer plaintext",
         ));
     }
     Ok(AnswerPlaintext {
         daemon_pk,
         offer_sdp_hash,
-        answer_sdp,
+        answer: AnswerPayload::V1Sdp(answer_sdp),
+    })
+}
+
+fn parse_answer_body_v2(body: &[u8]) -> Result<AnswerPlaintext> {
+    let mut r = InnerCursor::new(body);
+    let _domain = r.take(ANSWER_INNER_DOMAIN_V2.len())?;
+    let mut pk_bytes = [0u8; PUBLIC_KEY_LEN];
+    pk_bytes.copy_from_slice(r.take(PUBLIC_KEY_LEN)?);
+    let daemon_pk = PublicKey::from_bytes(&pk_bytes).map_err(PkarrError::Core)?;
+    let mut offer_sdp_hash = [0u8; OFFER_SDP_HASH_LEN];
+    offer_sdp_hash.copy_from_slice(r.take(OFFER_SDP_HASH_LEN)?);
+    let blob_len = r.u16_be()? as usize;
+    if blob_len > MAX_ANSWER_BLOB_LEN {
+        return Err(PkarrError::MalformedCanonical(
+            "v2 answer blob_len exceeds MAX_ANSWER_BLOB_LEN",
+        ));
+    }
+    let blob_bytes = r.take(blob_len)?;
+    let blob = parse_answer_blob(blob_bytes)?;
+    if !r.is_empty() {
+        return Err(PkarrError::MalformedCanonical(
+            "trailing bytes after v2 answer plaintext",
+        ));
+    }
+    Ok(AnswerPlaintext {
+        daemon_pk,
+        offer_sdp_hash,
+        answer: AnswerPayload::V2Blob(blob),
     })
 }
 
@@ -1077,6 +1518,10 @@ impl<'a> InnerCursor<'a> {
     }
     fn u8(&mut self) -> Result<u8> {
         Ok(self.take(1)?[0])
+    }
+    fn u16_be(&mut self) -> Result<u16> {
+        let b = self.take(2)?;
+        Ok(u16::from_be_bytes([b[0], b[1]]))
     }
     fn u32_be(&mut self) -> Result<u32> {
         let b = self.take(4)?;
@@ -1133,6 +1578,81 @@ fn zlib_decompress_capped(input: &[u8], cap: usize) -> Result<Vec<u8>> {
     Ok(out)
 }
 
+/// DTLS fingerprint byte length — SHA-256 output.
+pub const DTLS_FP_LEN: usize = 32;
+
+/// Reconstruct a minimal but webrtc-rs + Chromium-compatible SDP
+/// answer from a compact [`AnswerBlob`] + the host's already-verified
+/// DTLS certificate fingerprint. Produced string matches what
+/// legacy v1 answer records used to carry verbatim.
+///
+/// Implementation notes:
+///
+/// - `o=` origin session-id / version / `IN IP4 0.0.0.0` — safe
+///   placeholders; neither webrtc-rs nor Chromium trust them for
+///   anything load-bearing.
+/// - `m=application 9 UDP/DTLS/SCTP webrtc-datachannel` with
+///   `a=rtcp-mux` ⇒ one component, matches the daemon's generation.
+/// - `a=sctp-port:5000` matches webrtc-rs's default (pion's too); if
+///   the daemon ever drifts from 5000 the offer will still negotiate
+///   because the offerer echoes what it received.
+/// - `a=fingerprint:sha-256 <colon-hex>` is the load-bearing field —
+///   it binds the DTLS handshake to the pkarr record's pinned
+///   fingerprint, which is verified under the BEP44 signature before
+///   the blob is ever opened.
+/// - Each candidate synthesises a foundation of `1` and priority of
+///   `1`: the offerer's pairing logic uses the
+///   (local-candidate, remote-candidate) tuple for pair keys, so
+///   placeholder values don't confuse it. `generation 0` is emitted
+///   to match webrtc-rs's own answer output shape.
+///
+/// The output always ends with CRLF, matches the daemon-generated
+/// SDP byte-for-byte in the fields the peers actually consume.
+#[must_use]
+pub fn answer_blob_to_sdp(blob: &AnswerBlob, dtls_fp: &[u8; DTLS_FP_LEN]) -> String {
+    let fp_hex = colon_hex_upper(dtls_fp);
+    let mut s = String::with_capacity(512);
+    s.push_str("v=0\r\n");
+    s.push_str("o=- 1 1 IN IP4 0.0.0.0\r\n");
+    s.push_str("s=-\r\n");
+    s.push_str("t=0 0\r\n");
+    s.push_str("a=group:BUNDLE 0\r\n");
+    s.push_str("m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n");
+    s.push_str("c=IN IP4 0.0.0.0\r\n");
+    s.push_str("a=mid:0\r\n");
+    s.push_str("a=rtcp-mux\r\n");
+    s.push_str(&format!("a=ice-ufrag:{}\r\n", blob.ice_ufrag));
+    s.push_str(&format!("a=ice-pwd:{}\r\n", blob.ice_pwd));
+    s.push_str(&format!("a=fingerprint:sha-256 {fp_hex}\r\n"));
+    s.push_str(&format!("a=setup:{}\r\n", blob.setup.as_sdp_str()));
+    s.push_str("a=sctp-port:5000\r\n");
+    for cand in &blob.candidates {
+        s.push_str(&format!(
+            "a=candidate:1 1 udp 1 {ip} {port} typ {typ} generation 0\r\n",
+            ip = cand.ip,
+            port = cand.port,
+            typ = cand.typ.as_sdp_str(),
+        ));
+    }
+    s.push_str("a=end-of-candidates\r\n");
+    s
+}
+
+/// Lowercase hex-encode each byte, separated by `:`, matching the
+/// `a=fingerprint:sha-256 ...` formatting WebRTC uses. Upper-case is
+/// conventional in SDP fingerprints; reconstructor matches that.
+fn colon_hex_upper(bytes: &[u8]) -> String {
+    use core::fmt::Write as _;
+    let mut out = String::with_capacity(bytes.len() * 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 {
+            out.push(':');
+        }
+        write!(&mut out, "{b:02X}").expect("writing into String never fails");
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1162,6 +1682,22 @@ mod tests {
     const SAMPLE_ANSWER_SDP: &str = "v=0\r\no=- 1 1 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n\
                                      m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n\
                                      c=IN IP4 0.0.0.0\r\na=setup:passive\r\n";
+
+    /// Build a representative v2 blob used as the sample payload in
+    /// answer-plaintext tests. One srflx candidate, 4-char ufrag,
+    /// 22-char pwd — matches the post-PR-31 daemon output shape.
+    fn sample_blob() -> AnswerBlob {
+        AnswerBlob {
+            ice_ufrag: "abcd".to_string(),
+            ice_pwd: "Supercalifragilistic!2".to_string(),
+            setup: SetupRole::Passive,
+            candidates: vec![BlobCandidate {
+                typ: CandidateType::Srflx,
+                ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+                port: 51_820,
+            }],
+        }
+    }
 
     // ---------- label helpers ----------
 
@@ -1398,20 +1934,37 @@ mod tests {
         assert_eq!(dec, p);
     }
 
+    /// Hand-craft a v1 (legacy) answer plaintext (uncompressed + full
+    /// SDP) and confirm `parse_answer_plaintext` still decodes it into
+    /// an `AnswerPayload::V1Sdp`. New emitters never produce v1, but
+    /// decoders accept it for the duration of the rollout.
     #[test]
     fn answer_plaintext_accepts_v1_uncompressed_for_backcompat() {
         let daemon_pk = host_sk().public_key();
-        let p = AnswerPlaintext {
-            daemon_pk,
-            offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
-            answer_sdp: SAMPLE_ANSWER_SDP.to_string(),
-        };
-        let body = encode_answer_body(&p);
-        let mut v1 = Vec::with_capacity(1 + body.len());
-        v1.push(0x01);
-        v1.extend_from_slice(&body);
+        let answer_sdp = SAMPLE_ANSWER_SDP.to_string();
+        let offer_sdp_hash = hash_offer_sdp(SAMPLE_OFFER_SDP);
+
+        // Manually encode the v1 body shape.
+        let sdp_bytes = answer_sdp.as_bytes();
+        let mut v1_body = Vec::new();
+        v1_body.extend_from_slice(ANSWER_INNER_DOMAIN_V1);
+        v1_body.extend_from_slice(&daemon_pk.to_bytes());
+        v1_body.extend_from_slice(&offer_sdp_hash);
+        v1_body.extend_from_slice(&(sdp_bytes.len() as u32).to_be_bytes());
+        v1_body.extend_from_slice(sdp_bytes);
+
+        // Uncompressed tag + body.
+        let mut v1 = Vec::with_capacity(1 + v1_body.len());
+        v1.push(CompressionTag::Uncompressed as u8);
+        v1.extend_from_slice(&v1_body);
+
         let dec = parse_answer_plaintext(&v1).unwrap();
-        assert_eq!(dec, p);
+        assert_eq!(dec.daemon_pk, daemon_pk);
+        assert_eq!(dec.offer_sdp_hash, offer_sdp_hash);
+        match dec.answer {
+            AnswerPayload::V1Sdp(s) => assert_eq!(s, answer_sdp),
+            AnswerPayload::V2Blob(_) => panic!("expected V1Sdp"),
+        }
     }
 
     #[test]
@@ -1420,11 +1973,166 @@ mod tests {
         let p = AnswerPlaintext {
             daemon_pk,
             offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
-            answer_sdp: SAMPLE_ANSWER_SDP.to_string(),
+            answer: AnswerPayload::V2Blob(sample_blob()),
         };
-        let enc = encode_answer_plaintext(&p);
+        let enc = encode_answer_plaintext(&p).unwrap();
         let dec = parse_answer_plaintext(&enc).unwrap();
         assert_eq!(dec, p);
+    }
+
+    #[test]
+    fn answer_blob_roundtrips_all_fields() {
+        let blob = AnswerBlob {
+            ice_ufrag: "abcd".to_string(),
+            ice_pwd: "0123456789abcdefghij!@".to_string(),
+            setup: SetupRole::Active,
+            candidates: vec![
+                BlobCandidate {
+                    typ: CandidateType::Host,
+                    ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)),
+                    port: 12345,
+                },
+                BlobCandidate {
+                    typ: CandidateType::Srflx,
+                    ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+                    port: 51_820,
+                },
+                BlobCandidate {
+                    typ: CandidateType::Relay,
+                    ip: std::net::IpAddr::V6(std::net::Ipv6Addr::from([
+                        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                    ])),
+                    port: 3478,
+                },
+            ],
+        };
+        let enc = encode_answer_blob(&blob).unwrap();
+        let dec = parse_answer_blob(&enc).unwrap();
+        assert_eq!(dec, blob);
+    }
+
+    #[test]
+    fn answer_blob_parses_zero_candidates() {
+        let blob = AnswerBlob {
+            ice_ufrag: "abcd".to_string(),
+            ice_pwd: "0123456789abcdefghij!@".to_string(),
+            setup: SetupRole::Passive,
+            candidates: vec![],
+        };
+        let enc = encode_answer_blob(&blob).unwrap();
+        let dec = parse_answer_blob(&enc).unwrap();
+        assert_eq!(dec, blob);
+    }
+
+    #[test]
+    fn answer_blob_rejects_unknown_version() {
+        let mut enc = encode_answer_blob(&sample_blob()).unwrap();
+        enc[0] = 0xFF;
+        assert!(matches!(
+            parse_answer_blob(&enc),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+    }
+
+    #[test]
+    fn answer_blob_rejects_reserved_flag_bits() {
+        let mut enc = encode_answer_blob(&sample_blob()).unwrap();
+        enc[1] |= 0b1000_0000;
+        assert!(matches!(
+            parse_answer_blob(&enc),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+    }
+
+    #[test]
+    fn answer_blob_rejects_oversize_candidate_count() {
+        let too_many = AnswerBlob {
+            ice_ufrag: "abcd".to_string(),
+            ice_pwd: "0123456789abcdefghij!@".to_string(),
+            setup: SetupRole::Passive,
+            candidates: (0..(MAX_BLOB_CANDIDATES + 1) as u8)
+                .map(|i| BlobCandidate {
+                    typ: CandidateType::Host,
+                    ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, i)),
+                    port: 1000 + i as u16,
+                })
+                .collect(),
+        };
+        assert!(matches!(
+            encode_answer_blob(&too_many),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+    }
+
+    #[test]
+    fn answer_blob_rejects_short_ufrag() {
+        let bad = AnswerBlob {
+            ice_ufrag: "ab".to_string(),
+            ice_pwd: "0123456789abcdefghij!@".to_string(),
+            setup: SetupRole::Passive,
+            candidates: vec![],
+        };
+        assert!(matches!(
+            encode_answer_blob(&bad),
+            Err(PkarrError::MalformedCanonical(_))
+        ));
+    }
+
+    #[test]
+    fn answer_body_fits_in_single_fragment_with_main_record() {
+        // Seal a representative blob alongside the main record and
+        // assert the resulting BEP44 packet fits the 1000-byte cap with
+        // exactly one answer fragment — the whole point of the compact
+        // blob design.
+        let sk = host_sk();
+        let signed = SignedRecord::sign(sample_record(1_700_000_000), &sk).unwrap();
+        let client_pk = client_sk().public_key();
+        let daemon_pk = sk.public_key();
+        let salt = [0x33u8; SALT_LEN];
+
+        let plaintext = AnswerPlaintext {
+            daemon_pk,
+            offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
+            answer: AnswerPayload::V2Blob(sample_blob()),
+        };
+        let mut rng = deterministic_rng();
+        let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, 1).unwrap();
+
+        let expected_total = entry.sealed.len().div_ceil(MAX_FRAGMENT_PAYLOAD_BYTES);
+        assert_eq!(
+            expected_total, 1,
+            "compact blob should fit in a single fragment"
+        );
+
+        let packet = encode_with_answers(&signed, &sk, std::slice::from_ref(&entry)).unwrap();
+        assert!(
+            packet.encoded_packet().len() <= BEP44_MAX_V_BYTES,
+            "packet must fit BEP44 cap, got {}",
+            packet.encoded_packet().len()
+        );
+    }
+
+    #[test]
+    fn legacy_v1_answer_still_decodes_via_parse_answer_body() {
+        let daemon_pk = host_sk().public_key();
+        let answer_sdp = SAMPLE_ANSWER_SDP.to_string();
+        let sdp_bytes = answer_sdp.as_bytes();
+        let offer_sdp_hash = hash_offer_sdp(SAMPLE_OFFER_SDP);
+
+        let mut v1_body = Vec::new();
+        v1_body.extend_from_slice(ANSWER_INNER_DOMAIN_V1);
+        v1_body.extend_from_slice(&daemon_pk.to_bytes());
+        v1_body.extend_from_slice(&offer_sdp_hash);
+        v1_body.extend_from_slice(&(sdp_bytes.len() as u32).to_be_bytes());
+        v1_body.extend_from_slice(sdp_bytes);
+
+        let dec = parse_answer_body(&v1_body).unwrap();
+        assert_eq!(dec.daemon_pk, daemon_pk);
+        assert_eq!(dec.offer_sdp_hash, offer_sdp_hash);
+        match dec.answer {
+            AnswerPayload::V1Sdp(s) => assert_eq!(s, answer_sdp),
+            AnswerPayload::V2Blob(_) => panic!("expected V1Sdp"),
+        }
     }
 
     // ---------- seal / open ----------
@@ -1468,7 +2176,7 @@ mod tests {
         let plaintext = AnswerPlaintext {
             daemon_pk,
             offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
-            answer_sdp: SAMPLE_ANSWER_SDP.to_string(),
+            answer: AnswerPayload::V2Blob(sample_blob()),
         };
         let mut rng = deterministic_rng();
         let entry =
@@ -1510,7 +2218,7 @@ mod tests {
         let plaintext = AnswerPlaintext {
             daemon_pk,
             offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
-            answer_sdp: SAMPLE_ANSWER_SDP.to_string(),
+            answer: AnswerPayload::V2Blob(sample_blob()),
         };
         let mut rng = deterministic_rng();
         let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, 17).unwrap();
@@ -1606,7 +2314,7 @@ mod tests {
         let plaintext = AnswerPlaintext {
             daemon_pk: sk.public_key(),
             offer_sdp_hash: hash_offer_sdp(SAMPLE_OFFER_SDP),
-            answer_sdp: SAMPLE_ANSWER_SDP.to_string(),
+            answer: AnswerPayload::V2Blob(sample_blob()),
         };
         let mut rng = deterministic_rng();
         let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, 1).unwrap();

--- a/crates/openhost-pkarr/src/publisher.rs
+++ b/crates/openhost-pkarr/src/publisher.rs
@@ -728,7 +728,10 @@ mod tests {
 
     #[tokio::test]
     async fn publish_once_folds_in_answer_entries() {
-        use crate::offer::{hash_offer_sdp, AnswerEntry, AnswerPlaintext};
+        use crate::offer::{
+            hash_offer_sdp, AnswerBlob, AnswerEntry, AnswerPayload, AnswerPlaintext, BlobCandidate,
+            CandidateType, SetupRole,
+        };
         use openhost_core::pkarr_record::SALT_LEN;
         use rand::rngs::StdRng;
         use rand::SeedableRng;
@@ -741,11 +744,20 @@ mod tests {
         let client_sk = SigningKey::from_bytes(&[0x77u8; 32]);
         let client_pk = client_sk.public_key();
         let salt = [0x11u8; SALT_LEN];
-        let answer_sdp = "v=0\r\na=setup:passive\r\n";
+        let blob = AnswerBlob {
+            ice_ufrag: "abcd".to_string(),
+            ice_pwd: "0123456789abcdefghij!@".to_string(),
+            setup: SetupRole::Passive,
+            candidates: vec![BlobCandidate {
+                typ: CandidateType::Srflx,
+                ip: std::net::IpAddr::V4(std::net::Ipv4Addr::new(203, 0, 113, 7)),
+                port: 51_820,
+            }],
+        };
         let plaintext = AnswerPlaintext {
             daemon_pk,
             offer_sdp_hash: hash_offer_sdp("v=0\r\na=setup:active\r\n"),
-            answer_sdp: answer_sdp.to_string(),
+            answer: AnswerPayload::V2Blob(blob.clone()),
         };
         let mut rng = StdRng::from_seed([0x42; 32]);
         let entry = AnswerEntry::seal(&mut rng, &client_pk, &salt, &plaintext, 42).unwrap();
@@ -764,7 +776,10 @@ mod tests {
             .unwrap()
             .expect("answer fragments present");
         let opened = decoded.open(&client_sk).unwrap();
-        assert_eq!(opened.answer_sdp, answer_sdp);
+        match opened.answer {
+            AnswerPayload::V2Blob(got) => assert_eq!(got, blob),
+            AnswerPayload::V1Sdp(_) => panic!("expected V2Blob"),
+        }
     }
 
     #[tokio::test]

--- a/extension/src/dialer/openhost_session.js
+++ b/extension/src/dialer/openhost_session.js
@@ -190,8 +190,12 @@ export async function dialOhUrl(ohUrl, opts = {}) {
   const packet = build_offer_packet(clientSeed, daemonPkZ, sealed, BigInt(Math.floor(Date.now() / 1000)));
   await publishOfferPacket(clientPkZ, packet);
 
-  // 5. Poll answer fragments on the daemon's zone.
+  // 5. Poll answer fragments on the daemon's zone. The host's DTLS
+  // fingerprint was already verified under the BEP44 signature during
+  // step 1; threading it here lets the v2 compact-blob branch
+  // reconstruct the full SDP locally.
   const answerSdp = await pollAnswer({ daemonPkZ, daemonSalt, clientPkZ, clientSeed,
+                                       hostDtlsFpHex: hostRecord.dtls_fingerprint_hex,
                                        timeoutMs: opts.answerTimeoutMs ?? 30_000 });
 
   // 6. Apply answer + wait for DTLS Connected.
@@ -302,14 +306,14 @@ async function publishOfferPacket(clientPkZ, packetBytes) {
   throw new Error(`all relays rejected offer publish: ${lastErr?.message ?? "unknown"}`);
 }
 
-async function pollAnswer({ daemonPkZ, daemonSalt, clientPkZ, clientSeed, timeoutMs }) {
+async function pollAnswer({ daemonPkZ, daemonSalt, clientPkZ, clientSeed, hostDtlsFpHex, timeoutMs }) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
       const packet = await fetchHostPacket(daemonPkZ);
       const ans = decode_answer_fragments(packet, daemonSalt, clientPkZ);
       if (ans) {
-        const opened = open_answer(clientSeed, ans.sealed_base64url);
+        const opened = open_answer(clientSeed, ans.sealed_base64url, hostDtlsFpHex);
         if (opened.daemon_pk_zbase32 !== daemonPkZ) {
           throw new Error("answer's inner daemon_pk does not match the packet signer");
         }

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -269,7 +269,69 @@ sealed-box (`crypto_box_seal`) of the answer plaintext below,
 addressed to `public_key_to_x25519(client_pk)`.
 
 The answer plaintext carries the same `compression_tag || body`
-framing as the offer. The answer body is:
+framing as the offer. Post–compact-answer-blob PR, the daemon emits
+the **v2** shape; the v1 shape remains decode-only for clients
+resolving legacy daemons during rollout.
+
+**v2 body (`openhost-answer-inner2`, current encoder output):**
+
+```
+  body =  "openhost-answer-inner2"   (22 bytes)
+       || daemon_pk                   (32 bytes)
+       || offer_sdp_hash              (32 bytes, SHA-256 of the UTF-8
+                                       offer SDP being answered)
+       || blob_len                    (u16 big-endian; ≤ 512)
+       || answer_blob                 (blob_len bytes; structure below)
+```
+
+The `answer_blob` is:
+
+```
+  answer_blob =
+      version      : u8   (0x01)
+      flags        : u8   (bit 0 = setup_role: 0=active, 1=passive;
+                            bits 1..7 reserved, MUST be 0)
+      ufrag_len    : u8   (4..=32 per RFC 8445 §5.3)
+      ufrag        : ufrag_len bytes, ASCII ice-ufrag
+      pwd_len      : u8   (22..=32 per RFC 8445 §5.3)
+      pwd          : pwd_len bytes, ASCII ice-pwd
+      cand_count   : u8   (0..=8)
+      candidates[] : cand_count entries of:
+                        typ    : u8  (0=host, 1=srflx, 2=prflx, 3=relay)
+                        family : u8  (4=IPv4, 6=IPv6)
+                        addr   : 4 or 16 bytes depending on family
+                        port   : u16 big-endian
+```
+
+Clients reconstruct a complete answer SDP at consumption time from
+the blob plus the host's DTLS fingerprint (pinned under the outer
+BEP44 signature on the `_openhost` record). A reference
+reconstruction template:
+
+```
+  v=0
+  o=- 1 1 IN IP4 0.0.0.0
+  s=-
+  t=0 0
+  a=group:BUNDLE 0
+  m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+  c=IN IP4 0.0.0.0
+  a=mid:0
+  a=rtcp-mux
+  a=ice-ufrag:<blob.ufrag>
+  a=ice-pwd:<blob.pwd>
+  a=fingerprint:sha-256 <colon-hex(record.dtls_fp)>
+  a=setup:<active|passive from blob.flags bit 0>
+  a=sctp-port:5000
+  a=candidate:1 1 udp 1 <addr> <port> typ <host|srflx|prflx|relay> generation 0  (×cand_count)
+  a=end-of-candidates
+```
+
+The blob does **NOT** duplicate the DTLS fingerprint. Integrity of
+the fingerprint is already provided by the outer BEP44 signature
+over the main `_openhost` record that carries `dtls_fp`.
+
+**v1 body (`openhost-answer-inner1`, decode-only):**
 
 ```
   body =  "openhost-answer-inner1"   (22 bytes)
@@ -279,6 +341,9 @@ framing as the offer. The answer body is:
        || sdp_len                     (u32 big-endian)
        || answer_sdp_utf8             (sdp_len bytes)
 ```
+
+Decoders pick v1 vs v2 on the 22-byte domain-separator prefix.
+Encoders **MUST** emit v2.
 
 `offer_sdp_hash` binds the answer to a specific offer; a racing
 adversary cannot splice a valid answer onto a different offer. The

--- a/spec/04-security.md
+++ b/spec/04-security.md
@@ -95,6 +95,10 @@ The channel-binding HMAC (attack 7.1 above) feeds HKDF-SHA256 with a session-spe
 
 libp2p's browser WebRTC transport (shipped in production across IPFS + Filecoin) uses an analogous cert-fingerprint binding in place of RFC 5705 for the same reason. openhost's CertFp variant is the same design pattern.
 
+### 4.4 Answer blob fingerprint locality
+
+The v2 answer body (`openhost-answer-inner2`, see `01-wire-format.md §3.3`) does **NOT** carry a duplicate copy of the host's DTLS certificate fingerprint. The fingerprint is carried exactly once, in the `dtls_fp` field of the host's main `_openhost` record, where it is pinned under the outer BEP44 signature. Clients reconstruct a complete answer SDP locally by combining the compact blob with that already-verified fingerprint. An adversary who forged a matching fingerprint would have already broken the host's Ed25519 identity key — the integrity surface of the one-per-host fingerprint is unchanged relative to the legacy v1 answer body.
+
 ## 5. Security response
 
 See [`../SECURITY.md`](../SECURITY.md) for the reporting process and response-time commitments.


### PR DESCRIPTION
## Summary

- Replaces the full-SDP `openhost-answer-inner1` answer body with a compact binary `openhost-answer-inner2` body carrying only the fields webrtc-rs cannot derive (ice-ufrag, ice-pwd, setup-role, IPv4 candidate list). Sealed answer drops ~900B → ~220B; BEP44 packet fits with ~300B headroom.
- The host's DTLS fingerprint is **not** duplicated in the blob — clients reconstruct a minimal valid SDP locally using the blob + the `dtls_fp` field already pinned under the outer BEP44 signature on the main `_openhost` record.
- Wire compat: decoders accept v1 (legacy daemons) and v2; encoders emit only v2. Graceful one-way cutover, no flag day.

## Why

PR #31 proved the full Mac ↔ EC2 Mumbai handshake up to the answer-publish step, but every real dial failed at the same boundary: the sealed + fragmented answer routinely exceeded BEP44's 1000-byte `v` cap alongside the main record (~1050-1080B measured). Earlier `announce_ip` workarounds were rejected because they only help static-IP VPS deployments and anchor users away from home-NAT hosts, which is the whole point of openhost. The compact-blob design mirrors libp2p-webrtc's template-substitution approach (shipped in production across IPFS + Filecoin against Chromium + pion for 3+ years).

## Key changes

- `openhost-pkarr/src/offer.rs` — new types (`AnswerBlob`, `BlobCandidate`, `CandidateType`, `SetupRole`, `AnswerPayload`), `encode_answer_blob`/`parse_answer_blob` codec, v1/v2 dispatch in `parse_answer_body`, shared `answer_blob_to_sdp` reconstructor.
- `openhost-daemon/src/listener.rs` — new `sdp_to_answer_blob` extractor replaces `trim_rtcp_component_candidates`; `handle_offer`/`negotiate` return `AnswerBlob`.
- `openhost-client/src/dialer.rs` — `poll_answer` threads `host_dtls_fp` + branches on payload variant.
- `openhost-pkarr-wasm/src/{core,lib}.rs` — `open_answer` gains `host_dtls_fp_hex` + returns reconstructed SDP for either shape.
- `extension/src/dialer/openhost_session.js` — threads `hostRecord.dtls_fingerprint_hex` through `pollAnswer`.
- `spec/01-wire-format.md §3.3`, `spec/04-security.md §4.4` — v1/v2 documentation + fingerprint-locality rationale.

## Test plan

- [x] `cargo test --workspace` — all ~330 tests green, including the upgraded `daemon_produces_sealed_answer_for_dialer_offer` (previously a negative guard asserting dial *must* time out; now asserts dial succeeds end-to-end).
- [x] 10 new pkarr tests — blob roundtrips, invalid version byte, reserved flag bits, oversize candidate count, ufrag length bounds, legacy v1 decode, single-fragment-fit against a main record.
- [x] 5 new daemon tests — `sdp_to_answer_blob` extraction, component-2 drop, IPv6 drop, malformed-line skip.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo check -p openhost-pkarr-wasm --target wasm32-unknown-unknown` — clean.
- [x] `extension/scripts/build-wasm.sh` — WASM package regenerates.
- [ ] Live Mac ↔ EC2 Mumbai dial regression — rebuild daemon for aarch64 via `cross`, redeploy, `openhost-dial`, confirm ICE → DTLS → channel binding → HTTP round-trip all complete. (Next session.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)