### PR TITLE
feat(core+pkarr): turn_port v3 host record field (PR #42.1)

### DIFF
--- a/crates/openhost-client/src/bin/openhost-resolve.rs
+++ b/crates/openhost-client/src/bin/openhost-resolve.rs
@@ -197,6 +197,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x11u8; SALT_LEN],
             disc: "dht=1".to_string(),
+            turn_port: None,
         };
         SignedRecord::sign(record, &sk).expect("sign")
     }

--- a/crates/openhost-client/src/client.rs
+++ b/crates/openhost-client/src/client.rs
@@ -178,6 +178,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x11u8; SALT_LEN],
             disc: String::new(),
+            turn_port: None,
         }
     }
 

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -385,6 +385,7 @@ async fn publish_fake_host_record(net: &MemoryPkarrNetwork, daemon_sk: &SigningK
         roles: "server".to_string(),
         salt: [0x11; SALT_LEN],
         disc: String::new(),
+        turn_port: None,
     };
     let signed = SignedRecord::sign(record, daemon_sk).unwrap();
     let packet = encode(&signed, daemon_sk).unwrap();

--- a/crates/openhost-core/src/pkarr_record/mod.rs
+++ b/crates/openhost-core/src/pkarr_record/mod.rs
@@ -15,10 +15,24 @@ use crate::{Error, Result};
 use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
 
-/// openhost protocol version carried in the record. Incremented on breaking
-/// changes. v2 (PR #22) drops the `allow` and `ice` fields from the canonical
-/// bytes; v2 records are a hard break from v1.
+/// Default openhost protocol version emitted by builders that don't set
+/// any v3-only fields. Readers accept any version in
+/// [`MIN_SUPPORTED_VERSION`]..=[`MAX_SUPPORTED_VERSION`].
+///
+/// v2 (PR #22) dropped the `allow` and `ice` fields from the canonical
+/// bytes. v3 (PR #42.1) introduces the optional `turn_port` sidecar. A
+/// v3 record is only emitted when `turn_port.is_some()`; otherwise
+/// builders still emit v2 bytes for wire compatibility with pre-v3
+/// decoders.
 pub const PROTOCOL_VERSION: u8 = 2;
+
+/// Minimum record version a v3-aware decoder accepts. v1 is rejected —
+/// the `allow`/`ice` fields are gone and a v1 record signed over them
+/// can't be meaningfully reinterpreted.
+pub const MIN_SUPPORTED_VERSION: u8 = 2;
+
+/// Highest record version this crate emits or consumes.
+pub const MAX_SUPPORTED_VERSION: u8 = 3;
 
 /// Maximum permitted age of a signed record in seconds. Verifiers reject records
 /// whose internal timestamp is further from "now" than this window.
@@ -52,7 +66,10 @@ pub const MAX_DISC_LEN: usize = 256;
 /// carried them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenhostRecord {
-    /// Protocol version. Must equal [`PROTOCOL_VERSION`] for a v2 record.
+    /// Protocol version. Either [`PROTOCOL_VERSION`] (v2) or `3` (v3). v3
+    /// is emitted only when `turn_port.is_some()` so deployments that
+    /// don't run an embedded TURN server continue to publish
+    /// byte-identical records to the v2 format.
     pub version: u8,
     /// Unix timestamp (seconds) at which the host published this record.
     pub ts: u64,
@@ -64,6 +81,14 @@ pub struct OpenhostRecord {
     pub salt: [u8; SALT_LEN],
     /// Substrate discovery hints (informational). UTF-8, up to [`MAX_DISC_LEN`] bytes.
     pub disc: String,
+    /// Daemon's publicly-reachable UDP port for its embedded TURN
+    /// server, if one is enabled. `None` when the daemon does not
+    /// expose a TURN relay — clients then rely on direct ICE / STUN
+    /// only, which is fine on most home networks but fails under
+    /// symmetric NATs. Introduced in v3 (PR #42.1); a `Some(_)` value
+    /// forces `version = 3`.
+    #[serde(default)]
+    pub turn_port: Option<u16>,
 }
 
 impl OpenhostRecord {
@@ -71,8 +96,28 @@ impl OpenhostRecord {
     ///
     /// `now_ts` is the verifier's current Unix timestamp (seconds).
     pub fn validate(&self, now_ts: u64) -> Result<()> {
-        if self.version != PROTOCOL_VERSION {
+        if self.version < MIN_SUPPORTED_VERSION || self.version > MAX_SUPPORTED_VERSION {
             return Err(Error::InvalidRecord("unsupported protocol version"));
+        }
+        // turn_port is a v3-only field. Refuse a v2 record that claims
+        // to carry it — that would silently widen the signed surface.
+        if self.version < 3 && self.turn_port.is_some() {
+            return Err(Error::InvalidRecord(
+                "turn_port requires protocol version >= 3",
+            ));
+        }
+        // A v3 record MUST carry a turn_port; otherwise it's
+        // indistinguishable from v2 and should have been emitted as v2.
+        // (This keeps the version byte a meaningful capability flag.)
+        if self.version >= 3 && self.turn_port.is_none() {
+            return Err(Error::InvalidRecord(
+                "v3 record missing turn_port (emit as v2 instead)",
+            ));
+        }
+        if let Some(port) = self.turn_port {
+            if port == 0 {
+                return Err(Error::InvalidRecord("turn_port must be non-zero"));
+            }
         }
         // 2-hour window on either side.
         let delta = now_ts.abs_diff(self.ts);
@@ -97,12 +142,12 @@ impl OpenhostRecord {
 
     /// Produce the canonical byte representation used for signing and verification.
     ///
-    /// The v2 encoding is explicit and stable:
+    /// Layout (v2; stable since PR #22):
     ///
     /// ```text
     /// canonical = 0x01                        (legacy encoding tag; unchanged)
     ///          || "openhost1"                 (9 ASCII bytes, legacy domain separator)
-    ///          || version (1 byte, equals PROTOCOL_VERSION = 2)
+    ///          || version (1 byte; 2 or 3)
     ///          || ts (8 bytes, u64 big-endian)
     ///          || dtls_fp (32 bytes)
     ///          || roles_len (1 byte)    || roles_bytes
@@ -110,9 +155,22 @@ impl OpenhostRecord {
     ///          || disc_len (2 bytes BE) || disc_bytes
     /// ```
     ///
+    /// v3 (PR #42.1) appends one trailer:
+    ///
+    /// ```text
+    ///          || turn_port (2 bytes BE, u16; MUST be non-zero)
+    /// ```
+    ///
+    /// v2 records omit the trailer. A v3-aware decoder can therefore
+    /// consume a v2 record without change; a v2-only decoder reading a
+    /// v3 record will fail at the "trailing bytes" check. This is the
+    /// intended one-way compat: new readers see old records, old
+    /// readers reject new records. Deployments that don't run TURN
+    /// keep emitting v2 indefinitely.
+    ///
     /// The v1 schema inserted `allow_count || allow_entries || ice_count || ice_blobs`
-    /// between `salt` and `disc`. v2 drops those fields entirely; the `version`
-    /// byte is the sole discriminator for readers.
+    /// between `salt` and `disc`. v2 dropped those fields; v1 is
+    /// unsupported.
     ///
     /// Returns `Err` only when the record fails `validate(now_ts=self.ts)` — i.e.
     /// when the record is ill-formed. Otherwise the returned buffer is deterministic.
@@ -136,6 +194,11 @@ impl OpenhostRecord {
         let disc_len = u16::try_from(disc_bytes.len()).expect("validated <= MAX_DISC_LEN");
         out.extend_from_slice(&disc_len.to_be_bytes());
         out.extend_from_slice(disc_bytes);
+
+        // v3 trailer.
+        if let Some(port) = self.turn_port {
+            out.extend_from_slice(&port.to_be_bytes());
+        }
 
         Ok(out)
     }
@@ -196,6 +259,7 @@ mod tests {
             roles: "server".to_string(),
             salt,
             disc: "dht=1; relay=pkarr.example".to_string(),
+            turn_port: None,
         }
     }
 
@@ -300,6 +364,71 @@ mod tests {
         let mut r = sample_record(1_700_000_000);
         r.disc.push_str(" extra");
         assert_ne!(r.canonical_signing_bytes().unwrap(), base);
+    }
+
+    // ---------------------------------------------------------------------
+    // v3 turn_port coverage (PR #42.1)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn v3_round_trip_preserves_turn_port() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 3;
+        r.turn_port = Some(3478);
+        let bytes = r.canonical_signing_bytes().unwrap();
+        // v3 trailer is the last two bytes, big-endian u16 port.
+        assert_eq!(bytes[bytes.len() - 2..], 3478u16.to_be_bytes());
+    }
+
+    #[test]
+    fn v3_without_turn_port_rejected() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 3;
+        r.turn_port = None;
+        assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
+    }
+
+    #[test]
+    fn v2_with_turn_port_rejected() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 2;
+        r.turn_port = Some(3478);
+        assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
+    }
+
+    #[test]
+    fn turn_port_zero_rejected() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 3;
+        r.turn_port = Some(0);
+        assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
+    }
+
+    #[test]
+    fn v3_sign_verify_round_trip() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let pk = sk.public_key();
+        let mut record = sample_record(1_700_000_000);
+        record.version = 3;
+        record.turn_port = Some(3478);
+        let signed = SignedRecord::sign(record.clone(), &sk).unwrap();
+        signed.verify(&pk, record.ts).expect("v3 verifies");
+    }
+
+    #[test]
+    fn v2_records_still_encode_after_v3_landing() {
+        // Regression guard: PR #42.1 must not change v2 bytes. A v2
+        // record signed pre-PR and another signed post-PR MUST yield
+        // identical canonical bytes for the same logical record.
+        let r = sample_record(1_700_000_000);
+        let bytes = r.canonical_signing_bytes().unwrap();
+        // v2 record ends with the disc trailer; no turn_port byte.
+        // Sanity-check length equals the sum of fixed-width fields +
+        // variable-width roles + variable-width disc (no trailer).
+        let roles_len = r.roles.len();
+        let disc_len = r.disc.len();
+        let expected = 1 + 9 + 1 + 8 + 32 + 1 + roles_len + 32 + 2 + disc_len;
+        assert_eq!(bytes.len(), expected);
     }
 
     /// Measure the wire size of a v2 main record after base64url wrapping

--- a/crates/openhost-core/tests/end_to_end.rs
+++ b/crates/openhost-core/tests/end_to_end.rs
@@ -50,6 +50,7 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
         roles: "server".into(),
         salt,
         disc: "dht=1".into(),
+        turn_port: None,
     };
     let signed = SignedRecord::sign(record, &host_sk).expect("sign");
 

--- a/crates/openhost-core/tests/pkarr_record_vectors.rs
+++ b/crates/openhost-core/tests/pkarr_record_vectors.rs
@@ -33,6 +33,8 @@ struct RecordFields {
     roles: String,
     salt_hex: String,
     disc: String,
+    #[serde(default)]
+    turn_port: Option<u16>,
 }
 
 fn decode_hex32(s: &str) -> [u8; 32] {
@@ -48,6 +50,7 @@ fn build_record(r: &RecordFields) -> OpenhostRecord {
         roles: r.roles.clone(),
         salt: decode_hex32(&r.salt_hex),
         disc: r.disc.clone(),
+        turn_port: r.turn_port,
     }
 }
 

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -191,6 +191,9 @@ impl SharedState {
             roles: self.roles.clone(),
             salt: self.salt,
             disc: String::new(),
+            // PR #42.1 only wires the field through; PR #42.2 populates
+            // it from daemon config when TURN is enabled.
+            turn_port: None,
         }
     }
 }

--- a/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
+++ b/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
@@ -25,6 +25,7 @@ fn sample_signed_record(ts: u64) -> (SigningKey, SignedRecord) {
         roles: "server".to_string(),
         salt: [0x22; SALT_LEN],
         disc: String::new(),
+        turn_port: None,
     };
     let signed = SignedRecord::sign(record, &sk).unwrap();
     (sk, signed)

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -25,7 +25,8 @@ use base64::Engine;
 use ed25519_dalek::Signature;
 use openhost_core::identity::{PublicKey, SigningKey, PUBLIC_KEY_LEN};
 use openhost_core::pkarr_record::{
-    OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, MAX_DISC_LEN, PROTOCOL_VERSION, SALT_LEN,
+    OpenhostRecord, SignedRecord, DTLS_FINGERPRINT_LEN, MAX_DISC_LEN, MAX_SUPPORTED_VERSION,
+    MIN_SUPPORTED_VERSION, SALT_LEN,
 };
 use pkarr::dns::Name;
 use pkarr::{Keypair, SignedPacket, Timestamp};
@@ -207,7 +208,7 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
     }
 
     let version = r.u8()?;
-    if version != PROTOCOL_VERSION {
+    if !(MIN_SUPPORTED_VERSION..=MAX_SUPPORTED_VERSION).contains(&version) {
         return Err(PkarrError::MalformedCanonical(
             "unsupported protocol version",
         ));
@@ -238,11 +239,34 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
         .map_err(|_| PkarrError::MalformedCanonical("disc is not valid UTF-8"))?
         .to_string();
 
-    if !r.is_empty() {
-        return Err(PkarrError::MalformedCanonical(
-            "trailing bytes after canonical record",
-        ));
-    }
+    // v3 trailer: an optional u16 BE `turn_port`. v2 records stop at
+    // disc; v3 records carry exactly 2 more bytes. Anything in between
+    // is a malformed record.
+    let turn_port = match (version, r.is_empty()) {
+        (v, true) if v >= 3 => {
+            return Err(PkarrError::MalformedCanonical(
+                "v3 record missing turn_port trailer",
+            ))
+        }
+        (_, true) => None,
+        (v, false) if v < 3 => {
+            return Err(PkarrError::MalformedCanonical(
+                "trailing bytes after canonical record",
+            ));
+        }
+        (_, false) => {
+            let port = r.u16_be()?;
+            if !r.is_empty() {
+                return Err(PkarrError::MalformedCanonical(
+                    "trailing bytes after v3 turn_port",
+                ));
+            }
+            if port == 0 {
+                return Err(PkarrError::MalformedCanonical("turn_port must be non-zero"));
+            }
+            Some(port)
+        }
+    };
 
     Ok(OpenhostRecord {
         version,
@@ -251,6 +275,7 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
         roles,
         salt,
         disc,
+        turn_port,
     })
 }
 
@@ -432,6 +457,54 @@ mod tests {
             SignedPacket::deserialize(&wire).is_err(),
             "tampered BEP44 sig must fail pkarr deserialization"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // v3 turn_port codec coverage (PR #42.1)
+    // ---------------------------------------------------------------------
+
+    fn v3_record(port: u16) -> OpenhostRecord {
+        OpenhostRecord {
+            version: 3,
+            turn_port: Some(port),
+            ..reference_record()
+        }
+    }
+
+    #[test]
+    fn v3_round_trip_preserves_turn_port() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let record = v3_record(3478);
+        let signed = SignedRecord::sign(record.clone(), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+        let decoded = decode(&packet).unwrap();
+        assert_eq!(decoded.record.turn_port, Some(3478));
+        assert_eq!(decoded.record.version, 3);
+    }
+
+    #[test]
+    fn v3_signed_record_verifies_against_pubkey() {
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+        let pk = sk.public_key();
+        let signed = SignedRecord::sign(v3_record(3478), &sk).unwrap();
+        let packet = encode(&signed, &sk).unwrap();
+        let decoded = decode(&packet).unwrap();
+        decoded.verify(&pk, decoded.record.ts).expect("v3 verifies");
+    }
+
+    #[test]
+    fn v2_and_v3_records_coexist_on_the_wire() {
+        // Codec must accept both schema versions without a mode switch.
+        let sk = SigningKey::from_bytes(&RFC_SEED);
+
+        let v2_record = reference_record();
+        let v2_signed = SignedRecord::sign(v2_record.clone(), &sk).unwrap();
+        let v2_packet = encode(&v2_signed, &sk).unwrap();
+        assert_eq!(decode(&v2_packet).unwrap().record.turn_port, None);
+
+        let v3_signed = SignedRecord::sign(v3_record(51820), &sk).unwrap();
+        let v3_packet = encode(&v3_signed, &sk).unwrap();
+        assert_eq!(decode(&v3_packet).unwrap().record.turn_port, Some(51820));
     }
 
     /// Sanity-check: a v2 record with a maxed-out `disc` still encodes

--- a/crates/openhost-pkarr/src/test_fakes.rs
+++ b/crates/openhost-pkarr/src/test_fakes.rs
@@ -137,6 +137,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x22; SALT_LEN],
             disc: String::new(),
+            turn_port: None,
         };
         let signed = SignedRecord::sign(record, &sk).unwrap();
         let packet = encode(&signed, &sk).unwrap();

--- a/crates/openhost-pkarr/src/test_support.rs
+++ b/crates/openhost-pkarr/src/test_support.rs
@@ -25,5 +25,6 @@ pub(crate) fn sample_record(ts: u64) -> OpenhostRecord {
         roles: "server".to_string(),
         salt,
         disc: String::new(),
+        turn_port: None,
     }
 }

--- a/crates/openhost-pkarr/tests/round_trip.rs
+++ b/crates/openhost-pkarr/tests/round_trip.rs
@@ -43,6 +43,10 @@ fn reference_record() -> OpenhostRecord {
         roles: r["roles"].as_str().unwrap().to_string(),
         salt,
         disc: r["disc"].as_str().unwrap().to_string(),
+        turn_port: r
+            .get("turn_port")
+            .and_then(|v| v.as_u64())
+            .map(|p| p as u16),
     }
 }
 

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -49,6 +49,8 @@ The packet **MUST** contain a single TXT resource record:
 
 The v1 schema additionally carried an `allow` list of 16-byte truncated HMAC entries and a per-paired-client `ice` list immediately before `disc`. v2 removes both fields from the canonical bytes; the underlying facilities they represented now live elsewhere (see the bullet list below).
 
+**v3 schema (PR #42.1).** A v3 record appends one 2-byte big-endian unsigned integer after the `disc` bytes: `turn_port`. A v3 record's `version` byte is `0x03` and `turn_port` **MUST** be non-zero. `turn_port` advertises the UDP port on the daemon's public IP where its embedded TURN server listens; clients read the field and add `turn:<daemon-ip>:<turn_port>` to their ICE configuration before dialling, enabling relay fallback under symmetric NATs that defeat direct hole-punching. Deployments without an embedded TURN server continue to publish v2 records (version byte `0x02`, no trailer); decoders **MUST** accept both. v1 is unsupported.
+
 The base64url encoding uses the RFC 4648 §5 URL-safe alphabet without padding. If the encoded string exceeds 255 bytes, it **MUST** be split across multiple DNS character strings within the same TXT RDATA (per RFC 1035 §3.3.14); decoders reconstruct the payload by concatenating the character strings in the order they appear.
 
 Two signatures bind the record:


### PR DESCRIPTION
## Summary

First slice of the embedded-TURN work (plan: \`/Users/vamsi/.claude/plans/pr-42-embedded-turn.md\`). Adds an optional \`turn_port: Option<u16>\` to the host record canonical bytes under a new schema version 3. No TURN server yet — just the wire scaffolding so PR #42.2 can populate the field and PR #42.3 can consume it on the dialer side.

## Wire change

- **v2 record**: unchanged. Still the default emission from any deployment that doesn't enable TURN.
- **v3 record**: appends exactly 2 bytes (\`turn_port_be_u16\`) after the \`disc\` trailer. Version byte = 0x03; \`turn_port\` MUST be non-zero.

Decoders accept both; v3-aware readers consume pre-PR records unchanged.

## Why not bump \`PROTOCOL_VERSION\`?

A deployment that doesn't run TURN keeps emitting byte-identical v2 records. Clients that see a v2 record just use direct STUN. Only when the deployment flips \`[turn] enabled = true\` (PR #42.2) does it start emitting v3. This lets the rollout be one-sided: update code everywhere → only deployments opting into TURN change their wire output.

## Test coverage

- 6 new unit tests in \`pkarr_record::tests\` (round-trip, version/turn_port mismatch rejections, zero-port rejection, sign+verify, v2 regression guard)
- 3 new codec tests (codec round-trip, verify, v2/v3 coexistence)
- All existing 94 openhost-core + 62 openhost-pkarr tests still pass

## Spec

\`spec/01-wire-format.md §2\` gains a v3-schema paragraph.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`cargo check -p openhost-pkarr-wasm --target wasm32-unknown-unknown\`
- [x] \`markdownlint-cli2 spec/**/*.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)