### PR TITLE
fix(extension): move WebRTC session into offscreen document (PR #41)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "webNavigation",
     "tabs",
-    "storage"
+    "storage",
+    "offscreen"
   ],
   "host_permissions": [
     "https://relay.pkarr.org/*",
@@ -27,6 +28,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'; object-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; style-src 'self' 'unsafe-inline'"
   }
 }

--- a/extension/offscreen.html
+++ b/extension/offscreen.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>openhost offscreen</title>
+  </head>
+  <body>
+    <script type="module" src="src/offscreen.js"></script>
+  </body>
+</html>

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -1,29 +1,46 @@
 // openhost extension service worker (MV3).
 //
-// Two responsibilities:
+// Architecture (post-PR-#41):
 //
-// 1. PR #28.3 Phase 6: URL handler — cancel `oh://` navigations and
-//    redirect them into our SW-claimed `/oh/<pk>/...` scope.
+//   ┌────────────────────────────────────────────────┐
+//   │ Chrome tab                                     │
+//   │   URL: chrome-extension://<ext>/oh/<pk>/...    │
+//   │   Every fetch hits the SW.                     │
+//   └──────────────────┬─────────────────────────────┘
+//                      │ fetch event
+//                      ▼
+//   ┌────────────────────────────────────────────────┐
+//   │ Service Worker (this file)                     │
+//   │  - claims fetches under /oh/<pk>/*             │
+//   │  - forwards them to the offscreen doc via      │
+//   │    chrome.runtime.sendMessage                  │
+//   │  - wraps the offscreen reply in a Response     │
+//   └──────────────────┬─────────────────────────────┘
+//                      │ runtime message
+//                      ▼
+//   ┌────────────────────────────────────────────────┐
+//   │ Offscreen document (offscreen.html + .js)      │
+//   │  - holds the OpenhostSession (RTCPeerConnection│
+//   │    is only available in a document context,    │
+//   │    not in MV3 SWs)                             │
+//   │  - session cache per daemon-pk                 │
+//   │  - performs the dial + session.request call    │
+//   │  - returns {head, bodyBuf, status} over the    │
+//   │    runtime channel                             │
+//   └────────────────────────────────────────────────┘
 //
-// 2. PR #40: Service-Worker proxy for native in-browser rendering.
-//    Every `fetch` of a URL under `chrome-extension://<ext>/oh/*` is
-//    intercepted and routed through a live OpenhostSession's data
-//    channel. Subresource loads inside the rendered page (CSS, JS,
-//    images, video range requests) are transparently proxied by the
-//    SAME SW instance, so a video-server page (HTML + styles.css +
-//    app.js + videos) loads natively — no sandboxed iframe, no
-//    404s on relative-URL assets.
-//
-// Session model: one OpenhostSession per daemon pubkey, cached for
-// the SW's lifetime. Concurrent fetches (browsers fire many per page
-// load) are serialised through a single promise chain per session —
-// the wire format supports multiplexing via `request_id` (PR #40 wire
-// codec), but fully-concurrent multiplex awaits a follow-up PR to
-// the session + daemon. Serial is strictly better than the previous
-// sandboxed-iframe flow and ships the user's primary ask.
+// Why offscreen: MV3 service workers do not expose WebRTC APIs. The
+// `chrome.offscreen` API (Chrome 109+) lets an extension open a hidden
+// document whose context supports every web API. The SW spins up the
+// offscreen page on first `oh://` fetch and keeps it alive by setting
+// `reasons = ["USER_MEDIA"]` which the API explicitly permits for
+// long-lived WebRTC-holding documents.
 
 import { installOhNavigationHandler } from "./url_handler/oh_navigator.js";
-import { dialOhUrl } from "./dialer/openhost_session.js";
+import { loadOrCreateClientSeed } from "./dialer/openhost_session.js";
+import initWasm, {
+  client_pubkey_from_seed,
+} from "../wasm/pkg/openhost_pkarr.js";
 
 console.log(
   "openhost extension: service worker booted; arming oh:// handler",
@@ -31,63 +48,104 @@ console.log(
 
 installOhNavigationHandler();
 
+// Surface the per-install client pubkey on every SW boot.
+(async () => {
+  try {
+    await initWasm();
+    const seed = await loadOrCreateClientSeed();
+    console.log(
+      "openhost dialer: client_pubkey_zbase32 =",
+      client_pubkey_from_seed(seed),
+    );
+  } catch (err) {
+    console.warn("openhost: could not derive client pubkey at boot:", err);
+  }
+})();
+
 // ---------------------------------------------------------------------------
-// SW fetch proxy — PR #40
+// SW fetch proxy — forwards to offscreen doc (PR #41)
 // ---------------------------------------------------------------------------
 
-/**
- * Cache of in-flight or established OpenhostSession promises, keyed
- * by daemon zbase32 pubkey. The promise shape means concurrent
- * fetches for the same daemon share one dial.
- */
-const sessions = new Map();
+const OFFSCREEN_URL = "offscreen.html";
+let offscreenReady = null;
 
 /**
- * Matches the SW-claimed scope: `/oh/<52-char-zbase32>/<rest-of-path>`.
- * The `rest-of-path` is optional (a root `/oh/<pk>` or `/oh/<pk>/`
- * both route to path `/` on the daemon). Anything outside this scope
- * falls through to Chrome's default handler (e.g. extension-internal
- * resources at `/src/...`, `/wasm/...`, or the popup page).
+ * Ensure the offscreen document exists. Chrome allows at most one
+ * offscreen doc per extension. We return a memoised promise so
+ * concurrent first-fetches don't race `createDocument`.
  */
+function ensureOffscreen() {
+  if (offscreenReady) return offscreenReady;
+  offscreenReady = (async () => {
+    try {
+      const exists = await chrome.offscreen.hasDocument();
+      if (exists) return;
+    } catch (_) {
+      // `hasDocument` is Chrome 116+; on older versions fall through
+      // to createDocument and let it fail with "already exists" which
+      // we swallow.
+    }
+    try {
+      await chrome.offscreen.createDocument({
+        url: OFFSCREEN_URL,
+        reasons: ["USER_MEDIA"],
+        justification:
+          "openhost holds a long-lived WebRTC session to the home daemon",
+      });
+    } catch (err) {
+      if (!/already exists/i.test(String(err && err.message))) throw err;
+    }
+  })();
+  // Reset the memoised promise if creation fails so the next fetch
+  // retries rather than inheriting a permanently-failed state.
+  offscreenReady.catch(() => {
+    offscreenReady = null;
+  });
+  return offscreenReady;
+}
+
 const OH_PATH_RE = /^\/oh\/([a-z0-9]{52})(\/.*)?$/i;
 
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
-  // Only claim paths inside our own extension origin.
   if (url.origin !== self.location.origin) return;
   const match = OH_PATH_RE.exec(url.pathname);
-  if (!match) return; // not our scope — let Chrome handle it
+  if (!match) return;
 
   const daemonPkZ = match[1].toLowerCase();
   const path = (match[2] || "/") + (url.search || "");
   event.respondWith(handleOhFetch(daemonPkZ, path, event.request));
 });
 
-/**
- * Dial (or reuse) a session for the given daemon pubkey, then run
- * `session.request(...)` and translate the openhost response into a
- * native `Response` object the browser can render.
- */
 async function handleOhFetch(daemonPkZ, path, request) {
   try {
-    const session = await getOrDialSession(daemonPkZ);
+    await ensureOffscreen();
+
     const headers = {};
     for (const [k, v] of request.headers.entries()) {
-      // `host` is hard-coded by `session.request` to "openhost"; skip
-      // the browser's computed value which would otherwise double.
       if (k.toLowerCase() === "host") continue;
       headers[k] = v;
     }
-    const body =
+    const bodyBuf =
       request.method === "GET" || request.method === "HEAD"
         ? null
-        : new Uint8Array(await request.arrayBuffer());
-    const resp = await session.request(request.method, path, headers, body);
-    return buildResponseFromOpenhost(resp);
+        : await request.arrayBuffer();
+
+    const reply = await chrome.runtime.sendMessage({
+      kind: "openhost-request",
+      daemonPkZ,
+      method: request.method,
+      path,
+      headers,
+      // Arbitrary structured-cloneable types; ArrayBuffer is transferable.
+      bodyBuf,
+    });
+    if (!reply || reply.error) {
+      throw new Error(reply ? reply.error : "offscreen: no reply");
+    }
+    return buildResponseFromOpenhost(reply);
   } catch (err) {
     console.error("openhost SW: fetch failed", err, { daemonPkZ, path });
-    // Serve a user-facing error page so the tab at least shows
-    // something — avoids opaque "This site can't be reached".
     return new Response(
       `openhost dial error: ${err && err.message ? err.message : err}`,
       { status: 502, headers: { "content-type": "text/plain" } },
@@ -95,58 +153,9 @@ async function handleOhFetch(daemonPkZ, path, request) {
   }
 }
 
-/**
- * Session cache + dial-once semantics. Concurrent callers awaiting
- * the same daemon share one Promise. On RTCPeerConnection close /
- * failure the entry is purged so the next fetch re-dials.
- */
-function getOrDialSession(daemonPkZ) {
-  let pending = sessions.get(daemonPkZ);
-  if (pending) return pending;
-  pending = (async () => {
-    const session = await dialOhUrl(`oh://${daemonPkZ}/`);
-    // Serialise concurrent `.request()` calls behind a single chain.
-    // The current session + daemon don't yet multiplex on request_id;
-    // without the lock, overlapping fetches would interleave
-    // REQUEST_BODY frames and corrupt both responses.
-    const origRequest = session.request.bind(session);
-    let chain = Promise.resolve();
-    session.request = (method, path, headers, body) => {
-      const next = chain.then(() =>
-        origRequest(method, path, headers, body),
-      );
-      // Swallow errors on the chain so one failing request doesn't
-      // poison the next; the awaiter still sees the rejection.
-      chain = next.catch(() => {});
-      return next;
-    };
-    // Evict on connection failure so the next fetch re-dials.
-    try {
-      session._pc.addEventListener("connectionstatechange", () => {
-        const s = session._pc.connectionState;
-        if (s === "failed" || s === "closed" || s === "disconnected") {
-          sessions.delete(daemonPkZ);
-        }
-      });
-    } catch (e) {
-      console.warn("openhost SW: could not attach pc state listener", e);
-    }
-    return session;
-  })();
-  // If the dial itself fails, drop the cached rejection so the next
-  // fetch gets a fresh chance rather than inheriting the failure.
-  pending.catch(() => sessions.delete(daemonPkZ));
-  sessions.set(daemonPkZ, pending);
-  return pending;
-}
-
-/**
- * Parse the openhost response `{ head, body }` shape into a native
- * `Response` the browser can render. `head` is an HTTP/1.1 status
- * line + headers block (terminated by \r\n\r\n, already stripped).
- */
-function buildResponseFromOpenhost(resp) {
-  const lines = (resp.head || "").split(/\r?\n/);
+function buildResponseFromOpenhost(reply) {
+  const { head = "", bodyBuf } = reply;
+  const lines = head.split(/\r?\n/);
   const statusLine = lines[0] || "HTTP/1.1 200 OK";
   const m = /^HTTP\/\d\.\d\s+(\d+)\s*(.*)$/.exec(statusLine);
   const status = m ? parseInt(m[1], 10) : 200;
@@ -159,27 +168,11 @@ function buildResponseFromOpenhost(resp) {
     if (colon < 0) continue;
     const name = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
-    // Browser rejects some hop-by-hop + forbidden headers on Response
-    // (content-length, transfer-encoding, connection, etc.). Best
-    // effort — set what we can, silently skip the rest.
     try {
       headers.append(name, value);
     } catch {
-      // ignore
+      /* forbidden header — skip */
     }
   }
-  return new Response(resp.body, { status, statusText, headers });
+  return new Response(bodyBuf, { status, statusText, headers });
 }
-
-// ---------------------------------------------------------------------------
-// PR #28.2 resolver probe — dev-only, stays opt-in.
-//
-// To exercise the four WASM decode exports without the full dial:
-//
-//   1. Build the WASM pkg:  `./extension/scripts/build-wasm.sh`
-//   2. Uncomment the lines below; replace <pubkey> with a 52-char
-//      zbase32 pubkey of a running openhost daemon.
-//   3. Reload the unpacked extension in chrome://extensions.
-//
-// import { runResolverProbe } from "./dev/resolver-probe.js";
-// runResolverProbe("<pubkey-zbase32>");

--- a/extension/src/offscreen.js
+++ b/extension/src/offscreen.js
@@ -1,0 +1,71 @@
+// Offscreen document — holds the OpenhostSession on behalf of the
+// service worker. MV3 SWs don't expose RTCPeerConnection, so the dial
+// + session-request happens here. One offscreen doc per extension;
+// multiple daemons share this doc via a per-daemon session cache.
+
+import { dialOhUrl } from "./dialer/openhost_session.js";
+
+console.log("openhost offscreen: booted, awaiting SW requests");
+
+// sessions: Map<daemonPkZ, Promise<OpenhostSession>>.
+// Promise-valued entries deduplicate concurrent first-dials.
+const sessions = new Map();
+
+function getOrDialSession(daemonPkZ) {
+  let pending = sessions.get(daemonPkZ);
+  if (pending) return pending;
+  pending = (async () => {
+    const session = await dialOhUrl(`oh://${daemonPkZ}/`);
+    // Serialise concurrent `.request()` calls through a single chain;
+    // wire v2's `request_id` field is scaffolded but daemon-side
+    // concurrent dispatch ships in a later PR.
+    const orig = session.request.bind(session);
+    let chain = Promise.resolve();
+    session.request = (method, path, headers, body) => {
+      const next = chain.then(() => orig(method, path, headers, body));
+      chain = next.catch(() => {});
+      return next;
+    };
+    try {
+      session._pc.addEventListener("connectionstatechange", () => {
+        const s = session._pc.connectionState;
+        if (s === "failed" || s === "closed" || s === "disconnected") {
+          sessions.delete(daemonPkZ);
+        }
+      });
+    } catch (e) {
+      console.warn("openhost offscreen: pc state listener attach failed", e);
+    }
+    return session;
+  })();
+  pending.catch(() => sessions.delete(daemonPkZ));
+  sessions.set(daemonPkZ, pending);
+  return pending;
+}
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (!msg || msg.kind !== "openhost-request") return false;
+  (async () => {
+    try {
+      const session = await getOrDialSession(msg.daemonPkZ);
+      const body =
+        msg.bodyBuf == null ? null : new Uint8Array(msg.bodyBuf);
+      const resp = await session.request(
+        msg.method,
+        msg.path,
+        msg.headers || {},
+        body,
+      );
+      // `resp.body` is a Uint8Array view; pass its underlying buffer
+      // so structured-clone can transfer it without a copy.
+      const buf = resp.body instanceof Uint8Array ? resp.body.buffer : resp.body;
+      sendResponse({ head: resp.head, bodyBuf: buf });
+    } catch (err) {
+      console.error("openhost offscreen: request failed", err);
+      sendResponse({
+        error: err && err.message ? err.message : String(err),
+      });
+    }
+  })();
+  return true; // keep the channel open for async sendResponse
+});


### PR DESCRIPTION
## Summary

PR #40 put the OpenhostSession directly in the MV3 service worker. That path fails at runtime with `RTCPeerConnection is not defined` — MV3 SWs don't expose WebRTC APIs (see W3C ServiceWorker spec issue #1356).

Fix: use `chrome.offscreen` to spin up a hidden document that holds the session, and have the SW message-pass every fetch through `chrome.runtime.sendMessage`. The offscreen doc uses `reasons: ["USER_MEDIA"]` which the API explicitly allows for long-lived WebRTC-holding documents.

## Changes

- **`offscreen.html` + `src/offscreen.js`** (new): holds the `OpenhostSession` per-daemon cache. Handles `openhost-request` runtime messages. Serialises concurrent `.request()` calls behind a chain promise (wire `request_id` is scaffolded but daemon concurrent dispatch is a later PR).
- **`src/background.js`** (rewritten): SW fetch handler `ensureOffscreen()` + message-passes to the doc. Same `/oh/<pk>/<path>` claim logic.
- **`manifest.json`**: added `offscreen` permission; dropped `'unsafe-inline'` from `script-src` CSP (MV3 rejects it, extension wouldn't load).
- **Bonus**: background.js logs `client_pubkey_zbase32` on every SW boot so operators can read it from the console without triggering a dial.

## Followup

Full live verification is blocked on symmetric-NAT hole-punching, which is out of scope here — tracked in PR #42 (embedded TURN in daemon).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Extension loads in Chrome without CSP rejection
- [x] SW console logs `client_pubkey_zbase32` on boot
- [ ] End-to-end dial — blocked on PR #42 (tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)