### PR TITLE
feat(daemon): auto-watch paired clients for offer polling

### DIFF
--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -73,6 +73,7 @@ impl App {
             publish::start(&cfg.pkarr, identity.clone(), state.clone()).await?;
         let poller = build_offer_poller(
             &cfg,
+            &pair_db_path,
             identity.clone(),
             Arc::clone(&listener),
             state.clone(),
@@ -142,6 +143,7 @@ impl App {
             publish::start_with_transport(&cfg.pkarr, identity.clone(), state.clone(), transport);
         let poller = build_offer_poller(
             &cfg,
+            &pair_db_path,
             identity.clone(),
             Arc::clone(&listener),
             state.clone(),
@@ -394,6 +396,7 @@ async fn build_listener(
 /// needed.
 fn build_offer_poller(
     cfg: &Config,
+    pair_db_path: &Path,
     identity: Arc<SigningKey>,
     listener: Arc<PassivePeer>,
     state: Arc<SharedState>,
@@ -408,9 +411,15 @@ fn build_offer_poller(
         .iter()
         .filter_map(|s| openhost_core::identity::PublicKey::from_zbase32(s).ok())
         .collect();
-    if watched.is_empty() {
-        return None;
-    }
+    // PR #39 — auto-watch paired clients: the poller also consumes the
+    // pair DB on every tick, so a daemon with empty `watched_clients`
+    // but a pair-DB path still spawns. `openhostd pair add <pk>` then
+    // becomes sufficient to make a client dialable with no config edit.
+    // The pair-DB path is always produced by `resolve_pair_db_path`
+    // (falls back to the platform-default location), so the poller
+    // effectively always spawns from this build path. The `spawn`
+    // assert inside `OfferPoller` catches the truly-degenerate case.
+    let pair_db_path_owned = pair_db_path.to_path_buf();
     let trigger: Arc<dyn Fn() + Send + Sync> = {
         let handle = publisher.trigger_handle();
         Arc::new(move || handle())
@@ -435,6 +444,7 @@ fn build_offer_poller(
                 .copied()
                 .map(openhost_pkarr::BindingMode::from)
                 .collect(),
+            pair_db_path: Some(pair_db_path_owned),
         },
     ))
 }

--- a/crates/openhost-daemon/src/offer_poller.rs
+++ b/crates/openhost-daemon/src/offer_poller.rs
@@ -24,6 +24,7 @@
 //!   handle.
 
 use crate::listener::PassivePeer;
+use crate::pairing;
 use crate::publish::SharedState;
 use crate::rate_limit::TokenBucket;
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -32,6 +33,7 @@ use openhost_pkarr::{
 };
 use rand::rngs::OsRng;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
@@ -59,6 +61,14 @@ pub struct OfferPollerConfig {
     /// dropped pre-handshake with a `warn!`. Mirrors
     /// `[dtls] allowed_binding_modes` from the config file.
     pub allowed_binding_modes: Vec<openhost_pkarr::BindingMode>,
+    /// Path to the pairing DB. When set, the poller ALSO watches every
+    /// pubkey present in the pair DB in addition to `watched_clients`.
+    /// This makes `openhostd pair add <pk>` sufficient to make a client
+    /// dialable with no config edit or restart — PR #17's pair-watcher
+    /// rewrites the file, the poller's next tick picks up the change.
+    /// Absent → behaves exactly like the pre-auto-watch version
+    /// (config list only).
+    pub pair_db_path: Option<PathBuf>,
 }
 
 impl Default for OfferPollerConfig {
@@ -74,6 +84,7 @@ impl Default for OfferPollerConfig {
                 openhost_pkarr::BindingMode::Exporter,
                 openhost_pkarr::BindingMode::CertFp,
             ],
+            pair_db_path: None,
         }
     }
 }
@@ -109,9 +120,14 @@ impl OfferPoller {
         publisher_trigger: Arc<dyn Fn() + Send + Sync>,
         cfg: OfferPollerConfig,
     ) -> Self {
+        // Spawn is valid when EITHER the config list is non-empty OR a
+        // pair-DB path is configured. Auto-watch (PR #39) means a
+        // daemon with empty `watched_clients` but a pair DB can still
+        // pick up paired clients on each tick, so the empty-config
+        // case is no longer a programmer error.
         assert!(
-            !cfg.watched_clients.is_empty(),
-            "OfferPoller::spawn requires a non-empty watched_clients list",
+            !cfg.watched_clients.is_empty() || cfg.pair_db_path.is_some(),
+            "OfferPoller::spawn requires non-empty watched_clients OR a pair_db_path",
         );
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
@@ -203,6 +219,42 @@ async fn run_poll_loop(
     }
 }
 
+/// Effective per-tick watch list: the union of the explicit config
+/// `watched_clients` and the pubkeys present in the pair DB (when
+/// configured). Duplicates across the two sources collapse to one
+/// entry (by raw pubkey bytes). Pair-DB read errors (missing file,
+/// parse failure, permission denied) are logged at `debug!` and
+/// produce an empty contribution for that tick — the poller never
+/// crashes from a stale or mid-rotation pair DB.
+fn resolved_watched_clients(cfg: &OfferPollerConfig) -> Vec<PublicKey> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(cfg.watched_clients.len());
+    for pk in &cfg.watched_clients {
+        if seen.insert(pk.to_bytes()) {
+            out.push(*pk);
+        }
+    }
+    if let Some(path) = cfg.pair_db_path.as_ref() {
+        match pairing::load(path) {
+            Ok(db) => {
+                for (pk, _nickname) in db.parsed() {
+                    if seen.insert(pk.to_bytes()) {
+                        out.push(pk);
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    path = %path.display(),
+                    "openhostd: pair-DB read failed; auto-watch contributes 0 entries this tick",
+                );
+            }
+        }
+    }
+    out
+}
+
 async fn poll_one_cycle(
     identity: &SigningKey,
     resolver: &dyn Resolve,
@@ -218,7 +270,8 @@ async fn poll_one_cycle(
     // Evict stale entries.
     seen.retain(|_, v| now_instant.duration_since(v.last_touched) < SEEN_TTL);
 
-    for client_pk in &cfg.watched_clients {
+    let watched = resolved_watched_clients(cfg);
+    for client_pk in &watched {
         let pk_bytes = client_pk.to_bytes();
         let pkarr_pk = match pkarr::PublicKey::try_from(&pk_bytes) {
             Ok(k) => k,
@@ -447,4 +500,93 @@ async fn process_client_packet(
 
     entry.last_ts = packet_ts_secs;
     entry.last_processed = Some(now_instant);
+}
+
+#[cfg(test)]
+mod auto_watch_tests {
+    use super::*;
+    use openhost_core::identity::SigningKey;
+    use tempfile::TempDir;
+
+    fn make_cfg_with_pair_db(
+        watched: Vec<PublicKey>,
+        pair_db_path: Option<PathBuf>,
+    ) -> OfferPollerConfig {
+        OfferPollerConfig {
+            watched_clients: watched,
+            pair_db_path,
+            ..OfferPollerConfig::default()
+        }
+    }
+
+    #[test]
+    fn resolved_watched_clients_config_only_when_no_pair_db() {
+        let pk = SigningKey::generate_os_rng().public_key();
+        let cfg = make_cfg_with_pair_db(vec![pk], None);
+        let out = resolved_watched_clients(&cfg);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].to_bytes(), pk.to_bytes());
+    }
+
+    #[test]
+    fn resolved_watched_clients_handles_missing_pair_db_file() {
+        let pk = SigningKey::generate_os_rng().public_key();
+        // Path that doesn't exist — load() returns Err, helper logs
+        // debug + returns config-only.
+        let missing = PathBuf::from("/tmp/openhost-nonexistent-pair-db-xyz.toml");
+        let cfg = make_cfg_with_pair_db(vec![pk], Some(missing));
+        let out = resolved_watched_clients(&cfg);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].to_bytes(), pk.to_bytes());
+    }
+
+    #[test]
+    fn resolved_watched_clients_merges_config_and_pair_db() {
+        let config_pk = SigningKey::generate_os_rng().public_key();
+        let pair_pk = SigningKey::generate_os_rng().public_key();
+        let tmp = TempDir::new().unwrap();
+        let pair_db = tmp.path().join("allow.toml");
+        crate::pairing::add(&pair_db, &pair_pk, None).unwrap();
+
+        let cfg = make_cfg_with_pair_db(vec![config_pk], Some(pair_db));
+        let out = resolved_watched_clients(&cfg);
+        assert_eq!(out.len(), 2);
+        let bytes: std::collections::HashSet<_> = out.iter().map(|p| p.to_bytes()).collect();
+        assert!(bytes.contains(&config_pk.to_bytes()));
+        assert!(bytes.contains(&pair_pk.to_bytes()));
+    }
+
+    #[test]
+    fn resolved_watched_clients_dedupes_overlapping_pubkeys() {
+        let pk = SigningKey::generate_os_rng().public_key();
+        let tmp = TempDir::new().unwrap();
+        let pair_db = tmp.path().join("allow.toml");
+        crate::pairing::add(&pair_db, &pk, None).unwrap();
+
+        // Same pubkey in both sources.
+        let cfg = make_cfg_with_pair_db(vec![pk], Some(pair_db));
+        let out = resolved_watched_clients(&cfg);
+        assert_eq!(
+            out.len(),
+            1,
+            "overlapping pubkey must collapse to one entry"
+        );
+        assert_eq!(out[0].to_bytes(), pk.to_bytes());
+    }
+
+    #[test]
+    fn resolved_watched_clients_pair_db_only() {
+        // No config entries — pair-DB supplies the full watch list.
+        // Exercises the "empty watched_clients, pair-DB populates"
+        // path that PR #39 is built to enable.
+        let pair_pk = SigningKey::generate_os_rng().public_key();
+        let tmp = TempDir::new().unwrap();
+        let pair_db = tmp.path().join("allow.toml");
+        crate::pairing::add(&pair_db, &pair_pk, None).unwrap();
+
+        let cfg = make_cfg_with_pair_db(vec![], Some(pair_db));
+        let out = resolved_watched_clients(&cfg);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].to_bytes(), pair_pk.to_bytes());
+    }
 }

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -360,3 +360,151 @@ async fn rate_limit_caps_burst_of_distinct_offers() -> DaemonResult<()> {
     app.shutdown().await;
     Ok(())
 }
+
+/// PR #39 — auto-watch paired clients. Config has an EMPTY
+/// `watched_clients` list; the client is added only via
+/// `pairing::add`. The daemon's offer-poller must still pick the
+/// client up on its next tick (via the pair-DB union in
+/// `resolved_watched_clients`) and process a real offer.
+#[tokio::test]
+async fn unlisted_but_paired_client_is_auto_watched() -> DaemonResult<()> {
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db = tmp.path().join("allow.toml");
+    pairing::add(&pair_db, &client_pk, Some("auto-watch".into())).unwrap();
+
+    // Crucial bit: `watched = &[]` — config list empty, pair-DB
+    // populated. Pre-PR-#39 behavior was `build_offer_poller` returns
+    // None in this case and no polling happens at all.
+    let cfg = build_config(&tmp, &[], true, 3, 5.0, 5, Some(pair_db));
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    let daemon_pk = app.identity().public_key();
+    let offer_sdp = real_client_offer_sdp().await;
+    let client_fp = openhost_pkarr::extract_sha256_fingerprint_from_sdp(&offer_sdp).expect("fp");
+    let offer_blob = openhost_pkarr::sdp_to_offer_blob(
+        &offer_sdp,
+        &client_fp,
+        openhost_pkarr::BindingMode::Exporter,
+    )
+    .expect("blob");
+    let packet = build_offer_packet(&client_sk, &daemon_pk, offer_blob, 1_700_000_000).await;
+    resolver.set_packet(&client_pk, &packet);
+
+    let expected_hash =
+        openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if app
+            .state()
+            .snapshot_answers()
+            .iter()
+            .any(|e| e.client_hash == expected_hash)
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("auto-watched (paired-only) client offer did not yield an answer");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    app.shutdown().await;
+    Ok(())
+}
+
+/// PR #39 — removing a pubkey from the pair DB stops polling on the
+/// next tick. Starts with the client paired, confirms an offer is
+/// processed, then removes the pair and confirms a FRESH offer
+/// (distinct ts) is NOT processed.
+#[tokio::test]
+async fn pair_remove_stops_auto_watch() -> DaemonResult<()> {
+    let client_sk = SigningKey::generate_os_rng();
+    let client_pk = client_sk.public_key();
+
+    let tmp = TempDir::new().unwrap();
+    let pair_db = tmp.path().join("allow.toml");
+    pairing::add(&pair_db, &client_pk, None).unwrap();
+
+    let cfg = build_config(&tmp, &[], true, 3, 5.0, 0, Some(pair_db.clone()));
+    let transport = Arc::new(CaptureTransport::default());
+    let resolver = ScriptedResolve::new();
+
+    let app = App::build_with_transport_and_resolve(
+        cfg,
+        transport.clone() as Arc<dyn openhost_pkarr::Transport>,
+        resolver.clone() as Arc<dyn openhost_pkarr::Resolve>,
+    )
+    .await
+    .expect("app builds");
+
+    // Step 1: paired — first offer should process.
+    let daemon_pk = app.identity().public_key();
+    let offer_sdp = real_client_offer_sdp().await;
+    let client_fp = openhost_pkarr::extract_sha256_fingerprint_from_sdp(&offer_sdp).expect("fp");
+    let offer_blob = openhost_pkarr::sdp_to_offer_blob(
+        &offer_sdp,
+        &client_fp,
+        openhost_pkarr::BindingMode::Exporter,
+    )
+    .expect("blob");
+    let packet_a = build_offer_packet(&client_sk, &daemon_pk, offer_blob, 1_700_000_000).await;
+    resolver.set_packet(&client_pk, &packet_a);
+
+    let expected_hash =
+        openhost_core::crypto::allowlist_hash(&app.state().salt(), &client_pk.to_bytes());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if app
+            .state()
+            .snapshot_answers()
+            .iter()
+            .any(|e| e.client_hash == expected_hash)
+        {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("paired client's first offer did not yield an answer");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Step 2: remove pair — the poller's next tick should read the
+    // updated DB and stop polling this client.
+    pairing::remove(&pair_db, &client_pk).unwrap();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Stage a FRESH offer (different ts so it's not dedupe-skipped).
+    let fresh_sdp = real_client_offer_sdp().await;
+    let fresh_fp = openhost_pkarr::extract_sha256_fingerprint_from_sdp(&fresh_sdp).expect("fp");
+    let fresh_blob = openhost_pkarr::sdp_to_offer_blob(
+        &fresh_sdp,
+        &fresh_fp,
+        openhost_pkarr::BindingMode::Exporter,
+    )
+    .expect("blob");
+    let packet_b = build_offer_packet(&client_sk, &daemon_pk, fresh_blob, 1_700_000_060).await;
+    resolver.set_packet(&client_pk, &packet_b);
+
+    let answers_before = app.state().snapshot_answers().len();
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let answers_after = app.state().snapshot_answers().len();
+    assert_eq!(
+        answers_before, answers_after,
+        "removed-pair client offer must NOT yield a new answer"
+    );
+
+    app.shutdown().await;
+    Ok(())
+}

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -282,6 +282,21 @@ invalidating existing implementations.
 The inner `client_pk` **MUST** match the outer BEP44 signer pubkey.
 The daemon verifies this on decode and rejects a mismatch.
 
+**Offer-poll watch list (operator-facing).** A daemon knows WHICH
+clients to poll via two sources, merged as a union at every poll
+tick:
+
+1. Explicit config: `pkarr.offer_poll.watched_clients` — zbase32
+   pubkey strings.
+2. The pair DB (`allow.toml`, managed by `openhostd pair add`/`remove`
+   and PR #17's pair-watcher).
+
+Daemons MAY consume either source alone, or both. A client added via
+`openhostd pair add <pk>` becomes reachable on the next poll tick
+(no config edit, no restart). Pair-DB read errors (missing file,
+parse failure, permission denied) degrade gracefully — that tick
+contributes no auto-watched pubkeys, the config list still applies.
+
 **Answer (daemon → client).** The daemon publishes answer records as
 **extra** TXT entries inside its existing `_openhost` `SignedPacket`.
 Each answer is split into one or more **fragments**, each emitted as


### PR DESCRIPTION
## Summary

- Offer-poller now consumes the pair DB (in addition to `pkarr.offer_poll.watched_clients` config). Union at every tick, dedup by raw pubkey bytes, graceful degradation on pair-DB read failure.
- `openhostd pair add <pk>` is now sufficient to make a client dialable — no config edit, no daemon restart.
- Closes the operator-toil gap surfaced during the live browser-extension test in PR #38.

## Why not "just flip enforce_allowlist = false"

`enforce_allowlist` gates auth AFTER polling. The poller still only looked at `watched_clients`. True "any paired client" needs the poller consuming the pair DB.

## Scope

- `OfferPollerConfig` grows `pair_db_path: Option<PathBuf>`.
- New helper `resolved_watched_clients` returns `config ∪ pair_db`.
- `build_offer_poller` threads the already-resolved pair-DB path into the config.
- Spec §3.3: one-paragraph note on the union-of-two-sources semantics.
- Zero changes to the pair-watcher or any authentication path.

## Test plan

- [x] 5 new unit tests in `offer_poller::auto_watch_tests` (config-only / missing pair-DB / merge / dedup / pair-DB-only)
- [x] 2 new integration tests in `tests/pairing_enforcement.rs` (`unlisted_but_paired_client_is_auto_watched`, `pair_remove_stops_auto_watch`)
- [x] `cargo test --workspace -- --test-threads=1` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo check -p openhost-pkarr-wasm --target wasm32-unknown-unknown` clean
- [ ] Live verification against the running EC2 daemon `t7ums1...`/`zw4gsn...`: `pair add` from SSH, dial from Mac browser, confirm no config edit needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)