### PR TITLE
feat(daemon+client+ext): embedded TURN + auto-discovery (PR #42.2 + #42.3 + #42.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,12 @@ checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -813,7 +819,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.17.1",
  "x25519-dalek",
  "x509-parser",
 ]
@@ -1366,7 +1372,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1551,7 +1557,7 @@ dependencies = [
  "tokio",
  "waitgroup",
  "webrtc-srtp",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -2011,7 +2017,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "ed25519-dalek 2.2.0",
@@ -2041,7 +2047,7 @@ dependencies = [
 name = "openhost-core"
 version = "0.2.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chacha20poly1305",
  "crypto_box",
  "curve25519-dalek 4.1.3",
@@ -2068,7 +2074,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "directories",
@@ -2095,7 +2101,9 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "turn 0.8.0",
  "webrtc",
+ "webrtc-util 0.9.0",
  "zeroize",
 ]
 
@@ -2111,7 +2119,7 @@ name = "openhost-pkarr"
 version = "0.2.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "flate2",
  "hex",
@@ -2132,7 +2140,7 @@ dependencies = [
 name = "openhost-pkarr-wasm"
 version = "0.2.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hex",
@@ -2220,7 +2228,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2627,7 +2635,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2717,7 +2725,7 @@ source = "git+https://github.com/kaicoder03/webrtc.git?rev=a1c2dbb36915c43b532d9
 dependencies = [
  "bytes",
  "thiserror 1.0.69",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -2731,7 +2739,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "thiserror 1.0.69",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3226,10 +3234,29 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stun"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28fad383a1cc63ae141e84e48eaef44a1063e9d9e55bcb8f51a99b886486e01b"
+dependencies = [
+ "base64 0.21.7",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.8.6",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util 0.9.0",
+]
+
+[[package]]
+name = "stun"
 version = "0.17.1"
 source = "git+https://github.com/kaicoder03/webrtc.git?rev=a1c2dbb36915c43b532d9f067a96d9a6a8bd9c06#a1c2dbb36915c43b532d9f067a96d9a6a8bd9c06"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
@@ -3239,7 +3266,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "url",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3612,22 +3639,43 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "turn"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b000cebd930420ac1ed842c8128e3b3412512dfd5b82657eab035a3f5126acc"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand 0.8.6",
+ "ring",
+ "stun 0.6.0",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util 0.9.0",
+]
+
+[[package]]
+name = "turn"
 version = "0.17.1"
 source = "git+https://github.com/kaicoder03/webrtc.git?rev=a1c2dbb36915c43b532d9f067a96d9a6a8bd9c06#a1c2dbb36915c43b532d9f067a96d9a6a8bd9c06"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "futures",
  "log",
  "md-5",
  "portable-atomic",
  "rand 0.9.4",
  "ring",
- "stun",
+ "stun 0.17.1",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3913,10 +3961,10 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smol_str",
- "stun",
+ "stun 0.17.1",
  "thiserror 1.0.69",
  "tokio",
- "turn",
+ "turn 0.17.1",
  "unicase",
  "url",
  "waitgroup",
@@ -3926,7 +3974,7 @@ dependencies = [
  "webrtc-media",
  "webrtc-sctp",
  "webrtc-srtp",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3940,7 +3988,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "webrtc-sctp",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3956,15 +4004,15 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
- "stun",
+ "stun 0.17.1",
  "thiserror 1.0.69",
  "tokio",
- "turn",
+ "turn 0.17.1",
  "url",
  "uuid",
  "waitgroup",
  "webrtc-mdns",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -3976,7 +4024,7 @@ dependencies = [
  "socket2 0.5.10",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -4005,7 +4053,7 @@ dependencies = [
  "rand 0.9.4",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.17.1",
 ]
 
 [[package]]
@@ -4027,7 +4075,28 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
- "webrtc-util",
+ "webrtc-util 0.17.1",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8d9bc631768958ed97b8d68b5d301e63054ae90b09083d43e2fefb939fd77e"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "portable-atomic",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 pkarr = { version = "5", default-features = false }
 mainline = "6"
 webrtc = { version = "0.17", features = ["pem"] }
+# Embedded TURN server for daemon-hosted relay (PR #42.2). Pulled
+# from the same webrtc-rs workspace the `webrtc` crate lives in.
+turn = "0.8"
 tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 tracing = "0.1"

--- a/crates/openhost-client/Cargo.toml
+++ b/crates/openhost-client/Cargo.toml
@@ -25,7 +25,7 @@ required-features = ["cli"]
 
 [features]
 default = []
-cli = ["clap", "tracing-subscriber", "serde_json", "hex"]
+cli = ["clap", "tracing-subscriber", "serde_json"]
 # Opt-in suite that resolves a real host pubkey over public Pkarr
 # relays. NOT on CI — run manually before publishing.
 real-network = []
@@ -63,15 +63,16 @@ webrtc = { workspace = true }
 bytes = "1"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
+# Required by turn_creds (PR #42.3); hex-encodes the password digest.
+hex = { workspace = true }
+
 # Optional — cli feature only
 clap = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-hex = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
-hex = { workspace = true }
 serde_json = { workspace = true }
 # End-to-end test scaffolding (PR #8).
 openhost-daemon = { path = "../openhost-daemon" }

--- a/crates/openhost-client/src/bin/openhost-resolve.rs
+++ b/crates/openhost-client/src/bin/openhost-resolve.rs
@@ -197,7 +197,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x11u8; SALT_LEN],
             disc: "dht=1".to_string(),
-            turn_port: None,
+            turn_endpoint: None,
         };
         SignedRecord::sign(record, &sk).expect("sign")
     }

--- a/crates/openhost-client/src/client.rs
+++ b/crates/openhost-client/src/client.rs
@@ -178,7 +178,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x11u8; SALT_LEN],
             disc: String::new(),
-            turn_port: None,
+            turn_endpoint: None,
         }
     }
 

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -231,8 +231,12 @@ impl Dialer {
         let daemon_salt = signed.record.salt;
 
         // Stage 2: build the WebRTC offer (no ICE trickle — keeps SDP
-        // under the BEP44 1000-byte cap).
-        let (pc, dc, offer_sdp) = self.build_offer().await?;
+        // under the BEP44 1000-byte cap). If the resolved host record
+        // is v3 with a `turn_endpoint`, the PC picks up a relayed
+        // candidate for NAT-tolerant dials.
+        let (pc, dc, offer_sdp) = self
+            .build_offer(signed.record.turn_endpoint, &daemon_pk)
+            .await?;
 
         // RAII guard: if any stage 3-6 fails, close pc+dc before we
         // bubble the error. webrtc-rs's `RTCPeerConnection` holds UDP
@@ -329,15 +333,32 @@ impl Dialer {
     /// with zero candidates.
     pub async fn build_offer(
         &self,
+        turn_endpoint: Option<openhost_core::pkarr_record::TurnEndpoint>,
+        daemon_pk: &openhost_core::identity::PublicKey,
     ) -> Result<(Arc<RTCPeerConnection>, Arc<RTCDataChannel>, String)> {
         // STUN servers are mandatory for cross-NAT dials — without
         // them webrtc-rs gathers only `host`-type candidates and
         // can't discover the client's public address.
+        let mut ice_servers = vec![webrtc::ice_transport::ice_server::RTCIceServer {
+            urls: vec!["stun:stun.cloudflare.com:3478".to_string()],
+            ..Default::default()
+        }];
+        // v3 (PR #42.2): when the daemon advertises a TURN endpoint
+        // in its host record, add it here so ICE falls back to
+        // relayed candidates when direct hole-punching fails
+        // (symmetric NAT, UDP-blocked middleboxes, etc.). The TURN
+        // password is a public function of the daemon pubkey —
+        // derivable by both sides without a shared secret.
+        if let Some(ep) = turn_endpoint {
+            let password = crate::turn_creds::password_for_daemon(daemon_pk);
+            ice_servers.push(webrtc::ice_transport::ice_server::RTCIceServer {
+                urls: vec![format!("turn:{}:{}", ep.ip, ep.port)],
+                username: crate::turn_creds::TURN_USERNAME.to_string(),
+                credential: password,
+            });
+        }
         let config = RTCConfiguration {
-            ice_servers: vec![webrtc::ice_transport::ice_server::RTCIceServer {
-                urls: vec!["stun:stun.cloudflare.com:3478".to_string()],
-                ..Default::default()
-            }],
+            ice_servers,
             ..Default::default()
         };
         let pc = Arc::new(

--- a/crates/openhost-client/src/lib.rs
+++ b/crates/openhost-client/src/lib.rs
@@ -26,6 +26,7 @@ pub mod client;
 pub mod dialer;
 pub mod error;
 pub mod session;
+pub mod turn_creds;
 mod webrtc_helpers;
 
 pub use binding::{ClientBinder, ClientBindingError};

--- a/crates/openhost-client/src/turn_creds.rs
+++ b/crates/openhost-client/src/turn_creds.rs
@@ -1,0 +1,53 @@
+//! Client-side TURN credential derivation (PR #42.3).
+//!
+//! Mirrors `openhost-daemon::turn_server` — both sides compute the
+//! same password from the daemon's public Ed25519 identity, so a
+//! client with only the `oh://<daemon-pk>/` URL can authenticate
+//! against the daemon's embedded TURN relay without any pre-shared
+//! secret. The password is not actually secret (anyone who knows the
+//! daemon pubkey can compute it), but TURN long-term auth requires
+//! MESSAGE-INTEGRITY HMAC with matching inputs on both peers; this
+//! function provides that matching input.
+
+use openhost_core::identity::PublicKey;
+
+/// Fixed TURN realm advertised by openhost daemons.
+pub const TURN_REALM: &str = "openhost";
+
+/// Fixed TURN username clients must present.
+pub const TURN_USERNAME: &str = "openhost";
+
+/// Compute the long-term TURN password for a daemon, from its public
+/// key. See `openhost-daemon::turn_server::password_for_daemon` — the
+/// two functions MUST agree byte-for-byte.
+pub fn password_for_daemon(daemon_pk: &PublicKey) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(b"openhost-turn-v1");
+    h.update(daemon_pk.to_bytes());
+    let digest = h.finalize();
+    hex::encode(&digest[..16])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::identity::SigningKey;
+
+    #[test]
+    fn deterministic_per_daemon() {
+        let sk = SigningKey::from_bytes(&[0x11u8; 32]);
+        let pk = sk.public_key();
+        assert_eq!(password_for_daemon(&pk), password_for_daemon(&pk));
+    }
+
+    #[test]
+    fn differs_across_daemons() {
+        let sk_a = SigningKey::from_bytes(&[0x11u8; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22u8; 32]);
+        assert_ne!(
+            password_for_daemon(&sk_a.public_key()),
+            password_for_daemon(&sk_b.public_key())
+        );
+    }
+}

--- a/crates/openhost-client/tests/end_to_end.rs
+++ b/crates/openhost-client/tests/end_to_end.rs
@@ -107,6 +107,7 @@ fn daemon_config(tmp: &TempDir, watched: Vec<String>, upstream_port: Option<u16>
         }),
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 
@@ -385,7 +386,7 @@ async fn publish_fake_host_record(net: &MemoryPkarrNetwork, daemon_sk: &SigningK
         roles: "server".to_string(),
         salt: [0x11; SALT_LEN],
         disc: String::new(),
-        turn_port: None,
+        turn_endpoint: None,
     };
     let signed = SignedRecord::sign(record, daemon_sk).unwrap();
     let packet = encode(&signed, daemon_sk).unwrap();

--- a/crates/openhost-core/src/pkarr_record/mod.rs
+++ b/crates/openhost-core/src/pkarr_record/mod.rs
@@ -14,16 +14,34 @@ use crate::identity::{PublicKey, SigningKey};
 use crate::{Error, Result};
 use ed25519_dalek::Signature;
 use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+
+/// Reachability information for the daemon's embedded TURN relay.
+/// v3 schema trailer (PR #42.2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TurnEndpoint {
+    /// Publicly-reachable IPv4 address (the daemon's Elastic IP,
+    /// residential public IP, etc.). Operators configure this
+    /// explicitly in `[turn.public_ip]` — the daemon cannot discover
+    /// its own public IP reliably (EC2 is NATed behind an Elastic IP
+    /// mapping; most residential deployments are behind a home
+    /// router).
+    pub ip: Ipv4Addr,
+    /// UDP port the TURN server is bound to on the public IP.
+    /// Must be non-zero.
+    pub port: u16,
+}
 
 /// Default openhost protocol version emitted by builders that don't set
 /// any v3-only fields. Readers accept any version in
 /// [`MIN_SUPPORTED_VERSION`]..=[`MAX_SUPPORTED_VERSION`].
 ///
 /// v2 (PR #22) dropped the `allow` and `ice` fields from the canonical
-/// bytes. v3 (PR #42.1) introduces the optional `turn_port` sidecar. A
-/// v3 record is only emitted when `turn_port.is_some()`; otherwise
-/// builders still emit v2 bytes for wire compatibility with pre-v3
-/// decoders.
+/// bytes. v3 (PR #42.1 + PR #42.2) introduces the optional
+/// `turn_endpoint` sidecar (IPv4 address + UDP port) advertising the
+/// daemon's embedded TURN relay. A v3 record is only emitted when
+/// `turn_endpoint.is_some()`; otherwise builders still emit v2 bytes
+/// for wire compatibility with pre-v3 decoders.
 pub const PROTOCOL_VERSION: u8 = 2;
 
 /// Minimum record version a v3-aware decoder accepts. v1 is rejected —
@@ -81,14 +99,15 @@ pub struct OpenhostRecord {
     pub salt: [u8; SALT_LEN],
     /// Substrate discovery hints (informational). UTF-8, up to [`MAX_DISC_LEN`] bytes.
     pub disc: String,
-    /// Daemon's publicly-reachable UDP port for its embedded TURN
-    /// server, if one is enabled. `None` when the daemon does not
-    /// expose a TURN relay — clients then rely on direct ICE / STUN
-    /// only, which is fine on most home networks but fails under
-    /// symmetric NATs. Introduced in v3 (PR #42.1); a `Some(_)` value
-    /// forces `version = 3`.
+    /// Daemon's publicly-reachable IPv4 address + UDP port for its
+    /// embedded TURN server. Both fields are populated together in
+    /// v3 — a client can't dial TURN with only a port, and the
+    /// daemon's identity pubkey alone doesn't disclose an IP. A
+    /// `Some(_)` value forces `version = 3`; v2 records always have
+    /// `None`. IPv6 TURN is out of scope for v3; the field widens to
+    /// `IpAddr` in a future schema bump.
     #[serde(default)]
-    pub turn_port: Option<u16>,
+    pub turn_endpoint: Option<TurnEndpoint>,
 }
 
 impl OpenhostRecord {
@@ -99,24 +118,30 @@ impl OpenhostRecord {
         if self.version < MIN_SUPPORTED_VERSION || self.version > MAX_SUPPORTED_VERSION {
             return Err(Error::InvalidRecord("unsupported protocol version"));
         }
-        // turn_port is a v3-only field. Refuse a v2 record that claims
-        // to carry it — that would silently widen the signed surface.
-        if self.version < 3 && self.turn_port.is_some() {
+        // turn_endpoint is a v3-only field. Refuse a v2 record that
+        // claims to carry it — that would silently widen the signed
+        // surface.
+        if self.version < 3 && self.turn_endpoint.is_some() {
             return Err(Error::InvalidRecord(
-                "turn_port requires protocol version >= 3",
+                "turn_endpoint requires protocol version >= 3",
             ));
         }
-        // A v3 record MUST carry a turn_port; otherwise it's
-        // indistinguishable from v2 and should have been emitted as v2.
-        // (This keeps the version byte a meaningful capability flag.)
-        if self.version >= 3 && self.turn_port.is_none() {
+        // A v3 record MUST carry a turn_endpoint; otherwise it's
+        // indistinguishable from v2 and should have been emitted as
+        // v2. Keeps the version byte a meaningful capability flag.
+        if self.version >= 3 && self.turn_endpoint.is_none() {
             return Err(Error::InvalidRecord(
-                "v3 record missing turn_port (emit as v2 instead)",
+                "v3 record missing turn_endpoint (emit as v2 instead)",
             ));
         }
-        if let Some(port) = self.turn_port {
-            if port == 0 {
-                return Err(Error::InvalidRecord("turn_port must be non-zero"));
+        if let Some(ep) = self.turn_endpoint {
+            if ep.port == 0 {
+                return Err(Error::InvalidRecord("turn_endpoint.port must be non-zero"));
+            }
+            if ep.ip.is_unspecified() || ep.ip.is_loopback() {
+                return Err(Error::InvalidRecord(
+                    "turn_endpoint.ip must be a routable address",
+                ));
             }
         }
         // 2-hour window on either side.
@@ -155,9 +180,10 @@ impl OpenhostRecord {
     ///          || disc_len (2 bytes BE) || disc_bytes
     /// ```
     ///
-    /// v3 (PR #42.1) appends one trailer:
+    /// v3 (PR #42.1 + PR #42.2) appends one trailer:
     ///
     /// ```text
+    ///          || turn_ip (4 bytes, IPv4 in network order)
     ///          || turn_port (2 bytes BE, u16; MUST be non-zero)
     /// ```
     ///
@@ -196,8 +222,9 @@ impl OpenhostRecord {
         out.extend_from_slice(disc_bytes);
 
         // v3 trailer.
-        if let Some(port) = self.turn_port {
-            out.extend_from_slice(&port.to_be_bytes());
+        if let Some(ep) = self.turn_endpoint {
+            out.extend_from_slice(&ep.ip.octets());
+            out.extend_from_slice(&ep.port.to_be_bytes());
         }
 
         Ok(out)
@@ -259,7 +286,7 @@ mod tests {
             roles: "server".to_string(),
             salt,
             disc: "dht=1; relay=pkarr.example".to_string(),
-            turn_port: None,
+            turn_endpoint: None,
         }
     }
 
@@ -367,40 +394,63 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // v3 turn_port coverage (PR #42.1)
+    // v3 turn_endpoint coverage (PR #42.1 + PR #42.2)
     // ---------------------------------------------------------------------
 
-    #[test]
-    fn v3_round_trip_preserves_turn_port() {
-        let mut r = sample_record(1_700_000_000);
-        r.version = 3;
-        r.turn_port = Some(3478);
-        let bytes = r.canonical_signing_bytes().unwrap();
-        // v3 trailer is the last two bytes, big-endian u16 port.
-        assert_eq!(bytes[bytes.len() - 2..], 3478u16.to_be_bytes());
+    fn v3_endpoint() -> TurnEndpoint {
+        TurnEndpoint {
+            ip: std::net::Ipv4Addr::new(3, 238, 149, 237),
+            port: 3478,
+        }
     }
 
     #[test]
-    fn v3_without_turn_port_rejected() {
+    fn v3_round_trip_preserves_turn_endpoint() {
         let mut r = sample_record(1_700_000_000);
         r.version = 3;
-        r.turn_port = None;
+        r.turn_endpoint = Some(v3_endpoint());
+        let bytes = r.canonical_signing_bytes().unwrap();
+        // Trailer = IPv4 (4 bytes) + port (2 bytes BE) = 6 bytes.
+        let trailer = &bytes[bytes.len() - 6..];
+        assert_eq!(&trailer[..4], &[3u8, 238, 149, 237]);
+        assert_eq!(&trailer[4..], &3478u16.to_be_bytes());
+    }
+
+    #[test]
+    fn v3_without_turn_endpoint_rejected() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 3;
+        r.turn_endpoint = None;
         assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
     }
 
     #[test]
-    fn v2_with_turn_port_rejected() {
+    fn v2_with_turn_endpoint_rejected() {
         let mut r = sample_record(1_700_000_000);
         r.version = 2;
-        r.turn_port = Some(3478);
+        r.turn_endpoint = Some(v3_endpoint());
         assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
     }
 
     #[test]
-    fn turn_port_zero_rejected() {
+    fn turn_endpoint_zero_port_rejected() {
         let mut r = sample_record(1_700_000_000);
         r.version = 3;
-        r.turn_port = Some(0);
+        r.turn_endpoint = Some(TurnEndpoint {
+            ip: std::net::Ipv4Addr::new(1, 2, 3, 4),
+            port: 0,
+        });
+        assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
+    }
+
+    #[test]
+    fn turn_endpoint_loopback_ip_rejected() {
+        let mut r = sample_record(1_700_000_000);
+        r.version = 3;
+        r.turn_endpoint = Some(TurnEndpoint {
+            ip: std::net::Ipv4Addr::new(127, 0, 0, 1),
+            port: 3478,
+        });
         assert!(matches!(r.validate(r.ts), Err(Error::InvalidRecord(_))));
     }
 
@@ -410,21 +460,17 @@ mod tests {
         let pk = sk.public_key();
         let mut record = sample_record(1_700_000_000);
         record.version = 3;
-        record.turn_port = Some(3478);
+        record.turn_endpoint = Some(v3_endpoint());
         let signed = SignedRecord::sign(record.clone(), &sk).unwrap();
         signed.verify(&pk, record.ts).expect("v3 verifies");
     }
 
     #[test]
     fn v2_records_still_encode_after_v3_landing() {
-        // Regression guard: PR #42.1 must not change v2 bytes. A v2
-        // record signed pre-PR and another signed post-PR MUST yield
-        // identical canonical bytes for the same logical record.
+        // Regression guard: PR #42.1/.2 must not change v2 bytes.
         let r = sample_record(1_700_000_000);
         let bytes = r.canonical_signing_bytes().unwrap();
-        // v2 record ends with the disc trailer; no turn_port byte.
-        // Sanity-check length equals the sum of fixed-width fields +
-        // variable-width roles + variable-width disc (no trailer).
+        // v2 record ends with the disc trailer; no v3 trailer bytes.
         let roles_len = r.roles.len();
         let disc_len = r.disc.len();
         let expected = 1 + 9 + 1 + 8 + 32 + 1 + roles_len + 32 + 2 + disc_len;

--- a/crates/openhost-core/tests/end_to_end.rs
+++ b/crates/openhost-core/tests/end_to_end.rs
@@ -50,7 +50,7 @@ fn host_publishes_client_resolves_signs_and_exchanges_frames() {
         roles: "server".into(),
         salt,
         disc: "dht=1".into(),
-        turn_port: None,
+        turn_endpoint: None,
     };
     let signed = SignedRecord::sign(record, &host_sk).expect("sign");
 

--- a/crates/openhost-core/tests/pkarr_record_vectors.rs
+++ b/crates/openhost-core/tests/pkarr_record_vectors.rs
@@ -34,6 +34,8 @@ struct RecordFields {
     salt_hex: String,
     disc: String,
     #[serde(default)]
+    turn_ip: Option<String>,
+    #[serde(default)]
     turn_port: Option<u16>,
 }
 
@@ -43,6 +45,14 @@ fn decode_hex32(s: &str) -> [u8; 32] {
 }
 
 fn build_record(r: &RecordFields) -> OpenhostRecord {
+    use openhost_core::pkarr_record::TurnEndpoint;
+    let turn_endpoint = match (r.turn_ip.as_deref(), r.turn_port) {
+        (Some(ip), Some(port)) => Some(TurnEndpoint {
+            ip: ip.parse().expect("turn_ip is a valid IPv4"),
+            port,
+        }),
+        _ => None,
+    };
     OpenhostRecord {
         version: r.version,
         ts: r.ts,
@@ -50,7 +60,7 @@ fn build_record(r: &RecordFields) -> OpenhostRecord {
         roles: r.roles.clone(),
         salt: decode_hex32(&r.salt_hex),
         disc: r.disc.clone(),
-        turn_port: r.turn_port,
+        turn_endpoint,
     }
 }
 

--- a/crates/openhost-daemon/Cargo.toml
+++ b/crates/openhost-daemon/Cargo.toml
@@ -57,6 +57,13 @@ pkarr = { workspace = true }
 # WebRTC listener (PR #5). `pem` feature enables RTCCertificate::from_pem so
 # we can hand DtlsCertificate.pem_bundle directly to webrtc-rs.
 webrtc = { workspace = true }
+# Embedded TURN relay (PR #42.2). Bound only when [turn].enabled is
+# true in config; the daemon otherwise never creates a TURN socket.
+turn = { workspace = true }
+# The `turn::relay::relay_static::RelayAddressGeneratorStatic` struct
+# requires `Arc<webrtc_util::vnet::net::Net>`; the crate's version must
+# match the one inside the webrtc-rs workspace `turn` pulls from.
+webrtc-util = "0.9"
 bytes = "1"
 # rustls 0.23 decoupled crypto providers from the default feature set; the
 # daemon installs `ring` as the process-wide provider before the listener

--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -58,6 +58,10 @@ pub struct App {
     /// the daemon keeps running and pairing changes fall back to the
     /// SIGHUP path (Unix) or a restart (Windows).
     pair_watcher: Option<crate::pair_watcher::PairWatcher>,
+    /// Embedded TURN relay (PR #42.2). `Some` only when
+    /// `[turn] enabled = true` in config. Dropped alongside the other
+    /// subsystems on shutdown.
+    turn: Option<crate::turn_server::TurnHandle>,
 }
 
 impl App {
@@ -69,6 +73,7 @@ impl App {
         let forwarder = build_forwarder(&cfg)?;
         let listener =
             build_listener(&cert, identity.clone(), state.clone(), forwarder.clone()).await?;
+        let turn = maybe_spawn_turn(&cfg, &identity, &state).await?;
         let (publisher, resolver) =
             publish::start(&cfg.pkarr, identity.clone(), state.clone()).await?;
         let poller = build_offer_poller(
@@ -93,6 +98,7 @@ impl App {
             poller,
             pair_db_path,
             pair_watcher,
+            turn,
         })
     }
 
@@ -121,6 +127,7 @@ impl App {
             poller: None,
             pair_db_path,
             pair_watcher,
+            turn: None,
         })
     }
 
@@ -163,6 +170,7 @@ impl App {
             poller,
             pair_db_path,
             pair_watcher,
+            turn: None,
         })
     }
 
@@ -293,6 +301,11 @@ impl App {
         }
         if let Some(w) = self.pair_watcher.take() {
             w.shutdown();
+        }
+        if let Some(t) = self.turn.take() {
+            if let Err(err) = t.shutdown().await {
+                tracing::warn!(?err, "openhostd: TURN relay shutdown error");
+            }
         }
         self.publisher.shutdown().await;
         tracing::info!("openhostd: bye");
@@ -475,6 +488,52 @@ fn resolve_pair_db_path(cfg: &Config) -> PathBuf {
         .db_path
         .clone()
         .unwrap_or_else(pairing::default_db_path)
+}
+
+/// Spawn the embedded TURN relay when `[turn] enabled = true`,
+/// otherwise return `None` and leave the publisher's v2 path intact.
+///
+/// On success, installs `turn_endpoint` on [`SharedState`] so the
+/// publisher's next `snapshot_record` call emits a v3 record.
+async fn maybe_spawn_turn(
+    cfg: &Config,
+    identity: &Arc<SigningKey>,
+    state: &Arc<SharedState>,
+) -> Result<Option<crate::turn_server::TurnHandle>> {
+    if !cfg.turn.enabled {
+        return Ok(None);
+    }
+    let public_ip = cfg.turn.public_ip.ok_or_else(|| {
+        crate::error::DaemonError::Turn(
+            "turn.enabled = true requires turn.public_ip to be set".into(),
+        )
+    })?;
+    let bind_addr: std::net::SocketAddr = cfg.turn.bind_addr.parse().map_err(|_| {
+        crate::error::DaemonError::Turn(format!(
+            "turn.bind_addr is not a valid socket address: {}",
+            cfg.turn.bind_addr
+        ))
+    })?;
+    let runtime_cfg = crate::turn_server::TurnRuntimeConfig {
+        bind_addr,
+        public_ip,
+    };
+    let handle = crate::turn_server::spawn(&runtime_cfg, &identity.public_key())
+        .await
+        .map_err(|e| {
+            crate::error::DaemonError::Turn(format!("failed to spawn TURN server: {e}"))
+        })?;
+    let public_port = cfg.turn.public_port.unwrap_or(bind_addr.port());
+    state.set_turn_endpoint(Some(openhost_core::pkarr_record::TurnEndpoint {
+        ip: public_ip,
+        port: public_port,
+    }));
+    tracing::info!(
+        public_ip = %public_ip,
+        public_port,
+        "openhostd: TURN relay advertised in host record (v3)"
+    );
+    Ok(Some(handle))
 }
 
 /// Load the pairing DB into `state.allow`. Missing file = empty allow

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -37,6 +37,9 @@ pub struct Config {
     /// Pairing-database configuration.
     #[serde(default)]
     pub pairing: PairingConfig,
+    /// Embedded TURN relay (PR #42.2). Disabled by default.
+    #[serde(default)]
+    pub turn: TurnConfig,
 }
 
 /// Identity keystore configuration.
@@ -153,6 +156,40 @@ impl Default for PairingConfig {
 
 fn default_pair_watch_debounce_ms() -> u64 {
     250
+}
+
+/// Embedded TURN relay configuration (PR #42.2). Opt-in: every field
+/// has a safe default, and `enabled = false` keeps the daemon's
+/// behavior byte-identical to pre-PR deployments.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct TurnConfig {
+    /// Whether to bind the TURN relay and advertise it in the v3
+    /// host record.
+    pub enabled: bool,
+    /// Local UDP socket to bind. Typically `0.0.0.0:3478`; override to
+    /// pick a non-default port if 3478 is occupied or firewalled.
+    pub bind_addr: String,
+    /// Publicly-reachable IPv4 address the TURN server advertises as
+    /// the relay's external endpoint (Elastic IP, port-forwarded
+    /// router IP, etc.). Must match the IP reachable by external
+    /// clients from the internet.
+    pub public_ip: Option<std::net::Ipv4Addr>,
+    /// Port number published in the host record's `turn_endpoint`.
+    /// Defaults to the port component of `bind_addr`; override when
+    /// the daemon is port-mapped (NAT-PMP / UPnP / manual DNAT).
+    pub public_port: Option<u16>,
+}
+
+impl Default for TurnConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_addr: "0.0.0.0:3478".to_string(),
+            public_ip: None,
+            public_port: None,
+        }
+    }
 }
 
 fn default_enforce_allowlist() -> bool {
@@ -458,6 +495,7 @@ pub fn seed_config(data_dir: &Path) -> Config {
         forward: None,
         log: LogConfig::default(),
         pairing: PairingConfig::default(),
+        turn: TurnConfig::default(),
     }
 }
 

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -51,6 +51,10 @@ pub enum DaemonError {
     /// Low-level I/O failure not caught by a more specific variant.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// Embedded TURN relay spawn or misconfiguration (PR #42.2).
+    #[error("turn relay error: {0}")]
+    Turn(String),
 }
 
 /// Pair-DB file-watcher failures.

--- a/crates/openhost-daemon/src/lib.rs
+++ b/crates/openhost-daemon/src/lib.rs
@@ -33,6 +33,7 @@ pub mod pairing;
 pub mod publish;
 pub mod rate_limit;
 pub mod signal;
+pub mod turn_server;
 
 pub use app::{init_tracing, App};
 pub use channel_binding::{ChannelBinder, ChannelBindingError};

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -66,6 +66,10 @@ pub struct SharedState {
     ///
     /// [`snapshot_answers`]: SharedState::snapshot_answers
     answers: RwLock<HashMap<[u8; CLIENT_HASH_LEN], AnswerEntry>>,
+    /// Optional embedded-TURN endpoint to advertise in v3 host records.
+    /// `None` emits a v2 record (default); `Some` emits v3 with the
+    /// daemon's publicly-reachable TURN IP + UDP port.
+    turn_endpoint: RwLock<Option<openhost_core::pkarr_record::TurnEndpoint>>,
 }
 
 impl SharedState {
@@ -84,7 +88,17 @@ impl SharedState {
             allow: RwLock::new(Vec::new()),
             roles: "server".to_string(),
             answers: RwLock::new(HashMap::new()),
+            turn_endpoint: RwLock::new(None),
         }
+    }
+
+    /// Install (or clear) the TURN endpoint advertised in the host
+    /// record. Called by [`App::build`] when `[turn] enabled = true`.
+    pub fn set_turn_endpoint(&self, ep: Option<openhost_core::pkarr_record::TurnEndpoint>) {
+        *self
+            .turn_endpoint
+            .write()
+            .expect("turn_endpoint lock poisoned") = ep;
     }
 
     /// Queue an answer entry for publication. The entry is keyed on
@@ -184,16 +198,26 @@ impl SharedState {
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
+        let turn_endpoint = *self
+            .turn_endpoint
+            .read()
+            .expect("turn_endpoint lock poisoned");
+        // Deployments that leave [turn].enabled = false emit a v2 record
+        // (byte-identical to pre-PR #42 output). When turn_endpoint is
+        // Some, bump to v3 so the trailer is included on the wire.
+        let version = if turn_endpoint.is_some() {
+            3
+        } else {
+            PROTOCOL_VERSION
+        };
         OpenhostRecord {
-            version: PROTOCOL_VERSION,
+            version,
             ts,
             dtls_fp: self.dtls_fp(),
             roles: self.roles.clone(),
             salt: self.salt,
             disc: String::new(),
-            // PR #42.1 only wires the field through; PR #42.2 populates
-            // it from daemon config when TURN is enabled.
-            turn_port: None,
+            turn_endpoint,
         }
     }
 }

--- a/crates/openhost-daemon/src/turn_server.rs
+++ b/crates/openhost-daemon/src/turn_server.rs
@@ -1,0 +1,189 @@
+//! Embedded TURN relay (PR #42.2).
+//!
+//! When `[turn] enabled = true` in `config.toml`, the daemon stands
+//! up a small TURN server bound to a UDP port. Clients dialling
+//! through pkarr read the `turn_endpoint` field from the v3 host
+//! record, add a TURN ICE server to their `RTCPeerConnection`
+//! configuration, and get a relay fallback path when direct
+//! hole-punching fails (symmetric NAT, UDP-blocking middleboxes,
+//! CGNAT asymmetry, etc.).
+//!
+//! Authentication is intentionally thin: the realm, username, and
+//! password are all derivable from the daemon's public Ed25519
+//! identity key, which any client already knows from the `oh://`
+//! URL. This means ANY openhost-aware client can allocate a relay
+//! on the daemon — the goal is not secrecy but rate-limit
+//! defensibility (the daemon's upstream HTTP is still gated by the
+//! existing openhost auth handshake inside the WebRTC datachannel;
+//! TURN is a transport primitive, not an authorisation boundary).
+//!
+//! If abuse becomes a problem, PR #43+ will tighten the scheme with
+//! short-lived credentials signed by the daemon key.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use openhost_core::identity::PublicKey;
+use tokio::net::UdpSocket;
+use turn::auth::{generate_auth_key, AuthHandler};
+use turn::relay::relay_static::RelayAddressGeneratorStatic;
+use turn::server::config::{ConnConfig, ServerConfig};
+use turn::server::Server;
+use turn::Error as TurnError;
+use webrtc_util::vnet::net::Net;
+
+/// Realm the daemon's TURN server advertises. Fixed string so clients
+/// can compute credentials without reading the host record twice.
+pub const TURN_REALM: &str = "openhost";
+
+/// Username clients must present. Single shared username because
+/// TURN clients authenticate with STUN MESSAGE-INTEGRITY that hashes
+/// `username:realm:password`; opaque usernames would require extra
+/// wire to distribute per-client credentials.
+pub const TURN_USERNAME: &str = "openhost";
+
+/// Compute the TURN long-term credential password for a given daemon
+/// public key. Both sides — daemon (`auth_handle`) and client
+/// (`openhost-client` / extension ICE config) — run this identical
+/// function, so no secret transport is needed.
+///
+/// Construction: `lower_hex(sha256("openhost-turn-v1" || daemon_pk))`
+/// truncated to 32 hex chars (128 bits). Strictly deterministic;
+/// strictly derivable from public state. The value is not secret —
+/// it exists solely so the TURN MESSAGE-INTEGRITY HMAC has the same
+/// input on both sides.
+pub fn password_for_daemon(daemon_pk: &PublicKey) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(b"openhost-turn-v1");
+    h.update(daemon_pk.to_bytes());
+    let digest = h.finalize();
+    hex::encode(&digest[..16])
+}
+
+/// Auth handler that resolves every STUN `LongTermCredentials` request
+/// to the same daemon-pk-derived credential. The TURN server stores
+/// a single HMAC-MD5 key derived from (username, realm, password);
+/// `auth_handle` hands that back whenever the username matches.
+struct DaemonAuthHandler {
+    // Store the already-computed HMAC-MD5 digest (`generate_auth_key`)
+    // so we don't recompute on every inbound STUN transaction.
+    key: Vec<u8>,
+}
+
+impl AuthHandler for DaemonAuthHandler {
+    fn auth_handle(
+        &self,
+        username: &str,
+        _realm: &str,
+        _src_addr: SocketAddr,
+    ) -> Result<Vec<u8>, TurnError> {
+        if username == TURN_USERNAME {
+            Ok(self.key.clone())
+        } else {
+            Err(TurnError::ErrFakeErr)
+        }
+    }
+}
+
+/// A running TURN server. Drop the handle to shut down the server.
+pub struct TurnHandle {
+    server: Server,
+}
+
+impl TurnHandle {
+    /// Stop the server and release the UDP socket.
+    pub async fn shutdown(self) -> Result<(), TurnError> {
+        self.server.close().await
+    }
+}
+
+/// Configuration for the embedded TURN relay.
+#[derive(Debug, Clone)]
+pub struct TurnRuntimeConfig {
+    /// UDP socket address to bind on locally. For AWS-like deployments
+    /// this is `0.0.0.0:<port>`; the security group takes care of
+    /// what reaches this port from outside.
+    pub bind_addr: SocketAddr,
+    /// Publicly-reachable IPv4 address the TURN server advertises as
+    /// the relay's IP in the XOR-RELAYED-ADDRESS attribute returned
+    /// to clients. For EC2 this is the Elastic IP; for a home box
+    /// it's the router's public IP.
+    pub public_ip: Ipv4Addr,
+}
+
+/// Spawn a TURN server on the configured socket with auth keyed by
+/// the daemon's public identity.
+///
+/// The returned [`TurnHandle`] owns the server; dropping it OR calling
+/// [`TurnHandle::shutdown`] releases the socket. Typical usage:
+/// store on `App` state for the process lifetime.
+pub async fn spawn(
+    cfg: &TurnRuntimeConfig,
+    daemon_pk: &PublicKey,
+) -> Result<TurnHandle, TurnError> {
+    let conn = Arc::new(UdpSocket::bind(cfg.bind_addr).await?);
+    tracing::info!(
+        addr = %conn.local_addr()?,
+        public_ip = %cfg.public_ip,
+        "openhostd: TURN relay listening"
+    );
+
+    let password = password_for_daemon(daemon_pk);
+    let key = generate_auth_key(TURN_USERNAME, TURN_REALM, &password);
+
+    let server = Server::new(ServerConfig {
+        conn_configs: vec![ConnConfig {
+            conn,
+            relay_addr_generator: Box::new(RelayAddressGeneratorStatic {
+                relay_address: IpAddr::V4(cfg.public_ip),
+                address: "0.0.0.0".to_owned(),
+                net: Arc::new(Net::new(None)),
+            }),
+        }],
+        realm: TURN_REALM.to_owned(),
+        auth_handler: Arc::new(DaemonAuthHandler { key }),
+        channel_bind_timeout: std::time::Duration::from_secs(0),
+        alloc_close_notify: None,
+    })
+    .await?;
+
+    Ok(TurnHandle { server })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use openhost_core::identity::SigningKey;
+
+    #[test]
+    fn password_is_deterministic_per_daemon() {
+        let sk = SigningKey::from_bytes(&[0x11u8; 32]);
+        let pk = sk.public_key();
+        let a = password_for_daemon(&pk);
+        let b = password_for_daemon(&pk);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 32); // 16 bytes hex = 32 chars
+    }
+
+    #[test]
+    fn password_differs_across_daemons() {
+        let sk_a = SigningKey::from_bytes(&[0x11u8; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22u8; 32]);
+        assert_ne!(
+            password_for_daemon(&sk_a.public_key()),
+            password_for_daemon(&sk_b.public_key())
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_and_shutdown_cleanly() {
+        let sk = SigningKey::from_bytes(&[0x33u8; 32]);
+        let cfg = TurnRuntimeConfig {
+            bind_addr: "127.0.0.1:0".parse().unwrap(),
+            public_ip: Ipv4Addr::new(127, 0, 0, 1),
+        };
+        let handle = spawn(&cfg, &sk.public_key()).await.expect("spawn succeeds");
+        handle.shutdown().await.expect("shutdown succeeds");
+    }
+}

--- a/crates/openhost-daemon/tests/bootstrap.rs
+++ b/crates/openhost-daemon/tests/bootstrap.rs
@@ -55,6 +55,7 @@ fn test_config(dir: &TempDir) -> Config {
         forward: None,
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -54,6 +54,7 @@ fn test_config(dir: &TempDir, upstream_port: u16) -> Config {
         }),
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/offer_poll.rs
+++ b/crates/openhost-daemon/tests/offer_poll.rs
@@ -72,6 +72,7 @@ fn daemon_config(
         forward: None,
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/pair_watcher.rs
+++ b/crates/openhost-daemon/tests/pair_watcher.rs
@@ -56,6 +56,7 @@ fn build_config(tmp: &TempDir, pair_db_path: std::path::PathBuf) -> Config {
             // 250 ms window on every modification.
             watch_debounce_ms: 50,
         },
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/pairing_enforcement.rs
+++ b/crates/openhost-daemon/tests/pairing_enforcement.rs
@@ -72,6 +72,7 @@ fn build_config(
             db_path: pair_db_path,
             ..PairingConfig::default()
         },
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -42,6 +42,7 @@ fn real_config(dir: &TempDir) -> Config {
         forward: None,
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -206,6 +206,7 @@ pub fn test_config_noforward(dir: &tempfile::TempDir) -> openhost_daemon::Config
         forward: None,
         log: LogConfig::default(),
         pairing: Default::default(),
+        turn: Default::default(),
     }
 }
 

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -101,6 +101,12 @@ pub struct HostRecord {
     pub salt_hex: String,
     /// UTF-8 discovery hints.
     pub disc: String,
+    /// v3 sidecar (PR #42.2): daemon's embedded-TURN relay IPv4
+    /// address, if it advertises one. `None` for v2 records.
+    pub turn_ip: Option<String>,
+    /// v3 sidecar (PR #42.2): daemon's embedded-TURN relay UDP
+    /// port, if it advertises one. Paired with `turn_ip`.
+    pub turn_port: Option<u16>,
     /// 64-byte Ed25519 signature, hex. Already validated against
     /// `pubkey_zbase32` when this value came from
     /// [`decode_and_verify`]; advisory only when it came from
@@ -169,6 +175,8 @@ fn host_record_dto(pubkey_zbase32: &str, signed: &SignedRecord) -> HostRecord {
         roles: r.roles.clone(),
         salt_hex: hex::encode(r.salt),
         disc: r.disc.clone(),
+        turn_ip: r.turn_endpoint.map(|ep| ep.ip.to_string()),
+        turn_port: r.turn_endpoint.map(|ep| ep.port),
         signature_hex: hex::encode(signed.signature.to_bytes()),
     }
 }

--- a/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
+++ b/crates/openhost-pkarr-wasm/tests/wasm_smoke.rs
@@ -25,7 +25,7 @@ fn sample_signed_record(ts: u64) -> (SigningKey, SignedRecord) {
         roles: "server".to_string(),
         salt: [0x22; SALT_LEN],
         disc: String::new(),
-        turn_port: None,
+        turn_endpoint: None,
     };
     let signed = SignedRecord::sign(record, &sk).unwrap();
     (sk, signed)

--- a/crates/openhost-pkarr/src/codec.rs
+++ b/crates/openhost-pkarr/src/codec.rs
@@ -239,13 +239,12 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
         .map_err(|_| PkarrError::MalformedCanonical("disc is not valid UTF-8"))?
         .to_string();
 
-    // v3 trailer: an optional u16 BE `turn_port`. v2 records stop at
-    // disc; v3 records carry exactly 2 more bytes. Anything in between
-    // is a malformed record.
-    let turn_port = match (version, r.is_empty()) {
+    // v3 trailer: IPv4 address (4 bytes) + UDP port (2 bytes BE). v2
+    // records stop at disc; v3 records carry exactly 6 more bytes.
+    let turn_endpoint = match (version, r.is_empty()) {
         (v, true) if v >= 3 => {
             return Err(PkarrError::MalformedCanonical(
-                "v3 record missing turn_port trailer",
+                "v3 record missing turn_endpoint trailer",
             ))
         }
         (_, true) => None,
@@ -255,16 +254,28 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
             ));
         }
         (_, false) => {
+            let ip_bytes: [u8; 4] = r
+                .take(4)?
+                .try_into()
+                .map_err(|_| PkarrError::MalformedCanonical("turn_endpoint.ip truncated"))?;
+            let ip = std::net::Ipv4Addr::from(ip_bytes);
             let port = r.u16_be()?;
             if !r.is_empty() {
                 return Err(PkarrError::MalformedCanonical(
-                    "trailing bytes after v3 turn_port",
+                    "trailing bytes after v3 turn_endpoint",
                 ));
             }
             if port == 0 {
-                return Err(PkarrError::MalformedCanonical("turn_port must be non-zero"));
+                return Err(PkarrError::MalformedCanonical(
+                    "turn_endpoint.port must be non-zero",
+                ));
             }
-            Some(port)
+            if ip.is_unspecified() || ip.is_loopback() {
+                return Err(PkarrError::MalformedCanonical(
+                    "turn_endpoint.ip must be routable",
+                ));
+            }
+            Some(openhost_core::pkarr_record::TurnEndpoint { ip, port })
         }
     };
 
@@ -275,7 +286,7 @@ fn parse_canonical_bytes(bytes: &[u8]) -> Result<OpenhostRecord> {
         roles,
         salt,
         disc,
-        turn_port,
+        turn_endpoint,
     })
 }
 
@@ -460,25 +471,31 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
-    // v3 turn_port codec coverage (PR #42.1)
+    // v3 turn_endpoint codec coverage (PR #42.1 + PR #42.2)
     // ---------------------------------------------------------------------
 
-    fn v3_record(port: u16) -> OpenhostRecord {
+    fn v3_record(ip: [u8; 4], port: u16) -> OpenhostRecord {
+        use openhost_core::pkarr_record::TurnEndpoint;
         OpenhostRecord {
             version: 3,
-            turn_port: Some(port),
+            turn_endpoint: Some(TurnEndpoint {
+                ip: std::net::Ipv4Addr::from(ip),
+                port,
+            }),
             ..reference_record()
         }
     }
 
     #[test]
-    fn v3_round_trip_preserves_turn_port() {
+    fn v3_round_trip_preserves_turn_endpoint() {
         let sk = SigningKey::from_bytes(&RFC_SEED);
-        let record = v3_record(3478);
+        let record = v3_record([3, 238, 149, 237], 3478);
         let signed = SignedRecord::sign(record.clone(), &sk).unwrap();
         let packet = encode(&signed, &sk).unwrap();
         let decoded = decode(&packet).unwrap();
-        assert_eq!(decoded.record.turn_port, Some(3478));
+        let ep = decoded.record.turn_endpoint.expect("ep present");
+        assert_eq!(ep.ip.octets(), [3, 238, 149, 237]);
+        assert_eq!(ep.port, 3478);
         assert_eq!(decoded.record.version, 3);
     }
 
@@ -486,7 +503,7 @@ mod tests {
     fn v3_signed_record_verifies_against_pubkey() {
         let sk = SigningKey::from_bytes(&RFC_SEED);
         let pk = sk.public_key();
-        let signed = SignedRecord::sign(v3_record(3478), &sk).unwrap();
+        let signed = SignedRecord::sign(v3_record([3, 238, 149, 237], 3478), &sk).unwrap();
         let packet = encode(&signed, &sk).unwrap();
         let decoded = decode(&packet).unwrap();
         decoded.verify(&pk, decoded.record.ts).expect("v3 verifies");
@@ -500,11 +517,16 @@ mod tests {
         let v2_record = reference_record();
         let v2_signed = SignedRecord::sign(v2_record.clone(), &sk).unwrap();
         let v2_packet = encode(&v2_signed, &sk).unwrap();
-        assert_eq!(decode(&v2_packet).unwrap().record.turn_port, None);
+        assert!(decode(&v2_packet).unwrap().record.turn_endpoint.is_none());
 
-        let v3_signed = SignedRecord::sign(v3_record(51820), &sk).unwrap();
+        let v3_signed = SignedRecord::sign(v3_record([10, 0, 0, 1], 51820), &sk).unwrap();
         let v3_packet = encode(&v3_signed, &sk).unwrap();
-        assert_eq!(decode(&v3_packet).unwrap().record.turn_port, Some(51820));
+        let ep = decode(&v3_packet)
+            .unwrap()
+            .record
+            .turn_endpoint
+            .expect("v3 ep");
+        assert_eq!(ep.port, 51820);
     }
 
     /// Sanity-check: a v2 record with a maxed-out `disc` still encodes

--- a/crates/openhost-pkarr/src/test_fakes.rs
+++ b/crates/openhost-pkarr/src/test_fakes.rs
@@ -137,7 +137,7 @@ mod tests {
             roles: "server".to_string(),
             salt: [0x22; SALT_LEN],
             disc: String::new(),
-            turn_port: None,
+            turn_endpoint: None,
         };
         let signed = SignedRecord::sign(record, &sk).unwrap();
         let packet = encode(&signed, &sk).unwrap();

--- a/crates/openhost-pkarr/src/test_support.rs
+++ b/crates/openhost-pkarr/src/test_support.rs
@@ -25,6 +25,6 @@ pub(crate) fn sample_record(ts: u64) -> OpenhostRecord {
         roles: "server".to_string(),
         salt,
         disc: String::new(),
-        turn_port: None,
+        turn_endpoint: None,
     }
 }

--- a/crates/openhost-pkarr/tests/round_trip.rs
+++ b/crates/openhost-pkarr/tests/round_trip.rs
@@ -36,6 +36,16 @@ fn reference_record() -> OpenhostRecord {
     let mut salt = [0u8; 32];
     salt.copy_from_slice(&hex::decode(r["salt_hex"].as_str().unwrap()).unwrap());
 
+    let turn_endpoint = match (
+        r.get("turn_ip").and_then(|v| v.as_str()),
+        r.get("turn_port").and_then(|v| v.as_u64()),
+    ) {
+        (Some(ip), Some(port)) => Some(openhost_core::pkarr_record::TurnEndpoint {
+            ip: ip.parse().unwrap(),
+            port: port as u16,
+        }),
+        _ => None,
+    };
     OpenhostRecord {
         version: r["version"].as_u64().unwrap() as u8,
         ts: r["ts"].as_u64().unwrap(),
@@ -43,10 +53,7 @@ fn reference_record() -> OpenhostRecord {
         roles: r["roles"].as_str().unwrap().to_string(),
         salt,
         disc: r["disc"].as_str().unwrap().to_string(),
-        turn_port: r
-            .get("turn_port")
-            .and_then(|v| v.as_u64())
-            .map(|p| p as u16),
+        turn_endpoint,
     }
 }
 

--- a/extension/src/dialer/openhost_session.js
+++ b/extension/src/dialer/openhost_session.js
@@ -175,8 +175,28 @@ export async function dialOhUrl(ohUrl, opts = {}) {
   // of a host daemon can add it to their `watched_clients` allowlist.
   console.log("openhost dialer: client_pubkey_zbase32 =", clientPkZ);
 
-  // 3. Build RTCPeerConnection + data channel.
-  const pc = new RTCPeerConnection({ iceServers: STUN });
+  // 3. Build RTCPeerConnection + data channel. When the resolved
+  // host record carries a v3 `turn_endpoint` (daemon advertises an
+  // embedded TURN relay), add it to the ICE servers list so the PC
+  // can fall back to a relayed candidate when direct hole-punching
+  // fails. The TURN password is derived from the daemon's public
+  // key — both sides compute the same value without a shared secret.
+  const iceServers = [...STUN];
+  if (hostRecord.turn_ip && hostRecord.turn_port) {
+    const { turnIceServerFor } = await import("./turn_creds.js");
+    const turnServer = await turnIceServerFor(daemonPkZ, {
+      ip: hostRecord.turn_ip,
+      port: hostRecord.turn_port,
+    });
+    if (turnServer) {
+      iceServers.push(turnServer);
+      console.log(
+        "openhost dialer: TURN relay advertised —",
+        turnServer.urls[0],
+      );
+    }
+  }
+  const pc = new RTCPeerConnection({ iceServers });
   const dc = pc.createDataChannel("openhost", { ordered: true });
   const reader = new FrameReader();
   dc.binaryType = "arraybuffer";

--- a/extension/src/dialer/turn_creds.js
+++ b/extension/src/dialer/turn_creds.js
@@ -1,0 +1,64 @@
+// Client-side TURN credential derivation (PR #42.3, JS mirror of
+// `openhost-client::turn_creds`). The password is a public function
+// of the daemon's Ed25519 identity — anyone with the `oh://<pk>/`
+// URL can compute it. TURN long-term auth needs MESSAGE-INTEGRITY
+// HMAC with matching inputs on both peers; this provides that
+// matching input without a shared secret.
+
+export const TURN_REALM = "openhost";
+export const TURN_USERNAME = "openhost";
+
+// Decode the 52-char z-base-32 daemon pubkey to the raw 32 Ed25519 bytes.
+// Minimal zbase32 decoder — the alphabet is openhost's 52-char canonical
+// form "ybndrfg8ejkmcpqxot1uwisza345h769".
+const ZBASE32_ALPHABET = "ybndrfg8ejkmcpqxot1uwisza345h769";
+
+function zbase32Decode(s) {
+  const bits = [];
+  for (const ch of s.toLowerCase()) {
+    const idx = ZBASE32_ALPHABET.indexOf(ch);
+    if (idx < 0) throw new Error(`invalid zbase32 char: ${ch}`);
+    for (let i = 4; i >= 0; i--) bits.push((idx >> i) & 1);
+  }
+  // We encoded 32 bytes = 256 bits into 52 chars * 5 = 260 bits;
+  // the trailing 4 bits are padding zeros — drop them.
+  const trimmed = bits.slice(0, 256);
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    let byte = 0;
+    for (let j = 0; j < 8; j++) byte = (byte << 1) | trimmed[i * 8 + j];
+    out[i] = byte;
+  }
+  return out;
+}
+
+function hexEncode(bytes) {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// Match `openhost-daemon::turn_server::password_for_daemon` byte-for-byte:
+// `lower_hex(sha256("openhost-turn-v1" || daemon_pk))[..32]`.
+export async function passwordForDaemon(daemonPkZbase32) {
+  const pkBytes = zbase32Decode(daemonPkZbase32);
+  const prefix = new TextEncoder().encode("openhost-turn-v1");
+  const msg = new Uint8Array(prefix.length + pkBytes.length);
+  msg.set(prefix, 0);
+  msg.set(pkBytes, prefix.length);
+  const digest = await crypto.subtle.digest("SHA-256", msg);
+  return hexEncode(new Uint8Array(digest).slice(0, 16));
+}
+
+// Build the `RTCIceServer` entry to append to the `iceServers` list
+// when the resolved host record carries a v3 `turn_endpoint`. Returns
+// `null` if no TURN endpoint was advertised.
+export async function turnIceServerFor(daemonPkZbase32, turnEndpoint) {
+  if (!turnEndpoint) return null;
+  const password = await passwordForDaemon(daemonPkZbase32);
+  return {
+    urls: [`turn:${turnEndpoint.ip}:${turnEndpoint.port}`],
+    username: TURN_USERNAME,
+    credential: password,
+  };
+}

--- a/spec/01-wire-format.md
+++ b/spec/01-wire-format.md
@@ -49,7 +49,11 @@ The packet **MUST** contain a single TXT resource record:
 
 The v1 schema additionally carried an `allow` list of 16-byte truncated HMAC entries and a per-paired-client `ice` list immediately before `disc`. v2 removes both fields from the canonical bytes; the underlying facilities they represented now live elsewhere (see the bullet list below).
 
-**v3 schema (PR #42.1).** A v3 record appends one 2-byte big-endian unsigned integer after the `disc` bytes: `turn_port`. A v3 record's `version` byte is `0x03` and `turn_port` **MUST** be non-zero. `turn_port` advertises the UDP port on the daemon's public IP where its embedded TURN server listens; clients read the field and add `turn:<daemon-ip>:<turn_port>` to their ICE configuration before dialling, enabling relay fallback under symmetric NATs that defeat direct hole-punching. Deployments without an embedded TURN server continue to publish v2 records (version byte `0x02`, no trailer); decoders **MUST** accept both. v1 is unsupported.
+**v3 schema (PR #42.1 + PR #42.2).** A v3 record appends a 6-byte trailer after `disc`: `turn_ip` (4 bytes, IPv4 in network order) followed by `turn_port` (2 bytes, unsigned 16-bit big-endian). A v3 record's `version` byte is `0x03`; `turn_port` **MUST** be non-zero and `turn_ip` **MUST** be routable (`0.0.0.0` and `127.0.0.0/8` are rejected).
+
+The pair advertises the publicly-reachable IPv4 address + UDP port of the daemon's embedded TURN relay. Clients read the trailer and add `turn:<turn_ip>:<turn_port>` to their `RTCConfiguration.ice_servers` before dialling. The TURN long-term credential is derivable entirely from public state: `realm = "openhost"`, `username = "openhost"`, `password = lower_hex(sha256("openhost-turn-v1" || daemon_pubkey))[..32]`. Daemon and client compute the same password independently, so no out-of-band credential exchange is needed; the password is not secret, only matching-input scaffolding for the TURN MESSAGE-INTEGRITY HMAC.
+
+Deployments without an embedded TURN server keep publishing v2 records (version byte `0x02`, no trailer); decoders **MUST** accept both. v1 is unsupported.
 
 The base64url encoding uses the RFC 4648 §5 URL-safe alphabet without padding. If the encoded string exceeds 255 bytes, it **MUST** be split across multiple DNS character strings within the same TXT RDATA (per RFC 1035 §3.3.14); decoders reconstruct the payload by concatenating the character strings in the order they appear.
 


### PR DESCRIPTION
## Summary

Second, third, and fourth slices of the TURN resilience plan (plan: `/Users/vamsi/.claude/plans/pr-42-embedded-turn.md`). Bundled because half-state would be untestable.

## What ships

**Daemon (PR #42.2)**
- `openhost-daemon::turn_server`: wraps webrtc-rs's `turn::server::Server` in a `TurnHandle` bound to a configurable UDP port.
- `[turn]` config section (disabled by default). When `enabled = true`, the daemon spawns the TURN relay, installs `turn_endpoint` on `SharedState`, and the publisher emits a v3 host record carrying the endpoint.
- v3 schema widened from `turn_port: u16` to `turn_endpoint: (IPv4, u16)` — port alone is useless without IP, and a daemon's public IP isn't recoverable from its pubkey.

**Client + extension (PR #42.3)**
- `openhost-client::turn_creds`: exposes `password_for_daemon`, deterministic SHA-256-of-pubkey derivation. Both sides compute the same MESSAGE-INTEGRITY HMAC input without a shared secret.
- `Dialer::build_offer` appends `turn:<ip>:<port>` to `RTCConfiguration.ice_servers` when the resolved record is v3.
- `extension/src/dialer/turn_creds.js` mirrors the derivation in JS via `crypto.subtle.digest("SHA-256", ...)` + minimal zbase32 decoder.
- `extension/src/dialer/openhost_session.js` reads `turn_ip`/`turn_port` off the verified host record and appends the TURN entry to `iceServers`.
- WASM `HostRecord` DTO gains `turn_ip: Option<String>` + `turn_port: Option<u16>` so JS callers see the endpoint.

**Live deployment (PR #42.4)**
- EC2 daemon (`3.238.149.237`) re-rolled with the new binary, `[turn] enabled = true`, TURN listening on `3.238.149.237:3478` UDP. Security group `sg-0e417639de37fd68a` gained one inbound rule: `udp/3478` from `0.0.0.0/0`. This is the explicit deviation from the zero-inbound stance — negotiated because symmetric-NAT coverage is worth it.
- Host record on pkarr verified as v3 with `turn_endpoint: 3.238.149.237:3478`.
- STUN binding probe to the TURN port returns a MAPPED-ADDRESS from my Mac → the server is reachable over the public internet. Client-side browser verification pending.

## Why the password is public

TURN long-term auth requires matching HMAC inputs on both peers. Since any client with the `oh://<daemon-pk>/` URL has the daemon's public key, making the password a deterministic function of that key lets both sides compute the same HMAC without out-of-band credential exchange. The password is **not secret** — it's matching-input scaffolding for the MESSAGE-INTEGRITY HMAC. The real authorisation gate is openhost's existing `AUTH_CLIENT`/`AUTH_HOST` handshake inside the data channel. A follow-up can tighten this to short-lived signed credentials if abuse becomes a concern.

## Test coverage

- 97 openhost-core tests (v3 trailer round-trip, IP + port validation, v2/v3 coexistence, v3 sign/verify)
- 63 openhost-pkarr tests (v3 codec + v2/v3 wire coexistence)
- New `turn_server::tests` (password determinism, differ across daemons, spawn/shutdown)
- New `turn_creds::tests` on both Rust and JS sides

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check -p openhost-pkarr-wasm --target wasm32-unknown-unknown`
- [x] `./extension/scripts/build-wasm.sh`
- [x] `markdownlint-cli2 spec/**/*.md`
- [x] EC2 daemon deployed with `[turn] enabled = true`
- [x] TURN UDP port reachable from public internet (STUN binding probe returns MAPPED-ADDRESS)
- [x] Published pkarr host record is v3 with expected `turn_endpoint`
- [ ] **Live browser dial (blocked on user)** — requires Mac Chrome to reload the extension, navigate to `chrome-extension://okdbcmjpecconocjbaaagbmkieiejpck/oh/zw4gsnobuzddia4cr4amiwoued7ep183protpexymn4oroanb8ro/`, and confirm the gallery renders. The offscreen doc's console should show `openhost dialer: TURN relay advertised — turn:3.238.149.237:3478` before the dial proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)