### PR TITLE
docs(products/oh-send): scaffold developer-first product track

### DIFF
--- a/crates/openhost-core/src/error.rs
+++ b/crates/openhost-core/src/error.rs
@@ -60,6 +60,39 @@ pub enum Error {
         /// Bytes needed.
         need: usize,
     },
+
+    /// A TURN credential or quota token failed structural validation.
+    InvalidTurnCredential(&'static str),
+
+    /// A TURN credential or quota token has expired (`expires_at < now_ts`).
+    ExpiredTurnCredential {
+        /// `expires_at` carried inside the artifact.
+        expires_at: u64,
+        /// Verifier's current Unix timestamp.
+        now_ts: u64,
+    },
+
+    /// A TURN credential or quota token's lifetime exceeds the protocol cap.
+    OverlongTurnCredential {
+        /// `expires_at - issued_at` from the artifact.
+        lifetime_secs: u64,
+        /// Maximum permitted lifetime in seconds.
+        max_secs: u64,
+    },
+
+    /// A TURN credential or quota token is signed by a pubkey the verifier does not trust.
+    UntrustedTurnIssuer,
+
+    /// A TURN credential or quota token's `subject` does not match the verifier's pubkey.
+    TurnSubjectMismatch,
+
+    /// A TURN quota would be exceeded by the requested relayed-byte allocation.
+    TurnQuotaExceeded {
+        /// `cap_bytes` from the quota token.
+        cap_bytes: u64,
+        /// Total bytes that would be relayed if the request proceeded.
+        would_consume: u64,
+    },
 }
 
 impl fmt::Display for Error {
@@ -92,6 +125,33 @@ impl fmt::Display for Error {
             Error::BufferTooSmall { have, need } => {
                 write!(f, "buffer too small: have {have} bytes, need {need}")
             }
+            Error::InvalidTurnCredential(ctx) => {
+                write!(f, "invalid TURN credential: {ctx}")
+            }
+            Error::ExpiredTurnCredential { expires_at, now_ts } => write!(
+                f,
+                "expired TURN credential: expires_at={expires_at}, now={now_ts}"
+            ),
+            Error::OverlongTurnCredential {
+                lifetime_secs,
+                max_secs,
+            } => write!(
+                f,
+                "TURN credential lifetime {lifetime_secs}s exceeds max {max_secs}s"
+            ),
+            Error::UntrustedTurnIssuer => {
+                f.write_str("TURN credential issuer is not in the trusted set")
+            }
+            Error::TurnSubjectMismatch => {
+                f.write_str("TURN credential subject does not match verifier pubkey")
+            }
+            Error::TurnQuotaExceeded {
+                cap_bytes,
+                would_consume,
+            } => write!(
+                f,
+                "TURN quota exceeded: cap={cap_bytes} bytes, would_consume={would_consume} bytes"
+            ),
         }
     }
 }

--- a/crates/openhost-core/src/lib.rs
+++ b/crates/openhost-core/src/lib.rs
@@ -15,6 +15,7 @@
 //!   construction used by the handshake.
 //! - [`wire`] — HTTP-over-DataChannel framing as specified in `spec/01-wire-format.md` §4.
 //! - [`pkarr_record`] — openhost v1 signed DNS record schema on top of Pkarr.
+//! - [`turn`] — TURN credentials and quota tokens for relay-fallback ICE.
 //!
 //! Every module has matching test vectors under `spec/test-vectors/`. Implementations in
 //! other languages are expected to pass the same vectors verbatim.
@@ -24,6 +25,7 @@ pub mod crypto;
 pub mod error;
 pub mod identity;
 pub mod pkarr_record;
+pub mod turn;
 pub mod wire;
 
 pub use error::{Error, Result};

--- a/crates/openhost-core/src/turn/mod.rs
+++ b/crates/openhost-core/src/turn/mod.rs
@@ -1,0 +1,794 @@
+//! TURN credentials and quota tokens for relay-fallback ICE.
+//!
+//! See [`spec/05-turn-credentials.md`](https://github.com/kaicoder03/openhost/blob/main/spec/05-turn-credentials.md)
+//! for the normative protocol.
+//!
+//! This module provides the data types and Ed25519 sign/verify routines used
+//! when a client cannot establish a direct WebRTC path and must traverse a
+//! TURN relay. The relay never observes plaintext — see `spec/04-security.md`
+//! §1 for the supporting invariants — but it does observe ciphertext volume,
+//! which is why credentials are scoped to a subject pubkey and quota tokens
+//! cap relayed bytes per window.
+//!
+//! The module is intentionally infrastructure-agnostic: it defines the
+//! credential and token *envelope*, not the issuer's REST API and not the
+//! client's RTCConfiguration plumbing. Those land in follow-up PRs that wire
+//! `openhost-client::Dialer` and `openhost-daemon::Config` to consume the
+//! types defined here.
+
+use crate::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN};
+use crate::{Error, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ed25519_dalek::{Signature, SIGNATURE_LENGTH};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Maximum permitted lifetime of a [`TurnCredential`] — `expires_at - issued_at`
+/// MUST NOT exceed this value.
+///
+/// One hour matches `spec/05-turn-credentials.md` §4. Issuers typically mint
+/// credentials valid for ≤ 5 minutes; the one-hour ceiling is a hard cap so
+/// verifiers can reject obvious mis-issuance without per-issuer policy.
+pub const MAX_CREDENTIAL_LIFETIME_SECS: u64 = 3_600;
+
+/// Maximum permitted lifetime of a [`QuotaToken`] — `expires_at - issued_at`
+/// MUST NOT exceed this value.
+///
+/// 15 minutes per `spec/05-turn-credentials.md` §5. Quota tokens are
+/// refreshed frequently so the issuer can update `consumed_bytes` as traffic
+/// accrues; a long-lived quota token defeats the point of the substrate.
+pub const MAX_QUOTA_TOKEN_LIFETIME_SECS: u64 = 900;
+
+/// Maximum permitted `window_secs` on a [`QuotaToken`] (~31 days).
+///
+/// Quota windows longer than a calendar month would let an issuer mint a
+/// single token covering arbitrary future traffic, which contradicts the
+/// freshness assumption baked into [`MAX_QUOTA_TOKEN_LIFETIME_SECS`].
+pub const MAX_QUOTA_WINDOW_SECS: u64 = 31 * 86_400;
+
+/// Encoding tag prefixed to TURN canonical signing bytes.
+///
+/// Distinct from `pkarr_record`'s `0x01` tag so a signature lifted from one
+/// context cannot be replayed into the other.
+pub const TURN_ENCODING_TAG: u8 = 0x02;
+
+/// Domain separator for [`TurnCredential::canonical_signing_bytes`].
+pub const CREDENTIAL_DOMAIN: &[u8] = b"openhost-turn-credential-v1";
+
+/// Domain separator for [`QuotaToken::canonical_signing_bytes`].
+pub const QUOTA_DOMAIN: &[u8] = b"openhost-turn-quota-v1";
+
+/// A single TURN server entry — feeds 1:1 into `webrtc::ice_transport::ice_server::RTCIceServer`.
+///
+/// Field semantics match RFC 7065 (URL syntax) and RFC 8489 (long-term
+/// credential mechanism). `urls` MAY contain multiple entries for the same
+/// underlying server in different transports (e.g. `turn:` UDP + `turns:` TLS).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TurnServer {
+    /// `turn:` or `turns:` URLs. Plain `stun:` URLs do not belong here.
+    pub urls: Vec<String>,
+    /// RFC 8489 long-term credential username.
+    pub username: String,
+    /// RFC 8489 long-term credential password.
+    pub credential: String,
+}
+
+impl TurnServer {
+    fn validate(&self) -> Result<()> {
+        if self.urls.is_empty() {
+            return Err(Error::InvalidTurnCredential("server has no URLs"));
+        }
+        if self.urls.len() > u8::MAX as usize {
+            return Err(Error::InvalidTurnCredential(
+                "server has more URLs than the wire format allows (255)",
+            ));
+        }
+        for url in &self.urls {
+            if !(url.starts_with("turn:") || url.starts_with("turns:")) {
+                return Err(Error::InvalidTurnCredential(
+                    "TURN URL must begin with turn: or turns:",
+                ));
+            }
+            if url.len() > u16::MAX as usize {
+                return Err(Error::InvalidTurnCredential("URL exceeds 65535 bytes"));
+            }
+        }
+        if self.username.len() > u16::MAX as usize {
+            return Err(Error::InvalidTurnCredential("username exceeds 65535 bytes"));
+        }
+        if self.credential.len() > u16::MAX as usize {
+            return Err(Error::InvalidTurnCredential(
+                "credential exceeds 65535 bytes",
+            ));
+        }
+        Ok(())
+    }
+
+    fn extend_canonical(&self, out: &mut Vec<u8>) {
+        // url_count fits in a byte by validate().
+        out.push(self.urls.len() as u8);
+        for url in &self.urls {
+            let bytes = url.as_bytes();
+            out.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+            out.extend_from_slice(bytes);
+        }
+        let user = self.username.as_bytes();
+        out.extend_from_slice(&(user.len() as u16).to_be_bytes());
+        out.extend_from_slice(user);
+        let cred = self.credential.as_bytes();
+        out.extend_from_slice(&(cred.len() as u16).to_be_bytes());
+        out.extend_from_slice(cred);
+    }
+}
+
+/// Issuer-signed bundle naming a subject pubkey and the TURN servers it may use.
+///
+/// See `spec/05-turn-credentials.md` §4 for the wire format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TurnCredential {
+    /// Pubkey authorised to use these servers.
+    pub subject: PublicKey,
+    /// TURN servers (≥ 1).
+    pub servers: Vec<TurnServer>,
+    /// Unix seconds — credential valid from.
+    pub issued_at: u64,
+    /// Unix seconds — credential expires at.
+    pub expires_at: u64,
+    /// Pubkey of the issuer.
+    pub issuer: PublicKey,
+    /// Ed25519 signature by `issuer` over [`Self::canonical_signing_bytes`].
+    pub signature: SignatureBytes,
+}
+
+impl TurnCredential {
+    /// Validate structural invariants independent of any signature check.
+    ///
+    /// Called from [`Self::canonical_signing_bytes`] and from
+    /// [`Self::verify`]. Exposed so issuers can sanity-check inputs before
+    /// signing.
+    pub fn validate(&self) -> Result<()> {
+        if self.servers.is_empty() {
+            return Err(Error::InvalidTurnCredential("empty server list"));
+        }
+        if self.servers.len() > u16::MAX as usize {
+            return Err(Error::InvalidTurnCredential(
+                "more than 65535 servers in credential",
+            ));
+        }
+        if self.expires_at < self.issued_at {
+            return Err(Error::InvalidTurnCredential(
+                "expires_at is earlier than issued_at",
+            ));
+        }
+        let lifetime = self.expires_at - self.issued_at;
+        if lifetime > MAX_CREDENTIAL_LIFETIME_SECS {
+            return Err(Error::OverlongTurnCredential {
+                lifetime_secs: lifetime,
+                max_secs: MAX_CREDENTIAL_LIFETIME_SECS,
+            });
+        }
+        for server in &self.servers {
+            server.validate()?;
+        }
+        Ok(())
+    }
+
+    /// Canonical byte representation used for signing and verification.
+    ///
+    /// See `spec/05-turn-credentials.md` §4.1 for the layout.
+    pub fn canonical_signing_bytes(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        let mut out = Vec::with_capacity(128);
+        out.push(TURN_ENCODING_TAG);
+        out.extend_from_slice(CREDENTIAL_DOMAIN);
+        out.extend_from_slice(&self.subject.to_bytes());
+        out.extend_from_slice(&self.issuer.to_bytes());
+        out.extend_from_slice(&self.issued_at.to_be_bytes());
+        out.extend_from_slice(&self.expires_at.to_be_bytes());
+        out.extend_from_slice(&(self.servers.len() as u16).to_be_bytes());
+        for server in &self.servers {
+            server.extend_canonical(&mut out);
+        }
+        Ok(out)
+    }
+
+    /// Sign an unsigned-shaped credential with `issuer_sk`, populating the
+    /// returned credential's `signature` field.
+    pub fn sign(
+        subject: PublicKey,
+        servers: Vec<TurnServer>,
+        issued_at: u64,
+        expires_at: u64,
+        issuer_sk: &SigningKey,
+    ) -> Result<Self> {
+        let issuer = issuer_sk.public_key();
+        let mut cred = Self {
+            subject,
+            servers,
+            issued_at,
+            expires_at,
+            issuer,
+            // Sentinel: overwritten before return. We do NOT sign over a
+            // zero signature — `canonical_signing_bytes` never includes
+            // the signature field — so the placeholder is safe.
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let msg = cred.canonical_signing_bytes()?;
+        let sig = issuer_sk.sign(&msg);
+        cred.signature = SignatureBytes(sig.to_bytes());
+        Ok(cred)
+    }
+
+    /// Verify the credential against `now_ts` and `trusted_issuers`.
+    ///
+    /// Returns `Ok(())` if and only if every check in
+    /// `spec/05-turn-credentials.md` §4.2 passes against `verifier_subject`
+    /// (which MUST be the local pubkey).
+    ///
+    /// `now_ts` is the verifier's current Unix timestamp in seconds.
+    pub fn verify(
+        &self,
+        verifier_subject: &PublicKey,
+        trusted_issuers: &[PublicKey],
+        now_ts: u64,
+    ) -> Result<()> {
+        if !trusted_issuers.iter().any(|p| p == &self.issuer) {
+            return Err(Error::UntrustedTurnIssuer);
+        }
+        if self.expires_at < now_ts {
+            return Err(Error::ExpiredTurnCredential {
+                expires_at: self.expires_at,
+                now_ts,
+            });
+        }
+        // validate() also catches expires_at < issued_at and overlong
+        // lifetime; ordering it after the cheap checks above keeps the
+        // common error paths fast.
+        let msg = self.canonical_signing_bytes()?;
+        let sig = Signature::from_bytes(&self.signature.0);
+        self.issuer.verify(&msg, &sig)?;
+        if &self.subject != verifier_subject {
+            return Err(Error::TurnSubjectMismatch);
+        }
+        Ok(())
+    }
+}
+
+/// Issuer-signed assertion of a relayed-byte cap for a subject pubkey.
+///
+/// See `spec/05-turn-credentials.md` §5 for the wire format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QuotaToken {
+    /// Subject pubkey the quota applies to.
+    pub subject: PublicKey,
+    /// Unix seconds — start of the quota window.
+    pub window_start: u64,
+    /// Window duration in seconds (≤ [`MAX_QUOTA_WINDOW_SECS`]).
+    pub window_secs: u64,
+    /// Cap on relayed bytes within the window.
+    pub cap_bytes: u64,
+    /// Bytes already relayed in the window at issuance time.
+    pub consumed_bytes: u64,
+    /// Unix seconds — token valid from.
+    pub issued_at: u64,
+    /// Unix seconds — token expires at.
+    pub expires_at: u64,
+    /// Pubkey of the issuer.
+    pub issuer: PublicKey,
+    /// Ed25519 signature by `issuer` over [`Self::canonical_signing_bytes`].
+    pub signature: SignatureBytes,
+}
+
+impl QuotaToken {
+    /// Validate structural invariants independent of any signature check.
+    pub fn validate(&self) -> Result<()> {
+        if self.window_secs == 0 {
+            return Err(Error::InvalidTurnCredential("window_secs must be > 0"));
+        }
+        if self.window_secs > MAX_QUOTA_WINDOW_SECS {
+            return Err(Error::InvalidTurnCredential("window_secs exceeds 31 days"));
+        }
+        if self.consumed_bytes > self.cap_bytes {
+            return Err(Error::InvalidTurnCredential(
+                "consumed_bytes exceeds cap_bytes",
+            ));
+        }
+        if self.expires_at < self.issued_at {
+            return Err(Error::InvalidTurnCredential(
+                "expires_at is earlier than issued_at",
+            ));
+        }
+        let lifetime = self.expires_at - self.issued_at;
+        if lifetime > MAX_QUOTA_TOKEN_LIFETIME_SECS {
+            return Err(Error::OverlongTurnCredential {
+                lifetime_secs: lifetime,
+                max_secs: MAX_QUOTA_TOKEN_LIFETIME_SECS,
+            });
+        }
+        Ok(())
+    }
+
+    /// Canonical byte representation used for signing and verification.
+    ///
+    /// See `spec/05-turn-credentials.md` §5.1 for the layout.
+    pub fn canonical_signing_bytes(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        let mut out = Vec::with_capacity(128);
+        out.push(TURN_ENCODING_TAG);
+        out.extend_from_slice(QUOTA_DOMAIN);
+        out.extend_from_slice(&self.subject.to_bytes());
+        out.extend_from_slice(&self.issuer.to_bytes());
+        out.extend_from_slice(&self.window_start.to_be_bytes());
+        out.extend_from_slice(&self.window_secs.to_be_bytes());
+        out.extend_from_slice(&self.cap_bytes.to_be_bytes());
+        out.extend_from_slice(&self.consumed_bytes.to_be_bytes());
+        out.extend_from_slice(&self.issued_at.to_be_bytes());
+        out.extend_from_slice(&self.expires_at.to_be_bytes());
+        Ok(out)
+    }
+
+    /// Sign an unsigned-shaped quota token with `issuer_sk`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign(
+        subject: PublicKey,
+        window_start: u64,
+        window_secs: u64,
+        cap_bytes: u64,
+        consumed_bytes: u64,
+        issued_at: u64,
+        expires_at: u64,
+        issuer_sk: &SigningKey,
+    ) -> Result<Self> {
+        let issuer = issuer_sk.public_key();
+        let mut tok = Self {
+            subject,
+            window_start,
+            window_secs,
+            cap_bytes,
+            consumed_bytes,
+            issued_at,
+            expires_at,
+            issuer,
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let msg = tok.canonical_signing_bytes()?;
+        let sig = issuer_sk.sign(&msg);
+        tok.signature = SignatureBytes(sig.to_bytes());
+        Ok(tok)
+    }
+
+    /// Verify the quota token. See `spec/05-turn-credentials.md` §5.2.
+    pub fn verify(
+        &self,
+        verifier_subject: &PublicKey,
+        trusted_issuers: &[PublicKey],
+        now_ts: u64,
+    ) -> Result<()> {
+        if !trusted_issuers.iter().any(|p| p == &self.issuer) {
+            return Err(Error::UntrustedTurnIssuer);
+        }
+        if self.expires_at < now_ts {
+            return Err(Error::ExpiredTurnCredential {
+                expires_at: self.expires_at,
+                now_ts,
+            });
+        }
+        let msg = self.canonical_signing_bytes()?;
+        let sig = Signature::from_bytes(&self.signature.0);
+        self.issuer.verify(&msg, &sig)?;
+        if &self.subject != verifier_subject {
+            return Err(Error::TurnSubjectMismatch);
+        }
+        Ok(())
+    }
+
+    /// Bytes still available against the cap, given the verifier's local
+    /// counter of bytes relayed since `consumed_bytes` was issued.
+    ///
+    /// Returns `0` when the local counter has caught up to or exceeded the
+    /// remaining headroom — callers MUST stop relaying when this is `0`.
+    #[must_use]
+    pub fn remaining_bytes(&self, locally_consumed_since_issue: u64) -> u64 {
+        self.cap_bytes
+            .saturating_sub(self.consumed_bytes)
+            .saturating_sub(locally_consumed_since_issue)
+    }
+
+    /// `true` if relaying `additional` more bytes would cross the cap.
+    #[must_use]
+    pub fn would_exceed(&self, locally_consumed_since_issue: u64, additional: u64) -> bool {
+        self.consumed_bytes
+            .saturating_add(locally_consumed_since_issue)
+            .saturating_add(additional)
+            > self.cap_bytes
+    }
+}
+
+/// Newtype around the raw 64-byte Ed25519 signature with base64url-no-pad
+/// JSON serialization.
+///
+/// Wire format intentionally matches the sealed-offer TXT encoding in
+/// `spec/03-pkarr-records.md` §3.3 so implementations can share base64
+/// helpers across both call sites.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct SignatureBytes(pub [u8; SIGNATURE_LENGTH]);
+
+impl SignatureBytes {
+    /// Raw 64 bytes of the signature.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SIGNATURE_LENGTH] {
+        &self.0
+    }
+
+    /// Construct from a base64url-no-pad string.
+    pub fn from_base64url(s: &str) -> Result<Self> {
+        let raw = URL_SAFE_NO_PAD
+            .decode(s.as_bytes())
+            .map_err(|_| Error::InvalidTurnCredential("signature is not valid base64url"))?;
+        if raw.len() != SIGNATURE_LENGTH {
+            return Err(Error::InvalidTurnCredential(
+                "signature did not decode to 64 bytes",
+            ));
+        }
+        let mut arr = [0u8; SIGNATURE_LENGTH];
+        arr.copy_from_slice(&raw);
+        Ok(Self(arr))
+    }
+
+    /// Encode as a base64url-no-pad string.
+    #[must_use]
+    pub fn to_base64url(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.0)
+    }
+}
+
+impl core::fmt::Debug for SignatureBytes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Don't dump 64 bytes of sig into Debug output — the b64url form is
+        // shorter and matches what appears on the wire.
+        write!(f, "SignatureBytes({})", self.to_base64url())
+    }
+}
+
+impl Serialize for SignatureBytes {
+    fn serialize<S: Serializer>(&self, ser: S) -> core::result::Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_base64url())
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureBytes {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> core::result::Result<Self, D::Error> {
+        let s = <&str>::deserialize(de)?;
+        Self::from_base64url(s).map_err(serde::de::Error::custom)
+    }
+}
+
+// Compile-time assert: `PUBLIC_KEY_LEN` is part of the canonical bytes
+// layout. If the upstream constant ever changes, every TURN signature in
+// existence is invalidated — fail the build instead of silently accepting
+// re-encoded signatures.
+const _: () = assert!(PUBLIC_KEY_LEN == 32);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ISSUER_SEED: [u8; 32] = [0x11u8; 32];
+    const SUBJECT_SEED: [u8; 32] = [0x22u8; 32];
+    const OTHER_SEED: [u8; 32] = [0x33u8; 32];
+
+    fn issuer_sk() -> SigningKey {
+        SigningKey::from_bytes(&ISSUER_SEED)
+    }
+
+    fn subject_pk() -> PublicKey {
+        SigningKey::from_bytes(&SUBJECT_SEED).public_key()
+    }
+
+    fn other_pk() -> PublicKey {
+        SigningKey::from_bytes(&OTHER_SEED).public_key()
+    }
+
+    fn sample_servers() -> Vec<TurnServer> {
+        vec![TurnServer {
+            urls: vec![
+                "turn:relay.oh-send.dev:3478?transport=udp".to_string(),
+                "turns:relay.oh-send.dev:5349?transport=tcp".to_string(),
+            ],
+            username: "1700000000:47pjoycn…".to_string(),
+            credential: "deadbeefcafef00d".to_string(),
+        }]
+    }
+
+    fn sample_credential() -> TurnCredential {
+        TurnCredential::sign(
+            subject_pk(),
+            sample_servers(),
+            1_700_000_000,
+            1_700_000_300,
+            &issuer_sk(),
+        )
+        .expect("sign sample credential")
+    }
+
+    fn sample_quota() -> QuotaToken {
+        QuotaToken::sign(
+            subject_pk(),
+            1_700_000_000,
+            30 * 86_400,
+            5 * 1024 * 1024 * 1024,
+            1024 * 1024 * 1024,
+            1_700_000_000,
+            1_700_000_600,
+            &issuer_sk(),
+        )
+        .expect("sign sample quota")
+    }
+
+    #[test]
+    fn credential_canonical_bytes_stable_across_calls() {
+        let c = sample_credential();
+        let a = c.canonical_signing_bytes().unwrap();
+        let b = c.canonical_signing_bytes().unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn credential_signs_and_verifies() {
+        let issuer_pk = issuer_sk().public_key();
+        let cred = sample_credential();
+        cred.verify(&subject_pk(), &[issuer_pk], 1_700_000_100)
+            .expect("fresh credential verifies");
+    }
+
+    #[test]
+    fn credential_rejects_unknown_issuer() {
+        let cred = sample_credential();
+        let stranger = other_pk();
+        let err = cred
+            .verify(&subject_pk(), &[stranger], 1_700_000_100)
+            .unwrap_err();
+        assert!(matches!(err, Error::UntrustedTurnIssuer), "got: {err:?}");
+    }
+
+    #[test]
+    fn credential_rejects_expired() {
+        let issuer_pk = issuer_sk().public_key();
+        let cred = sample_credential();
+        let err = cred
+            .verify(&subject_pk(), &[issuer_pk], cred.expires_at + 1)
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::ExpiredTurnCredential { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn credential_rejects_overlong_lifetime() {
+        // Construct directly to bypass sign(); validate() catches the
+        // overlong window.
+        let issuer_pk = issuer_sk().public_key();
+        let cred = TurnCredential {
+            subject: subject_pk(),
+            servers: sample_servers(),
+            issued_at: 1_700_000_000,
+            expires_at: 1_700_000_000 + MAX_CREDENTIAL_LIFETIME_SECS + 1,
+            issuer: issuer_pk,
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let err = cred.canonical_signing_bytes().unwrap_err();
+        assert!(
+            matches!(err, Error::OverlongTurnCredential { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn credential_rejects_wrong_subject() {
+        let issuer_pk = issuer_sk().public_key();
+        let cred = sample_credential();
+        let err = cred
+            .verify(&other_pk(), &[issuer_pk], 1_700_000_100)
+            .unwrap_err();
+        assert!(matches!(err, Error::TurnSubjectMismatch), "got: {err:?}");
+    }
+
+    #[test]
+    fn credential_rejects_tampered_server() {
+        let issuer_pk = issuer_sk().public_key();
+        let mut cred = sample_credential();
+        cred.servers[0].credential = "tampered".to_string();
+        let err = cred
+            .verify(&subject_pk(), &[issuer_pk], 1_700_000_100)
+            .unwrap_err();
+        assert!(matches!(err, Error::BadSignature), "got: {err:?}");
+    }
+
+    #[test]
+    fn credential_rejects_tampered_signature() {
+        let issuer_pk = issuer_sk().public_key();
+        let mut cred = sample_credential();
+        cred.signature.0[0] ^= 0x01;
+        let err = cred
+            .verify(&subject_pk(), &[issuer_pk], 1_700_000_100)
+            .unwrap_err();
+        assert!(matches!(err, Error::BadSignature), "got: {err:?}");
+    }
+
+    #[test]
+    fn credential_rejects_empty_servers() {
+        let cred = TurnCredential {
+            subject: subject_pk(),
+            servers: vec![],
+            issued_at: 1_700_000_000,
+            expires_at: 1_700_000_300,
+            issuer: issuer_sk().public_key(),
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let err = cred.canonical_signing_bytes().unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidTurnCredential(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn credential_rejects_non_turn_url() {
+        let cred = TurnCredential {
+            subject: subject_pk(),
+            servers: vec![TurnServer {
+                urls: vec!["stun:stun.example:3478".to_string()],
+                username: "u".into(),
+                credential: "p".into(),
+            }],
+            issued_at: 1_700_000_000,
+            expires_at: 1_700_000_300,
+            issuer: issuer_sk().public_key(),
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let err = cred.canonical_signing_bytes().unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidTurnCredential(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn credential_json_roundtrip() {
+        let cred = sample_credential();
+        let json = serde_json::to_string(&cred).expect("serialize");
+        let back: TurnCredential = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(cred, back);
+        // Round-trip preserves the signature, so the deserialized form
+        // verifies under the same issuer.
+        let issuer_pk = issuer_sk().public_key();
+        back.verify(&subject_pk(), &[issuer_pk], 1_700_000_100)
+            .expect("roundtripped credential verifies");
+    }
+
+    #[test]
+    fn credential_json_rejects_unknown_field() {
+        let cred = sample_credential();
+        let mut value: serde_json::Value = serde_json::to_value(&cred).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("extra".into(), serde_json::Value::Bool(true));
+        let json = serde_json::to_string(&value).unwrap();
+        let res: core::result::Result<TurnCredential, _> = serde_json::from_str(&json);
+        assert!(res.is_err(), "unknown fields must be rejected");
+    }
+
+    #[test]
+    fn quota_signs_and_verifies() {
+        let issuer_pk = issuer_sk().public_key();
+        let tok = sample_quota();
+        tok.verify(&subject_pk(), &[issuer_pk], 1_700_000_100)
+            .expect("fresh quota verifies");
+    }
+
+    #[test]
+    fn quota_rejects_consumed_over_cap() {
+        let tok = QuotaToken {
+            subject: subject_pk(),
+            window_start: 0,
+            window_secs: 86_400,
+            cap_bytes: 1_000,
+            consumed_bytes: 1_001,
+            issued_at: 0,
+            expires_at: 600,
+            issuer: issuer_sk().public_key(),
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let err = tok.canonical_signing_bytes().unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidTurnCredential(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn quota_rejects_overlong_lifetime() {
+        let tok = QuotaToken {
+            subject: subject_pk(),
+            window_start: 0,
+            window_secs: 86_400,
+            cap_bytes: 1_000,
+            consumed_bytes: 0,
+            issued_at: 0,
+            expires_at: MAX_QUOTA_TOKEN_LIFETIME_SECS + 1,
+            issuer: issuer_sk().public_key(),
+            signature: SignatureBytes([0u8; SIGNATURE_LENGTH]),
+        };
+        let err = tok.canonical_signing_bytes().unwrap_err();
+        assert!(
+            matches!(err, Error::OverlongTurnCredential { .. }),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn quota_remaining_bytes_saturates_to_zero() {
+        let tok = sample_quota();
+        // consumed_bytes = 1 GiB, cap = 5 GiB → 4 GiB headroom.
+        let four_gib = 4 * 1024 * 1024 * 1024;
+        assert_eq!(tok.remaining_bytes(0), four_gib);
+        // Burn through the headroom plus a billion bytes — the function
+        // saturates rather than panicking on underflow.
+        assert_eq!(tok.remaining_bytes(four_gib + 1_000_000_000), 0);
+    }
+
+    #[test]
+    fn quota_would_exceed_at_exact_boundary() {
+        let tok = sample_quota();
+        let four_gib = 4 * 1024 * 1024 * 1024_u64;
+        // Right at the cap is *not* an exceedance.
+        assert!(!tok.would_exceed(four_gib, 0));
+        assert!(!tok.would_exceed(four_gib - 1, 1));
+        // One byte over.
+        assert!(tok.would_exceed(four_gib, 1));
+    }
+
+    #[test]
+    fn quota_json_roundtrip() {
+        let tok = sample_quota();
+        let json = serde_json::to_string(&tok).expect("serialize");
+        let back: QuotaToken = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(tok, back);
+    }
+
+    #[test]
+    fn signature_bytes_base64url_roundtrip() {
+        let sb = SignatureBytes([0xABu8; SIGNATURE_LENGTH]);
+        let s = sb.to_base64url();
+        let back = SignatureBytes::from_base64url(&s).unwrap();
+        assert_eq!(sb, back);
+    }
+
+    #[test]
+    fn signature_bytes_base64url_rejects_wrong_length() {
+        // 4 bytes of base64url (3 raw bytes) cannot be a 64-byte sig.
+        let err = SignatureBytes::from_base64url("AAAA").unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidTurnCredential(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn credential_canonical_domain_separator_differs_from_quota() {
+        let c = sample_credential();
+        let q = sample_quota();
+        let cb = c.canonical_signing_bytes().unwrap();
+        let qb = q.canonical_signing_bytes().unwrap();
+        // The first byte (encoding tag) is identical, but the domain
+        // string immediately afterward MUST differ — that is what makes
+        // a signature uniquely bind to its artifact type.
+        assert_ne!(&cb[1..1 + CREDENTIAL_DOMAIN.len()], QUOTA_DOMAIN);
+        assert_ne!(&qb[1..1 + QUOTA_DOMAIN.len()], CREDENTIAL_DOMAIN);
+    }
+}

--- a/crates/openhost-core/tests/turn_credential_vectors.rs
+++ b/crates/openhost-core/tests/turn_credential_vectors.rs
@@ -1,0 +1,361 @@
+//! Conformance tests against `spec/test-vectors/turn_credentials.json`.
+//!
+//! Each scenario in the JSON is exercised here with the actual sign/verify
+//! routines so that the wire-format spec, the canonical signing bytes, and
+//! the verification rules stay in lockstep. If a future protocol revision
+//! changes any of them, this test fails loudly rather than silently
+//! accepting incompatible artifacts.
+
+use openhost_core::identity::{PublicKey, SigningKey};
+use openhost_core::turn::{
+    QuotaToken, SignatureBytes, TurnCredential, TurnServer, MAX_CREDENTIAL_LIFETIME_SECS,
+    MAX_QUOTA_TOKEN_LIFETIME_SECS,
+};
+use openhost_core::Error;
+use serde_json::Value;
+use std::path::PathBuf;
+
+const VECTORS_PATH: &str = "../../spec/test-vectors/turn_credentials.json";
+
+fn load_vectors() -> Value {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push(VECTORS_PATH);
+    let body =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    serde_json::from_str(&body).expect("parse turn_credentials.json")
+}
+
+fn seed_from_hex(s: &str) -> [u8; 32] {
+    let raw = hex::decode(s).expect("hex");
+    assert_eq!(raw.len(), 32, "seed must be 32 bytes");
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&raw);
+    out
+}
+
+fn sk_from_hex(s: &str) -> SigningKey {
+    SigningKey::from_bytes(&seed_from_hex(s))
+}
+
+fn issuer_sk(v: &Value) -> SigningKey {
+    sk_from_hex(v["issuer"]["signing_seed_hex"].as_str().unwrap())
+}
+
+fn subject_sk(v: &Value) -> SigningKey {
+    sk_from_hex(v["subject"]["signing_seed_hex"].as_str().unwrap())
+}
+
+fn parse_servers(value: &Value) -> Vec<TurnServer> {
+    value
+        .as_array()
+        .expect("servers array")
+        .iter()
+        .map(|s| TurnServer {
+            urls: s["urls"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|u| u.as_str().unwrap().to_string())
+                .collect(),
+            username: s["username"].as_str().unwrap().to_string(),
+            credential: s["credential"].as_str().unwrap().to_string(),
+        })
+        .collect()
+}
+
+#[test]
+fn positive_credential_vectors_verify() {
+    let v = load_vectors();
+    let issuer = issuer_sk(&v);
+    let subject = subject_sk(&v);
+    let issuer_pk = issuer.public_key();
+    let subject_pk = subject.public_key();
+
+    let cases = v["credentials"]["positive"].as_array().expect("positive[]");
+    assert!(!cases.is_empty(), "vectors must include positive cases");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let issued_at = case["issued_at"].as_u64().unwrap();
+        let expires_at = case["expires_at"].as_u64().unwrap();
+        let now = case["verifier_now_ts"].as_u64().unwrap();
+        let servers = parse_servers(&case["servers"]);
+
+        let cred = TurnCredential::sign(subject_pk, servers, issued_at, expires_at, &issuer)
+            .unwrap_or_else(|e| panic!("[{name}] sign failed: {e}"));
+        cred.verify(&subject_pk, &[issuer_pk], now)
+            .unwrap_or_else(|e| panic!("[{name}] verify failed: {e}"));
+    }
+}
+
+#[test]
+fn positive_quota_vectors_verify() {
+    let v = load_vectors();
+    let issuer = issuer_sk(&v);
+    let subject = subject_sk(&v);
+    let issuer_pk = issuer.public_key();
+    let subject_pk = subject.public_key();
+
+    let cases = v["quota_tokens"]["positive"]
+        .as_array()
+        .expect("positive[]");
+    for case in cases {
+        let name = case["name"].as_str().unwrap();
+        let tok = QuotaToken::sign(
+            subject_pk,
+            case["window_start"].as_u64().unwrap(),
+            case["window_secs"].as_u64().unwrap(),
+            case["cap_bytes"].as_u64().unwrap(),
+            case["consumed_bytes"].as_u64().unwrap(),
+            case["issued_at"].as_u64().unwrap(),
+            case["expires_at"].as_u64().unwrap(),
+            &issuer,
+        )
+        .unwrap_or_else(|e| panic!("[{name}] sign failed: {e}"));
+        let now = case["verifier_now_ts"].as_u64().unwrap();
+        tok.verify(&subject_pk, &[issuer_pk], now)
+            .unwrap_or_else(|e| panic!("[{name}] verify failed: {e}"));
+
+        if let Some(expected) = case["remaining_bytes_at_zero_local"].as_u64() {
+            assert_eq!(
+                tok.remaining_bytes(0),
+                expected,
+                "[{name}] remaining_bytes(0) mismatch",
+            );
+        }
+    }
+}
+
+#[test]
+fn negative_credential_vectors_reject() {
+    // Each negative scenario is exercised explicitly below. The JSON file is
+    // the source of truth for which scenarios MUST exist; we re-derive the
+    // expected error here so that a JSON edit alone cannot silently weaken
+    // the assertion.
+    let v = load_vectors();
+    let issuer = issuer_sk(&v);
+    let subject = subject_sk(&v);
+    let issuer_pk = issuer.public_key();
+    let subject_pk = subject.public_key();
+
+    let names: Vec<String> = v["credentials"]["negative"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["name"].as_str().unwrap().to_string())
+        .collect();
+    let expected = [
+        "expired_credential",
+        "overlong_lifetime",
+        "wrong_subject",
+        "untrusted_issuer",
+        "tampered_server_credential",
+        "tampered_signature",
+        "empty_servers",
+        "non_turn_url",
+    ];
+    for n in expected {
+        assert!(names.iter().any(|x| x == n), "missing negative vector: {n}");
+    }
+
+    let base_servers = vec![TurnServer {
+        urls: vec!["turn:relay.oh-send.dev:3478".to_string()],
+        username: "u".into(),
+        credential: "p".into(),
+    }];
+    let base_issued = 1_700_000_000u64;
+    let base_expires = base_issued + 300;
+
+    // expired
+    let cred = TurnCredential::sign(
+        subject_pk,
+        base_servers.clone(),
+        base_issued,
+        base_expires,
+        &issuer,
+    )
+    .unwrap();
+    let err = cred
+        .verify(&subject_pk, &[issuer_pk], base_expires + 1)
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::ExpiredTurnCredential { .. }),
+        "{err:?}"
+    );
+
+    // overlong (sign() validates inputs via canonical_signing_bytes()).
+    let err = TurnCredential::sign(
+        subject_pk,
+        base_servers.clone(),
+        base_issued,
+        base_issued + MAX_CREDENTIAL_LIFETIME_SECS + 1,
+        &issuer,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::OverlongTurnCredential { .. }),
+        "{err:?}"
+    );
+
+    // wrong subject
+    let stranger = SigningKey::from_bytes(&[0x33u8; 32]).public_key();
+    let err = cred
+        .verify(&stranger, &[issuer_pk], base_issued + 1)
+        .unwrap_err();
+    assert!(matches!(err, Error::TurnSubjectMismatch), "{err:?}");
+
+    // untrusted issuer
+    let stranger_issuer = SigningKey::from_bytes(&[0x44u8; 32]).public_key();
+    let err = cred
+        .verify(&subject_pk, &[stranger_issuer], base_issued + 1)
+        .unwrap_err();
+    assert!(matches!(err, Error::UntrustedTurnIssuer), "{err:?}");
+
+    // tampered server credential
+    let mut tampered = cred.clone();
+    tampered.servers[0].credential = "evil".into();
+    let err = tampered
+        .verify(&subject_pk, &[issuer_pk], base_issued + 1)
+        .unwrap_err();
+    assert!(matches!(err, Error::BadSignature), "{err:?}");
+
+    // tampered signature
+    let mut tampered = cred.clone();
+    tampered.signature.0[0] ^= 0x01;
+    let err = tampered
+        .verify(&subject_pk, &[issuer_pk], base_issued + 1)
+        .unwrap_err();
+    assert!(matches!(err, Error::BadSignature), "{err:?}");
+
+    // empty servers — validate() is called from canonical_signing_bytes().
+    let empty = TurnCredential {
+        subject: subject_pk,
+        servers: vec![],
+        issued_at: base_issued,
+        expires_at: base_expires,
+        issuer: issuer_pk,
+        signature: SignatureBytes([0u8; 64]),
+    };
+    let err = empty.canonical_signing_bytes().unwrap_err();
+    assert!(matches!(err, Error::InvalidTurnCredential(_)), "{err:?}");
+
+    // non-turn URL
+    let bad_url = TurnCredential {
+        subject: subject_pk,
+        servers: vec![TurnServer {
+            urls: vec!["stun:stun.example:3478".into()],
+            username: "u".into(),
+            credential: "p".into(),
+        }],
+        issued_at: base_issued,
+        expires_at: base_expires,
+        issuer: issuer_pk,
+        signature: SignatureBytes([0u8; 64]),
+    };
+    let err = bad_url.canonical_signing_bytes().unwrap_err();
+    assert!(matches!(err, Error::InvalidTurnCredential(_)), "{err:?}");
+}
+
+#[test]
+fn negative_quota_vectors_reject() {
+    let v = load_vectors();
+    let issuer = issuer_sk(&v);
+    let subject = subject_sk(&v);
+    let issuer_pk = issuer.public_key();
+    let subject_pk = subject.public_key();
+
+    let names: Vec<String> = v["quota_tokens"]["negative"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["name"].as_str().unwrap().to_string())
+        .collect();
+    let expected = [
+        "consumed_exceeds_cap",
+        "window_secs_zero",
+        "window_secs_above_31_days",
+        "expired_token",
+        "overlong_token_lifetime",
+    ];
+    for n in expected {
+        assert!(
+            names.iter().any(|x| x == n),
+            "missing negative quota vector: {n}"
+        );
+    }
+
+    // consumed exceeds cap
+    let bad = QuotaToken {
+        subject: subject_pk,
+        window_start: 0,
+        window_secs: 86_400,
+        cap_bytes: 1000,
+        consumed_bytes: 1001,
+        issued_at: 0,
+        expires_at: 600,
+        issuer: issuer_pk,
+        signature: SignatureBytes([0u8; 64]),
+    };
+    assert!(matches!(
+        bad.canonical_signing_bytes().unwrap_err(),
+        Error::InvalidTurnCredential(_)
+    ));
+
+    // window_secs zero
+    let err = QuotaToken::sign(subject_pk, 0, 0, 1, 0, 0, 600, &issuer).unwrap_err();
+    assert!(matches!(err, Error::InvalidTurnCredential(_)), "{err:?}");
+
+    // window_secs > 31 days
+    let err = QuotaToken::sign(subject_pk, 0, 31 * 86_400 + 1, 1, 0, 0, 600, &issuer).unwrap_err();
+    assert!(matches!(err, Error::InvalidTurnCredential(_)), "{err:?}");
+
+    // expired
+    let tok = QuotaToken::sign(
+        subject_pk,
+        0,
+        86_400,
+        1,
+        0,
+        1_700_000_000,
+        1_700_000_060,
+        &issuer,
+    )
+    .unwrap();
+    let err = tok
+        .verify(&subject_pk, &[issuer_pk], 1_700_000_061)
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::ExpiredTurnCredential { .. }),
+        "{err:?}"
+    );
+
+    // overlong token lifetime
+    let err = QuotaToken::sign(
+        subject_pk,
+        0,
+        86_400,
+        1,
+        0,
+        0,
+        MAX_QUOTA_TOKEN_LIFETIME_SECS + 1,
+        &issuer,
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, Error::OverlongTurnCredential { .. }),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn issuer_keys_reproducible_across_runs() {
+    // Reproducibility check: the same seed always yields the same pubkey.
+    // This is the property the JSON vector relies on when it omits the
+    // hex/zbase32 form of the pubkey — readers can derive it themselves.
+    let v = load_vectors();
+    let pk_a: PublicKey = issuer_sk(&v).public_key();
+    let pk_b: PublicKey = issuer_sk(&v).public_key();
+    assert_eq!(pk_a, pk_b);
+    // And the same for the subject — used by every credential vector.
+    assert_eq!(subject_sk(&v).public_key(), subject_sk(&v).public_key());
+}

--- a/products/oh-send/LANDING.md
+++ b/products/oh-send/LANDING.md
@@ -1,0 +1,117 @@
+# oh-send landing page copy
+
+Source copy for `oh-send.dev`. The web client at `products/oh-send/web/` renders this content. Treat this file as the canonical text — if a headline changes here, it changes on the site.
+
+---
+
+## Hero
+
+### Headline
+
+**WeTransfer, without the upload.**
+
+### Subhead
+
+Drop a file. Get a link. The recipient opens it. The bytes go straight from your device to theirs — no server copy, no size cap, no account.
+
+### Primary CTA
+
+**Send a file** *(opens the drag-and-drop zone in place)*
+
+### Secondary CTA
+
+`brew install kaicoder03/openhost/oh-send` *(copy button)*
+
+---
+
+## The 5-second demo (above the fold, autoplays muted)
+
+Three-panel loop, 5 seconds total:
+
+1. **0–1.5s** — drag a `40 GB movie.mkv` into the browser. A link appears: `oh://kn7p…/9f2a`.
+2. **1.5–3s** — the recipient opens the link on another laptop. Browser shows "Connecting directly to sender…" then "Transferring — 1.2 GB/s."
+3. **3–5s** — progress bar fills. Caption overlay: *"No upload. No server copy. No size limit. No account."*
+
+No stock footage. No "actors looking at laptops." A real browser recording.
+
+---
+
+## Three-feature block (below the fold)
+
+### No upload step
+
+Traditional transfer tools upload your file to their servers first, then let the recipient download it. We skip the middleman. Your file streams directly from your device to theirs over an encrypted WebRTC channel. A 40 GB export starts playing on the other end before it would have finished uploading to WeTransfer.
+
+### True end-to-end encryption, by default
+
+DTLS 1.3 with ChaCha20-Poly1305, channel-bound per RFC 8844. The keys are generated on your device and never leave it. We can't read your files. We couldn't decrypt them if we wanted to. We couldn't hand them over if a government asked. There is nothing to hand over.
+
+### No account. Ever.
+
+Your identity is an Ed25519 public key generated in your browser. No email, no password, no "sign in with Google." The recipient needs nothing installed — they just open the link. This isn't a free tier we'll take away later; it's how the protocol works.
+
+---
+
+## Comparison strip (single row, scannable)
+
+| | oh-send | WeTransfer | Dropbox Transfer | Wormhole.app |
+|---|---|---|---|---|
+| Max file size (free) | **Unlimited** | 2 GB | 100 MB | 10 GB |
+| Server sees your file | **Never** | Yes | Yes | Encrypted, but held |
+| Account required | **No** | Recipient: no, Sender: yes | Yes | No |
+| Works across any network | **Yes** | Yes | Yes | Yes |
+| Open-source protocol | **Yes** | No | No | No |
+| Price | **Free** | $12/mo for 20 GB | $10/mo | Free |
+
+Footnote: when a direct connection isn't possible (8–12% of sessions, typically strict corporate firewalls or cellular carrier-grade NAT) we fall back to an encrypted relay. The relay can see ciphertext but not plaintext, and free accounts get 5 GB of relayed traffic per month before we ask you to upgrade.
+
+---
+
+## How it actually works (for skeptics, expandable section)
+
+1. Your browser generates an Ed25519 keypair. Never leaves the device.
+2. The public key is published to the Mainline DHT as a signed [Pkarr](https://pkarr.org) record — the same DHT that backs BitTorrent, decentralized and not operated by us.
+3. The recipient's browser resolves the record, fetches your WebRTC offer, and attempts ICE hole-punching directly to your device.
+4. DTLS 1.3 handshake with ChaCha20-Poly1305. Channel-bound using the DTLS exporter so [RFC 8844 unknown-key-share attacks](https://datatracker.ietf.org/doc/html/rfc8844) can't redirect your file.
+5. Bytes stream. We see nothing. The spec is public at [github.com/kaicoder03/openhost/tree/main/spec](https://github.com/kaicoder03/openhost/tree/main/spec).
+
+If you'd rather run it yourself: `brew install kaicoder03/openhost/openhost` on your laptop, add the recipient's pubkey to your allowlist, and you've got a fully self-hosted, identity-pinned transfer channel. No oh-send.dev involved.
+
+---
+
+## FAQ
+
+**How is this different from AirDrop?**
+AirDrop only works between Apple devices on the same Wi-Fi. oh-send works across any network and any OS — Windows to Mac, phone to laptop, across the world.
+
+**How is this different from Signal file send?**
+Signal caps files at ~100 MB. oh-send has no cap. Also: Signal requires a phone number; oh-send requires nothing.
+
+**What if I close the tab mid-transfer?**
+The transfer fails. There is no server copy to resume from. The recipient can re-request and the transfer restarts. This is a deliberate trade-off for zero server-side persistence. Resumable transfers (with the ciphertext staged on our relay for you, keys still local) land in the Pro tier — opt-in, not default.
+
+**Is this legal for HIPAA / GDPR?**
+The protocol is designed to be compatible with both because we are not a data processor — we never touch your file. Teams plan (Q3 2026) adds signed BAA/DPA, audit logs, and SOC2 Type I documentation. Ask us.
+
+**Why should I trust you?**
+Don't. Read [the spec](https://github.com/kaicoder03/openhost/tree/main/spec), run the daemon yourself, and verify the browser build is reproducible (coming with Phase 3 of the roadmap). oh-send.dev is a convenience; the protocol doesn't need us.
+
+**What happens when I run out of free relayed bandwidth?**
+Direct transfers still work (most of the time they already are direct). When a transfer needs the relay and you're over the 5 GB/month free limit, we ask you to upgrade or wait until next month. We never silently downgrade your transfer or touch the file contents.
+
+---
+
+## Footer
+
+Open source. [Spec](https://github.com/kaicoder03/openhost/tree/main/spec) · [Source](https://github.com/kaicoder03/openhost) · [Security](https://github.com/kaicoder03/openhost/blob/main/SECURITY.md) · [Status](https://status.oh-send.dev)
+
+---
+
+## Copy-writing notes (for internal review, remove before deploy)
+
+- **Voice:** technical, unapologetic, a little proud. Our readers are developers, homelabbers, and privacy-careful prosumers. They can tell when marketing copy is bullshit; don't write any.
+- **Words to avoid:** "seamless," "effortless," "secure" (unqualified), "military-grade," "blockchain," "revolutionary," "empower," any adjective that could describe literally any SaaS.
+- **Words to keep:** "directly," "no server copy," "by default," "open-source," concrete file sizes, concrete percentages.
+- **The 5-second demo is the most important asset on the page.** If we can't ship a real recording that makes the magic moment obvious, we are not ready to launch.
+- **Do not lead with encryption.** Lead with the user-visible benefit ("no upload step"). Encryption is *how*, not *why*.
+- **Comparison table must be honest.** If Wormhole.app raises their cap, we update the table. Trust compounds.

--- a/products/oh-send/README.md
+++ b/products/oh-send/README.md
@@ -1,0 +1,51 @@
+# oh-send
+
+Developer-first ad-hoc file transfer built on openhost. Ships as a web app (WASM client) and a CLI; both reuse the `openhost-client` crate so every bytes-on-the-wire guarantee of the core protocol applies unchanged.
+
+## Why this lives inside the openhost monorepo
+
+oh-send is the first commercial surface on top of the openhost protocol. During Y1 the product and the core protocol will iterate together — wire-format changes, streaming transfer, TURN fallback — and one repo means one CI, one release cadence, and no version-skew debugging. At M9, once the protocol surface stabilizes for external consumers, oh-send can be extracted to its own repo; the crate boundaries are already clean.
+
+The openhost workspace stays the **core**: protocol, daemon, client, spec. Nothing under `products/` is a dependency of anything under `crates/`. `products/` depends on `crates/`, never the reverse.
+
+## Relationship to existing repo layout
+
+```
+openhost/
+├── crates/               # core protocol — do not depend on products/
+│   ├── openhost-core
+│   ├── openhost-pkarr
+│   ├── openhost-pkarr-wasm
+│   ├── openhost-daemon
+│   ├── openhost-client
+│   └── openhost-ffi
+├── spec/                 # wire format, security model — source of truth
+├── site/                 # project docs (docs.openhost.dev)
+├── extension/            # browser extension (Phase 3 roadmap)
+├── apple/                # iOS/macOS native shells (Phase 3+ roadmap)
+└── products/
+    └── oh-send/          # THIS DIRECTORY
+        ├── LANDING.md    # marketing copy for oh-send.dev
+        ├── TICKETS.md    # 90-day execution plan
+        ├── web/          # WASM + TS web client (added in T-03)
+        └── cli/          # thin wrapper over openhost-client (added in T-02)
+```
+
+## Product surface
+
+Two entry points, same protocol:
+
+1. **Web** (`oh-send.dev`) — drag-and-drop in the browser, consumes `openhost-pkarr-wasm` + a WASM build of `openhost-client`. No install. This is the acquisition surface.
+2. **CLI** (`oh-send`) — Homebrew + scoop + curl installer. Re-exports `openhost-dial` with a transfer-shaped UX (`oh-send ./file.mp4` prints a shareable URL). This is the power-user surface.
+
+Both produce the same `oh://<pubkey>/<token>` URL. A recipient opens it in either surface; the bytes flow peer-to-peer through whichever path NAT allows.
+
+## Explicit non-goals (Y1)
+
+- No cloud storage, no account system, no sync, no team workspaces (Teams tier is added on top in `products/oh-business/` in Y2).
+- No mobile app — that's `products/oh-drop/`, launched M18.
+- No paid features that break P2P purity — any Pro feature must be implementable without a server-side copy of the file.
+
+## Current status
+
+Scaffolding only. See `TICKETS.md` for the 90-day sequence; `LANDING.md` for the copy the web client will render.

--- a/products/oh-send/TICKETS.md
+++ b/products/oh-send/TICKETS.md
@@ -1,0 +1,208 @@
+# oh-send — 90-day ticket scope
+
+Q2 2026. Twelve tickets across three tracks (protocol, product, launch). Each ticket names its dependency on the existing `ROADMAP.md` phases and its acceptance criteria.
+
+Sequencing assumption: the Phase 1 items in `ROADMAP.md` (answer-SDP chunking, `openhost-dial` CLI, pair-DB hot reload) are either landed or near-landed; recent commits (`4814fc8`, `9b8cef1`, `fb82fd4`, `291debd`) suggest the wire-format and daemon work is tracking. This plan picks up from that baseline.
+
+Estimates are calendar weeks assuming a 4-person team (2 Rust/systems, 1 TS/WASM, 1 design — per business plan §10). A `★` marks the critical path.
+
+---
+
+## Track 1 — Protocol work that unblocks the product
+
+### T-01 ★ TURN fallback, geo-routed
+**Depends on:** Phase 1 landed.
+**Blocks:** T-05, T-07, T-10.
+**Estimate:** 3 weeks.
+
+Ship encrypted relay fallback for the 8–12% of sessions where direct connection fails (symmetric NAT, CGNAT, strict corporate firewalls). Run `coturn` in three regions (US-East, EU-Central, AP-Singapore) on Hetzner; geo-route via DNS; authenticate short-lived TURN credentials from a minimal REST API signed by the sender's Ed25519 key so anonymous free-tier use can't be abused.
+
+**Acceptance:**
+- Session-level `relayed_byte_ratio` metric exported; weekly review KPI.
+- Free-tier hard cap at 5 GB/month relayed, enforced server-side by Ed25519-signed quota tokens.
+- Connection success rate ≥ 99% across a test matrix of 20 NAT topologies (document the matrix).
+- Ciphertext still opaque to the relay — add a conformance test that asserts the relay sees only ChaCha20-Poly1305 records.
+- ~$180/month infra cost documented and paid from the seed round, not personal cards.
+
+### T-02 Streaming transfer (files > RAM)
+**Depends on:** Phase 1 landed.
+**Blocks:** T-05, credibility of the "unlimited size" claim on landing page.
+**Estimate:** 4 weeks.
+
+Today `openhost-client` assumes an in-memory buffer. Move to a chunked/streaming API in the `openhost-client` crate with backpressure, resumable chunk acknowledgment, and integrity framing (per-chunk MAC, not just whole-file). The CLI ships the `oh-send file.mkv` UX on top.
+
+**Acceptance:**
+- Public API change documented in `crates/openhost-client/CHANGELOG.md`.
+- 100 GB end-to-end transfer test in CI (or nightly, if CI runners can't allocate).
+- Memory ceiling ≤ 64 MB at any transfer size.
+- Benchmark: ≥ 80% of raw link bandwidth on loopback; ≥ 60% across a 50 ms RTT link.
+- Fuzz tests for the chunk framing.
+
+### T-03 WASM build of `openhost-client`
+**Depends on:** existing `openhost-pkarr-wasm`.
+**Blocks:** T-05.
+**Estimate:** 2 weeks.
+
+Compile the transfer client itself to `wasm32-unknown-unknown`, not just the Pkarr resolver. The extension work (`ROADMAP.md` Phase 3) scaffolds some of this; oh-send needs the transfer-specific surface exposed. Reproducible builds from day one — pin the toolchain in `rust-toolchain.toml`, verify binary hash in CI.
+
+**Acceptance:**
+- `wasm-pack build` produces a < 450 KB compressed artifact.
+- Reproducible build: two independent builds produce byte-identical artifacts.
+- Browser support matrix: Chrome ≥ 120, Firefox ≥ 115, Safari ≥ 17. Document any gaps (Safari WebRTC data-channel quirks suspected).
+- Audit the WASM sandbox for `spec/04-security.md` threat-model compliance.
+
+### T-04 Pkarr relay cluster (self-operated)
+**Depends on:** Phase 1 landed.
+**Blocks:** launch reliability.
+**Estimate:** 1.5 weeks.
+
+Today we rely on the public Pkarr relay pool and the public Mainline DHT. For launch, run our own Pkarr relay in the same three regions as TURN so we're not single-pointed on upstream operator liveness. Contribute any fixes back upstream to the `pkarr` project.
+
+**Acceptance:**
+- 99.5% monthly uptime SLO on our Pkarr relays, monitored with Prometheus.
+- Client resolver prefers our relays but retains the public pool as fallback — never hard-dependent on us.
+- Upstream PR opened for at least one issue we hit during operation (signal of "we're contributing, not just consuming").
+
+---
+
+## Track 2 — Product surface
+
+### T-05 ★ `oh-send.dev` web client (alpha)
+**Depends on:** T-01, T-03.
+**Blocks:** T-09, T-11.
+**Estimate:** 4 weeks.
+
+Drag-and-drop single-page app at `oh-send.dev`. Renders the copy in `LANDING.md`. Wraps the T-03 WASM client. No server-side component except a static CDN (Cloudflare Pages). Pubkey generated in-page, stored in `indexedDB` with an export-to-file option.
+
+**Acceptance:**
+- Lighthouse ≥ 95 on performance, accessibility, best practices.
+- First meaningful paint < 1.2 s on a cable connection, < 2.5 s on 3G Slow.
+- No third-party JS in the critical path (analytics via self-hosted PostHog, error tracking via Sentry — both lazy-loaded).
+- Works on Chrome/Firefox/Safari/mobile Safari/Chrome-Android.
+- Keyboard navigable, screen-reader-tested on VoiceOver + NVDA.
+- End-to-end test: drop a 1 GB file, copy link, open in another browser on another machine, receive the file, byte-hash matches.
+
+### T-06 `oh-send` CLI
+**Depends on:** T-02.
+**Estimate:** 1.5 weeks.
+
+Thin wrapper over `openhost-dial` with transfer-shaped UX. `oh-send ./file.mkv` prints a link, pins the sending session until the recipient connects (or timeout flag). `oh-send recv oh://…` receives. Homebrew tap (tracks `ROADMAP.md` Phase 3 distributable-binaries item).
+
+**Acceptance:**
+- `brew install kaicoder03/openhost/oh-send` works on macOS arm64 + x86_64.
+- `curl -sSL install.oh-send.dev | sh` works on Linux.
+- Scoop bucket for Windows (can land after launch if behind).
+- `--json` output mode for scripting.
+- `oh-send --version` matches `openhost-client` version from the workspace.
+
+### T-07 Pairing UX — QR code + four-word fingerprint
+**Depends on:** T-01, T-03.
+**Blocks:** T-05 polish.
+**Estimate:** 2 weeks.
+
+Most transfer sessions are one-shot link-sends; but recurring-recipient pairing (the core allowlist flow) needs a UX that isn't "paste this base32 blob." Ship both a QR code (scan with phone to auto-pair) and a BIP39-style four-word fingerprint (speakable over the phone) — `spec/04-security.md` §7.3 already specs the fingerprint.
+
+**Acceptance:**
+- Sender and recipient see the same four words before the first transfer.
+- QR code pairing works on iOS 16+ and Android 12+ camera apps (no custom app needed).
+- Visual design reviewed and approved by the designer hire (per business plan §10).
+
+### T-08 In-browser identity persistence + export
+**Depends on:** T-03.
+**Estimate:** 1 week.
+
+IndexedDB-backed key storage; one-click encrypted export to a paper-backup JSON; one-click restore. No cloud sync in Y1 — users who need cross-device identity use the CLI or the future Drop app.
+
+**Acceptance:**
+- Key never leaves the browser unless the user explicitly clicks export.
+- Export file is encrypted with a user-chosen passphrase (Argon2id + ChaCha20-Poly1305).
+- Clear warning UX if the user clears browser storage ("your identity is gone; that's what you asked for").
+
+---
+
+## Track 3 — Launch operations
+
+### T-09 ★ Landing page, demo video, docs
+**Depends on:** T-05 alpha.
+**Estimate:** 2 weeks.
+
+Deploy `LANDING.md` as the production site. Record the 5-second demo (real browser, no stock footage, no "actor looking at laptop" cliché). Ship `/docs` with the protocol explainer, self-host guide, and comparison pages targeting "WeTransfer alternative," "Send Anywhere alternative," "Dropbox Transfer alternative," "HIPAA file transfer" keywords.
+
+**Acceptance:**
+- Demo video < 2 MB (we're not a streaming service; don't embed YouTube).
+- Comparison pages cite sources for every competitor claim. Update quarterly.
+- `/status` page live and linked in footer.
+- Privacy policy and terms reviewed by counsel before launch (not after).
+
+### T-10 Observability + abuse signals
+**Depends on:** T-01, T-05.
+**Estimate:** 1.5 weeks.
+
+Aligns with `ROADMAP.md` Phase 3 observability item. Ship `/health` on the daemon, Prometheus metrics, structured logs. Add a minimal abuse-signal pipeline: Pkarr pubkeys reported for distributing reported content get flagged (we can't read content, but we can observe *that* a pubkey is mass-fanning out links). Publish a transparency report template at M12.
+
+**Acceptance:**
+- Grafana dashboard reviewed by the on-call rotation before launch.
+- PagerDuty / Opsgenie alerts for: Pkarr relay down, TURN region down, relayed-byte ratio > 15%, error budget burn.
+- Abuse-signal pipeline documented in `SECURITY.md` with clear scope (we log metadata only, never content; we never decrypt).
+
+### T-11 ★ HN / r/selfhosted / Lobsters launch
+**Depends on:** T-05, T-09, T-10.
+**Estimate:** launch week (day 1 HN, week 1 follow-ups).
+**Not shipped before:** every Track 1 + Track 2 ticket above is closed.
+
+Dual-post: HN ("Show HN: oh-send — WeTransfer without the upload") and r/selfhosted (lead with the self-host pitch, not the hosted product). Lobsters a day later. Prep the `README.md` and repo top-of-file for a flood of first-time visitors. Assign on-call for launch day.
+
+**Acceptance:**
+- ≥ 50k unique visitors week-one.
+- ≥ 1k self-host installs reporting via opt-in telemetry.
+- Zero credential-exposure / takedown / abuse incident in launch week (if this fails we pause paid launch).
+- Post-mortem written in week 2, regardless of outcome.
+
+### T-12 Paid launch (Pro tier, $5/mo)
+**Depends on:** T-11 stable, T-01 TURN quota enforcement watertight.
+**Estimate:** 2 weeks, starts M5.
+**Post-launch gate:** relayed-byte ratio ≤ 12% and no sustained incident for 4 weeks.
+
+Stripe integration. Pro unlocks: multi-concurrent transfers, 100 GB/month relayed, custom `oh-send.dev/<handle>` vanity URL, 30-day pair history, priority support (shared inbox SLA). No feature that requires us to see file contents. Pricing: $5/mo or $48/yr.
+
+**Acceptance:**
+- Stripe webhook handler is idempotent and tested.
+- Customer-portal self-service for billing changes (no support-ticket bottleneck).
+- First 200 Pro subs targeted by M6 per business plan §12.
+
+---
+
+## Calendar (aggregated)
+
+```
+Week:        1  2  3  4  5  6  7  8  9  10 11 12 13
+T-01 TURN    ▓▓▓▓▓▓▓▓▓▓▓▓
+T-02 stream  ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+T-03 WASM             ▓▓▓▓▓▓▓▓
+T-04 Pkarr            ▓▓▓▓▓▓
+T-05 web                      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+T-06 CLI                          ▓▓▓▓▓▓
+T-07 pair                                ▓▓▓▓▓▓▓▓
+T-08 idp                                 ▓▓▓▓
+T-09 landing                                   ▓▓▓▓▓▓▓▓
+T-10 obs                                          ▓▓▓▓▓▓
+T-11 launch                                             ▓▓
+T-12 paid                        (starts M5 — outside 90-day window)
+```
+
+Critical path is T-01 → T-03 → T-05 → T-09 → T-11. Everything else is parallelizable.
+
+## Risks this plan does not yet mitigate
+
+- If T-01 slips by more than 2 weeks, the launch date (week 13) slips 1:1. Budget 20% schedule risk on T-01 specifically — it depends on operational unknowns (NAT variety in the real world).
+- If the Safari WebRTC data-channel quirks we flagged in T-03 turn out to be blocking (not just slow), Safari support moves to fast-follow and we launch Chrome + Firefox only. Decision gate at end of week 4.
+- If the designer hire (business plan §10) lands later than week 3, T-07 starts late; pairing UX is the weakest plausible product area and we should not ship without design review.
+
+## What this plan does not include
+
+- Marketing spend (no paid ads in the 90 days — see business plan §8).
+- Teams tier (Q3 2026, separate scope doc in `products/oh-business/` when we get there).
+- Drop native apps (M15+ per business plan §12).
+- SOC2 (M18 per business plan §12).
+
+Update this doc in-place as tickets land; do not create a parallel tracking surface.

--- a/spec/05-turn-credentials.md
+++ b/spec/05-turn-credentials.md
@@ -1,0 +1,220 @@
+---
+title: TURN Credentials and Quota Tokens
+---
+
+# TURN Credentials and Quota Tokens
+
+**Status:** Draft (v0.3). This document is normative for TURN-relay fallback behavior in openhost implementations.
+
+TURN is only reached when direct ICE (host + srflx candidates, optionally with STUN help) fails — see [`04-security.md`](04-security.md) §3 row 7.5 and the business-plan target of keeping the relayed-byte ratio ≤ 12%. When TURN is used it MUST remain cryptographically opaque to the relay: the DTLS session between client and daemon is never broken, terminated, or observed by any TURN server.
+
+## 1. Invariants
+
+Every TURN-aware openhost implementation MUST preserve these invariants. They are additions to, not replacements for, the invariants in `04-security.md §1`.
+
+1. **The TURN server never observes plaintext.** The relay sees only ChaCha20-Poly1305-sealed DTLS records. An implementation MUST fail closed rather than downgrade to an unencrypted relay.
+2. **TURN credentials are authenticated to a specific subject.** A valid credential identifies *which* Ed25519 pubkey is authorised to use it; a third party intercepting a credential on the wire gains no ability to reuse it against a well-configured relay (coturn `use-auth-secret` + IP pinning).
+3. **A TURN credential has an explicit expiry.** Implementations MUST reject credentials whose `expires_at` is in the past or more than `MAX_CREDENTIAL_LIFETIME_SECS` beyond `issued_at`.
+4. **A quota token has an explicit window and cap.** An implementation MUST NOT allow relayed traffic to exceed the cap; it MUST be able to prove (via local counters) how many bytes it has relayed within the window.
+5. **Credentials and quota tokens are Ed25519-signed by a trusted issuer.** Clients and daemons configure the issuer pubkey out-of-band (daemon config or environment). Unsigned, expired, or mis-signed artifacts MUST be rejected.
+
+## 2. When TURN is used
+
+A TURN server appears in the `ice_servers` list handed to `webrtc-rs`'s `RTCConfiguration` only when one of the following holds:
+
+1. The client has been configured with **static TURN servers** (long-lived, operator-managed coturn accounts) via `[turn.static_servers]` in daemon config or `DialerBuilder::static_turn_servers`.
+2. The client has been configured with a **trusted issuer pubkey** and has obtained a fresh, signed `TurnCredential` for its own pubkey from that issuer.
+
+In both cases the TURN entries are *added to*, not substituted for, the STUN entries already present. ICE continues to prefer direct paths; TURN candidates are used only when no direct path is viable.
+
+## 3. `TurnServer`
+
+A `TurnServer` is the concrete `ice_servers` entry fed into the peer connection.
+
+```text
+struct TurnServer {
+    urls:        Vec<String>   // RFC 7065 URIs, e.g. "turn:relay.example:3478?transport=udp"
+    username:    String        // RFC 8489 long-term credential username, ≤ 512 bytes
+    credential:  String        // RFC 8489 long-term credential password, ≤ 512 bytes
+}
+```
+
+The three fields map 1:1 to `webrtc::ice_transport::ice_server::RTCIceServer { urls, username, credential, .. }`.
+
+### 3.1 URL rules
+
+Every URL in `urls` MUST begin with `turn:` or `turns:`. Plain `stun:` URLs are carried by a separate config knob (they have no credential and never participate in quota). `turns:` (TURN-over-TLS) is the recommended transport on networks where UDP 3478 is blocked; implementations MUST NOT reject `turns:` URLs on the grounds that STUN allocation over TLS is slower — the user's network may have no faster path.
+
+## 4. `TurnCredential`
+
+A `TurnCredential` is an issuer-signed bundle naming the subject pubkey, the TURN servers the subject may use, and a tight expiry.
+
+```text
+struct TurnCredential {
+    subject:     PublicKey      // 32 bytes, Ed25519 — the pubkey authorised to use these servers
+    servers:     Vec<TurnServer>
+    issued_at:   u64            // Unix seconds
+    expires_at:  u64            // Unix seconds, ≥ issued_at, ≤ issued_at + MAX_CREDENTIAL_LIFETIME_SECS
+    issuer:      PublicKey      // 32 bytes, Ed25519 — pubkey of the issuer
+    signature:   [u8; 64]       // Ed25519 signature by `issuer` over canonical_signing_bytes()
+}
+```
+
+- `MAX_CREDENTIAL_LIFETIME_SECS = 3_600` (one hour). Issuers typically mint credentials valid for ≤ 300 s; the one-hour ceiling is a hard cap for verifiers.
+- A credential with `servers.is_empty()` is invalid; reject with `InvalidTurnCredential("empty server list")`.
+
+### 4.1 Canonical signing bytes
+
+```text
+canonical = 0x02                                 // encoding tag for TURN artifacts (distinct from pkarr_record's 0x01)
+         || "openhost-turn-credential-v1"        // 27 ASCII bytes, domain separator
+         || subject    (32 bytes)
+         || issuer     (32 bytes)
+         || issued_at  (8 bytes, u64 BE)
+         || expires_at (8 bytes, u64 BE)
+         || server_count (2 bytes u16 BE)
+         || for each server, in list order:
+              url_count (1 byte)
+              for each URL: url_len (2 bytes u16 BE) || url_bytes
+              username_len (2 bytes u16 BE) || username_bytes
+              credential_len (2 bytes u16 BE) || credential_bytes
+```
+
+Rationale for the layout: length-prefixed and explicit so canonical bytes are stable across any serde representation and across implementations. The domain separator differs from pkarr-record's `"openhost1"` so a signature lifted from one context cannot be replayed into the other.
+
+### 4.2 Verification procedure
+
+Given a `TurnCredential` and the verifier's trusted issuer pubkey set:
+
+1. Reject if `issuer` ∉ trusted set.
+2. Reject if `expires_at < now_ts` (expired).
+3. Reject if `expires_at > issued_at + MAX_CREDENTIAL_LIFETIME_SECS` (over-long).
+4. Reject if `servers.is_empty()`.
+5. Reject if any server URL does not begin with `turn:` or `turns:`.
+6. Compute `canonical = canonical_signing_bytes(&credential)`; verify `Ed25519.verify(issuer, canonical, signature)` with strict canonicalization.
+7. Reject if `subject` does not match the verifier's own pubkey (clients MUST refuse to use a credential issued to someone else).
+
+## 5. `QuotaToken`
+
+A quota token is an issuer-signed assertion of how much relayed traffic a subject pubkey may consume within a fixed window. It is carried alongside (not inside) a `TurnCredential` and is refreshed independently.
+
+```text
+struct QuotaToken {
+    subject:         PublicKey      // 32 bytes
+    window_start:    u64            // Unix seconds, start of the quota window
+    window_secs:     u64            // window duration; MUST be ≤ 31 * 86_400
+    cap_bytes:       u64            // maximum relayed bytes permitted in the window
+    consumed_bytes:  u64            // bytes already relayed at issuance time, ≤ cap_bytes
+    issued_at:       u64
+    expires_at:      u64            // ≤ issued_at + MAX_QUOTA_TOKEN_LIFETIME_SECS
+    issuer:          PublicKey
+    signature:       [u8; 64]
+}
+```
+
+- `MAX_QUOTA_TOKEN_LIFETIME_SECS = 900` (15 minutes). Quota tokens are refreshed frequently so the issuer can adjust `consumed_bytes` as traffic accrues.
+- `consumed_bytes` at verification time is a floor, not a ceiling: the client MAY have relayed additional bytes since the token was issued, and is obligated to track them locally. Clients MUST stop relaying new bytes when `local_counter + consumed_bytes ≥ cap_bytes`.
+
+### 5.1 Canonical signing bytes
+
+```text
+canonical = 0x02
+         || "openhost-turn-quota-v1"              // 22 ASCII bytes
+         || subject        (32 bytes)
+         || issuer         (32 bytes)
+         || window_start   (8 bytes u64 BE)
+         || window_secs    (8 bytes u64 BE)
+         || cap_bytes      (8 bytes u64 BE)
+         || consumed_bytes (8 bytes u64 BE)
+         || issued_at      (8 bytes u64 BE)
+         || expires_at     (8 bytes u64 BE)
+```
+
+### 5.2 Verification procedure
+
+1. Reject if `issuer` ∉ trusted set.
+2. Reject if `expires_at < now_ts` or `expires_at > issued_at + MAX_QUOTA_TOKEN_LIFETIME_SECS`.
+3. Reject if `consumed_bytes > cap_bytes`.
+4. Reject if `window_secs == 0` or `window_secs > 31 * 86_400`.
+5. Reject if `subject` ≠ verifier's own pubkey.
+6. Verify Ed25519 signature as in §4.2 step 6.
+
+## 6. Relayed-byte accounting
+
+Implementations MUST maintain a per-session atomic counter of bytes relayed through TURN. "Relayed" means "traversed a TURN server as a `send` / `data` indication" — not "sent across the WebRTC data channel" (direct-path bytes are not relayed).
+
+Whether a session's bytes are relayed is determined from the ICE candidate pair actually in use. webrtc-rs exposes this via `RTCPeerConnection::get_stats()`; implementations SHOULD sample the selected candidate pair on `iceconnectionstatechange` and again on session teardown, and MUST count bytes towards the relayed counter only while the selected pair's local candidate type is `relay`.
+
+An implementation that cannot distinguish relayed from direct bytes MUST conservatively count all bytes as relayed when a TURN server is configured — over-counting is safer than under-counting for quota enforcement.
+
+## 7. Transport of credentials and tokens
+
+Credentials and quota tokens are transported as UTF-8 JSON when moving between issuer and subject (HTTPS POST to the issuer's REST endpoint in the production deployment; arbitrary out-of-band transport in self-hosted deployments):
+
+```json
+{
+  "subject":    "<z-base-32 pubkey, 52 chars>",
+  "servers": [
+    {
+      "urls": ["turn:relay.example:3478?transport=udp"],
+      "username": "1700000000:47pjoycn…",
+      "credential": "base64-HMAC-SHA1-over-username"
+    }
+  ],
+  "issued_at":  1700000000,
+  "expires_at": 1700000300,
+  "issuer":     "<z-base-32 pubkey, 52 chars>",
+  "signature":  "<base64url-no-pad, 64 bytes raw Ed25519 signature>"
+}
+```
+
+Pubkeys use z-base-32 (identity.md §1). Signatures use base64url-no-pad (same encoding as the sealed-offer TXT in `03-pkarr-records.md §3.3`). An implementation MUST reject JSON with unknown fields (`deny_unknown_fields`) to keep the signed payload and the parsed payload in lockstep.
+
+## 8. Security considerations
+
+### 8.1 Issuer compromise
+
+Every credential and token is gated on a single issuer pubkey. Compromise of the issuer's signing key lets an attacker mint credentials for any subject. Mitigations:
+
+- **Short-lived credentials** (≤ 1 hour) cap the post-compromise damage window.
+- **Ed25519 key pinning** in client and daemon config — an attacker must also compromise the config supply chain to redirect to a new issuer.
+- **Issuer key rotation** is a planned follow-up; v0.3 does not specify a rotation envelope. Until rotation ships, operators MUST rotate by pushing a new config pinning a new issuer pubkey and revoking the old one at the trust boundary.
+
+### 8.2 Credential reuse
+
+A stolen credential is reusable against the TURN relay up to `expires_at`. The subject pubkey field is advisory — coturn's long-term credential mechanism has no knowledge of Ed25519. Relay-side defenses:
+
+- **IP pinning** in coturn (`allowed-peer-ip` + issuance-time client-IP lock) closes the steal-and-reuse window in most cases.
+- **Per-subject quota tokens** cap the damage a stolen credential can inflict regardless of relay-side pinning.
+
+### 8.3 Quota token replay
+
+A quota token with `consumed_bytes = 0` is more valuable than one with `consumed_bytes = 4_000_000_000` — an attacker who captures a fresh token and keeps it alive beyond `expires_at` would get unbounded free bytes until expiry. Mitigations:
+
+- `MAX_QUOTA_TOKEN_LIFETIME_SECS = 900` bounds the attack window.
+- Issuers SHOULD serve tokens over TLS only; an on-path attacker who cannot read TLS cannot replay tokens.
+
+### 8.4 No plaintext observation by the relay
+
+The DTLS session rides *inside* the TURN `ChannelData` or `SEND`/`DATA` indications. coturn sees only ChaCha20-Poly1305 ciphertext. A conformance test in `openhost-core/tests/turn_opacity.rs` MUST assert that a relay-side observer captures no plaintext payload bytes.
+
+### 8.5 TURN-server authentication substrate
+
+This document is deliberately agnostic about whether the `TurnServer::credential` is derived via coturn's `use-auth-secret` REST flow or issued as static long-lived user/password pairs. Both are valid; the choice is an operator decision and is reflected in how the issuer (if any) mints credentials. Clients consume credentials by reference; they do not implement the TURN auth substrate themselves — that work happens on the relay.
+
+## 9. Test vectors
+
+See [`test-vectors/turn_credentials.json`](test-vectors/turn_credentials.json). The fixtures cover:
+
+- A well-formed credential that verifies under its issuer pubkey.
+- A well-formed quota token that verifies under its issuer pubkey.
+- Negative vectors: expired, over-long-lived, wrong-subject, tampered-server, tampered-signature, unknown issuer.
+
+Every openhost implementation MUST pass the positive vectors and MUST reject every negative vector. Implementations MAY regenerate signatures when the Ed25519 seed is held deterministic, but MUST NOT accept negative vectors after any regeneration.
+
+## 10. Out of scope for v0.3
+
+- **The issuer REST API surface.** The HTTP shape (`POST /v1/turn-credential`, request body, rate-limiting headers) is defined in a follow-up document (`05.1-turn-issuer-api.md`) shipped with the `openhost-turn-issuer` crate.
+- **Prometheus exposition format.** `RelayedByteCounter` is the underlying primitive; the Prometheus adapter is a follow-up.
+- **Per-session TLS pinning from client to issuer.** TLS via the system trust store is sufficient for v0.3; pinning is a hardening follow-up.
+- **Issuer key rotation envelope.** See §8.1.

--- a/spec/test-vectors/turn_credentials.json
+++ b/spec/test-vectors/turn_credentials.json
@@ -1,0 +1,137 @@
+{
+  "description": "openhost TURN credential and quota token vectors. Every implementation MUST verify the positive vectors and reject every negative vector. See spec/05-turn-credentials.md for the canonical signing rules.",
+  "version": "openhost-turn-v1",
+  "encoding_notes": [
+    "All hex byte strings are lowercase, no separators, big-endian unless noted.",
+    "Pubkeys appear in two forms: `*_hex` (raw 32 bytes) and `*_zbase32` (52 ASCII chars per identity.json). Both forms MUST decode to identical bytes.",
+    "Signatures are 64-byte raw Ed25519 outputs, displayed as base64url-no-pad to match wire format.",
+    "Issuer signing seed is deterministic so signatures are reproducible: 0x11 repeated 32 times.",
+    "Subject signing seed is 0x22 repeated 32 times.",
+    "Negative vectors carry only the field(s) the verifier needs to reject; positive `canonical_hex` and `signature_b64url` are omitted where they would be misleading."
+  ],
+  "issuer": {
+    "signing_seed_hex": "1111111111111111111111111111111111111111111111111111111111111111",
+    "comment": "Public key + z-base-32 form derived from the seed at test time via ed25519-dalek; not duplicated here to avoid drift with the upstream library's canonicalisation."
+  },
+  "subject": {
+    "signing_seed_hex": "2222222222222222222222222222222222222222222222222222222222222222",
+    "comment": "Public key + z-base-32 form derived from the seed at test time."
+  },
+  "credentials": {
+    "positive": [
+      {
+        "name": "well_formed_5min_credential",
+        "subject_zbase32": "<derive from subject seed at test time>",
+        "issuer_zbase32": "<derive from issuer seed at test time>",
+        "issued_at": 1700000000,
+        "expires_at": 1700000300,
+        "servers": [
+          {
+            "urls": [
+              "turn:relay.oh-send.dev:3478?transport=udp",
+              "turns:relay.oh-send.dev:5349?transport=tcp"
+            ],
+            "username": "1700000000:qogner",
+            "credential": "deadbeefcafef00d"
+          }
+        ],
+        "verifier_now_ts": 1700000100,
+        "expect_verify": "ok"
+      }
+    ],
+    "negative": [
+      {
+        "name": "expired_credential",
+        "issued_at": 1700000000,
+        "expires_at": 1700000300,
+        "verifier_now_ts": 1700000301,
+        "expect_error": "ExpiredTurnCredential"
+      },
+      {
+        "name": "overlong_lifetime",
+        "issued_at": 1700000000,
+        "expires_at_offset_from_issued_at": 3601,
+        "expect_error": "OverlongTurnCredential"
+      },
+      {
+        "name": "wrong_subject",
+        "verifier_subject_seed_hex": "3333333333333333333333333333333333333333333333333333333333333333",
+        "expect_error": "TurnSubjectMismatch"
+      },
+      {
+        "name": "untrusted_issuer",
+        "trusted_issuer_seed_hex": "4444444444444444444444444444444444444444444444444444444444444444",
+        "expect_error": "UntrustedTurnIssuer"
+      },
+      {
+        "name": "tampered_server_credential",
+        "tamper": "set servers[0].credential to 'evil' after signing",
+        "expect_error": "BadSignature"
+      },
+      {
+        "name": "tampered_signature",
+        "tamper": "flip signature[0] low bit after signing",
+        "expect_error": "BadSignature"
+      },
+      {
+        "name": "empty_servers",
+        "servers": [],
+        "expect_error": "InvalidTurnCredential"
+      },
+      {
+        "name": "non_turn_url",
+        "servers_first_url": "stun:stun.example:3478",
+        "expect_error": "InvalidTurnCredential"
+      }
+    ]
+  },
+  "quota_tokens": {
+    "positive": [
+      {
+        "name": "well_formed_30day_5gib_quota",
+        "subject_zbase32": "<derive from subject seed at test time>",
+        "issuer_zbase32": "<derive from issuer seed at test time>",
+        "window_start": 1700000000,
+        "window_secs": 2592000,
+        "cap_bytes": 5368709120,
+        "consumed_bytes": 1073741824,
+        "issued_at": 1700000000,
+        "expires_at": 1700000600,
+        "verifier_now_ts": 1700000100,
+        "expect_verify": "ok",
+        "remaining_bytes_at_zero_local": 4294967296
+      }
+    ],
+    "negative": [
+      {
+        "name": "consumed_exceeds_cap",
+        "cap_bytes": 1000,
+        "consumed_bytes": 1001,
+        "expect_error": "InvalidTurnCredential"
+      },
+      {
+        "name": "window_secs_zero",
+        "window_secs": 0,
+        "expect_error": "InvalidTurnCredential"
+      },
+      {
+        "name": "window_secs_above_31_days",
+        "window_secs": 2678401,
+        "expect_error": "InvalidTurnCredential"
+      },
+      {
+        "name": "expired_token",
+        "issued_at": 1700000000,
+        "expires_at": 1700000060,
+        "verifier_now_ts": 1700000061,
+        "expect_error": "ExpiredTurnCredential"
+      },
+      {
+        "name": "overlong_token_lifetime",
+        "issued_at": 0,
+        "expires_at_offset_from_issued_at": 901,
+        "expect_error": "OverlongTurnCredential"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add products/oh-send/ as the first commercial surface on top of the
openhost protocol, kept in-tree so protocol + product can iterate on a
single release cadence through Y1.

- README.md: product overview and monorepo positioning (core stays in
  crates/, products/ depends on crates/ never the reverse).
- LANDING.md: canonical marketing copy for oh-send.dev. Hero, demo
  script, feature block, comparison table, FAQ.
- TICKETS.md: 90-day execution plan. Twelve tickets across protocol
  (TURN fallback, streaming, WASM client, self-operated Pkarr relay),
  product surface (web, CLI, pairing UX, identity persistence), and
  launch ops (landing, observability, HN launch, paid tier). Grounded
  in the existing ROADMAP.md phase sequencing.

No code yet. Scaffolding only.