### PR TITLE
⚡ Bolt: optimize frame decoding with O(1) buffer advancement

### DIFF
--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +182,7 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                buf.lock().await.put_slice(&msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +199,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -688,7 +688,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -778,11 +778,11 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
I have optimized the frame decoding process in both the `openhost-daemon` and `openhost-client` crates.

Previously, incoming frames were buffered in a `Vec<u8>`, and processed frames were removed using `buf.drain(..consumed)`. This is an $O(N)$ operation as it requires shifting all remaining bytes in the vector.

I replaced these buffers with `bytes::BytesMut`, which allows for $O(1)$ buffer advancement using `buf.advance(consumed)`. This provides a significant efficiency gain, especially when handling large frames (up to 16 MiB) or a high volume of small frames.

**Changes:**
- In `crates/openhost-daemon/src/listener.rs` and `crates/openhost-client/src/session.rs`:
    - Changed the inbound buffer type from `Arc<Mutex<Vec<u8>>>` to `Arc<Mutex<BytesMut>>`.
    - Updated `on_message` callbacks to use `buf.put_slice(&msg.data)` (requiring `BufMut`).
    - Updated frame decoding loops to use `buf.advance(consumed)` (requiring `Buf`).

**Performance Impact:**
- Reduces the cost of consuming $N$ bytes from an $M$-byte buffer from $O(M)$ to $O(1)$.
- Measurable improvement in CPU efficiency for high-throughput data channels.

**Verification:**
- Verified that all workspace tests pass (`cargo test --workspace`).
- Verified that the code compiles without warnings (`cargo clippy`).
- Verified logic correctness through existing integration tests that exercise the full request/response cycle over data channels.

---
*PR created automatically by Jules for task [104691423292189395](https://jules.google.com/task/104691423292189395) started by @vamzi*