### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -42,6 +42,7 @@ use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
 use std::sync::Arc;
 use thiserror::Error;
+use zeroize::Zeroizing;
 
 // Wire-level constants shared with `openhost-client`'s client-side
 // binder. The canonical source is `openhost-core::channel_binding_wire`;
@@ -168,7 +169,7 @@ impl ChannelBinder {
         let signature = Signature::from_bytes(&sig_bytes);
         client_pk
             .as_dalek()
-            .verify_strict(&auth, &signature)
+            .verify_strict(auth.as_ref(), &signature)
             .map_err(|_| ChannelBindingError::VerifyFailed)?;
 
         Ok(client_pk)
@@ -190,7 +191,7 @@ impl ChannelBinder {
             &client_pk_bytes,
             nonce,
         )?;
-        let signature = self.identity.sign(&auth);
+        let signature = self.identity.sign(auth.as_ref());
         Ok(signature.to_bytes())
     }
 }
@@ -200,9 +201,9 @@ fn derive_auth(
     host_pk: &[u8; 32],
     client_pk: &[u8; 32],
     nonce: &[u8; AUTH_NONCE_LEN],
-) -> Result<[u8; 32], ChannelBindingError> {
+) -> Result<Zeroizing<[u8; 32]>, ChannelBindingError> {
     match auth_bytes_bound(exporter_secret, host_pk, client_pk, nonce) {
-        Ok(auth) => Ok(auth),
+        Ok(auth) => Ok(Zeroizing::new(auth)),
         Err(openhost_core::Error::BufferTooSmall { have, .. }) => {
             Err(ChannelBindingError::ExporterLength(have))
         }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,6 +26,7 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
+use zeroize::Zeroizing;
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1095,7 +1096,7 @@ async fn handle_auth_client(
 ) -> FrameOutcome {
     let binding_secret =
         match derive_binding_secret(dtls_transport, binding_mode, local_dtls_fp).await {
-            Ok(bytes) => bytes,
+            Ok(secret) => secret,
             Err(reason) => {
                 tracing::warn!(
                     ?binding_mode,
@@ -1172,7 +1173,7 @@ async fn derive_binding_secret(
     dtls_transport: &RTCDtlsTransport,
     binding_mode: BindingMode,
     local_dtls_fp: &[u8; 32],
-) -> Result<Vec<u8>, &'static str> {
+) -> Result<Zeroizing<Vec<u8>>, &'static str> {
     match binding_mode {
         BindingMode::Exporter => {
             let exporter = dtls_transport
@@ -1182,7 +1183,7 @@ async fn derive_binding_secret(
             if exporter.len() != EXPORTER_SECRET_LEN {
                 return Err("DTLS exporter returned wrong length");
             }
-            Ok(exporter)
+            Ok(Zeroizing::new(exporter))
         }
         BindingMode::CertFp => {
             // Spec/04-security.md §4.1 says both sides hash *the host's*
@@ -1196,7 +1197,7 @@ async fn derive_binding_secret(
             // latent since PR #28.3 because the pre-compact-offer
             // dial path could not reach the binding step from a real
             // browser.
-            Ok(local_dtls_fp.to_vec())
+            Ok(Zeroizing::new(local_dtls_fp.to_vec()))
         }
     }
 }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,7 +26,6 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
-use zeroize::Zeroizing;
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -45,6 +44,7 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
+use zeroize::Zeroizing;
 
 /// Ensures the rustls CryptoProvider is installed exactly once per
 /// process. Required in rustls 0.23+ because the crate no longer picks


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

### 🚨 Severity: MEDIUM

### 💡 Vulnerability
Sensitive cryptographic material (DTLS exporter secrets and derived authentication bytes) was being held in standard `Vec<u8>` and `[u8; 32]` buffers without explicit zeroization after use.

### 🎯 Impact
If an attacker manages to obtain a memory dump of the `openhostd` process (e.g., via a separate vulnerability or physical access), they could potentially extract these session-specific secrets. While the impact is limited to the specific session and does not compromise the host's long-term identity key, it is a violation of cryptographic best practices.

### 🔧 Fix
Updated `crates/openhost-daemon/src/listener.rs` and `crates/openhost-daemon/src/channel_binding.rs` to wrap these sensitive intermediate values in `zeroize::Zeroizing`. This ensures that the memory is automatically wiped as soon as the values go out of scope.

### ✅ Verification
- Ran `cargo test --workspace` and verified all tests pass.
- Verified that `Zeroizing` is correctly applied to the return types of derivation functions.

---
*PR created automatically by Jules for task [12784103550185065666](https://jules.google.com/task/12784103550185065666) started by @vamzi*