### PR TITLE
feat(peer): public TURN for cross-network dials

### DIFF
--- a/crates/openhost-daemon/src/app.rs
+++ b/crates/openhost-daemon/src/app.rs
@@ -393,15 +393,49 @@ async fn build_listener(
     state: Arc<SharedState>,
     forwarder: Option<Arc<Forwarder>>,
 ) -> Result<Arc<PassivePeer>> {
+    // Optional public-internet TURN (OH_PUBLIC_TURN_URL +
+    // OH_PUBLIC_TURN_USER + OH_PUBLIC_TURN_PASSWORD). Set by
+    // callers like `oh send` so peers on different NATs can
+    // always reach each other via a shared relay. Missing any
+    // of the three env vars disables the entry — the listener
+    // falls back to STUN + (optionally) its own embedded TURN.
+    let extra = public_turn_from_env();
     let peer = PassivePeer::new(
         cert.certificate.clone(),
         cert.fingerprint_sha256,
         identity,
         state,
         forwarder,
+        extra,
     )
     .await?;
     Ok(Arc::new(peer))
+}
+
+/// Read the `OH_PUBLIC_TURN_*` env triplet and turn it into an ICE
+/// server entry. Returning an empty Vec (not an error) when any var
+/// is missing makes the knob fully opt-in — default behaviour is
+/// unchanged.
+fn public_turn_from_env() -> Vec<webrtc::ice_transport::ice_server::RTCIceServer> {
+    let (Ok(url), Ok(user), Ok(pass)) = (
+        std::env::var("OH_PUBLIC_TURN_URL"),
+        std::env::var("OH_PUBLIC_TURN_USER"),
+        std::env::var("OH_PUBLIC_TURN_PASSWORD"),
+    ) else {
+        return Vec::new();
+    };
+    if url.trim().is_empty() || user.trim().is_empty() || pass.trim().is_empty() {
+        return Vec::new();
+    }
+    tracing::info!(
+        url = %url,
+        "openhostd: public TURN wired from OH_PUBLIC_TURN_URL"
+    );
+    vec![webrtc::ice_transport::ice_server::RTCIceServer {
+        urls: vec![url],
+        username: user,
+        credential: pass,
+    }]
 }
 
 /// Spawn an [`OfferPoller`] from the config's `offer_poll` section.

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -310,6 +310,12 @@ pub struct PassivePeer {
     /// it self-allocates a relay candidate for ICE. Empty string
     /// when the daemon wasn't started with TURN enabled.
     turn_password: String,
+    /// Additional ICE servers threaded in by the caller (e.g. `oh
+    /// send` adds a public-internet TURN from env vars so
+    /// cross-network dials can relay without the sender owning a
+    /// public IP). Always appended to the listener's own STUN +
+    /// embedded-TURN entries — never replaces them.
+    extra_ice_servers: Vec<webrtc::ice_transport::ice_server::RTCIceServer>,
     /// Localhost forwarder. `None` falls back to the PR #5 stub
     /// (`HTTP/1.1 502 Bad Gateway` on every `REQUEST_HEAD`) — a daemon
     /// without a `[forward]` config section stays serviceable as a
@@ -329,6 +335,7 @@ impl PassivePeer {
         identity: Arc<SigningKey>,
         state: Arc<SharedState>,
         forwarder: Option<Arc<Forwarder>>,
+        extra_ice_servers: Vec<webrtc::ice_transport::ice_server::RTCIceServer>,
     ) -> Result<Self, ListenerError> {
         // rustls 0.23+ requires a CryptoProvider before any TLS / DTLS
         // session is established. Install ring once per process; the
@@ -382,6 +389,7 @@ impl PassivePeer {
             skip_ice_gather: Arc::new(AtomicBool::new(false)),
             binder,
             turn_password,
+            extra_ice_servers,
             forwarder,
         })
     }
@@ -487,6 +495,10 @@ impl PassivePeer {
         if let Some(turn_srv) = self.turn_ice_server() {
             ice_servers.push(turn_srv);
         }
+        // Caller-supplied extras: e.g. a public-internet TURN on a
+        // cloud VPS so peers on unrelated NATs (phone on cellular
+        // + laptop on home WiFi) still get a reachable relay pair.
+        ice_servers.extend(self.extra_ice_servers.iter().cloned());
         let config = RTCConfiguration {
             certificates: vec![self.certificate.clone()],
             ice_servers,

--- a/web/recv.html
+++ b/web/recv.html
@@ -10,6 +10,16 @@
   the `content` attribute — no JS rebuild required.
 -->
 <meta name="oh-relay" content="https://pkarr.pubky.app">
+<!--
+  Public-internet TURN relay for cross-network dials (phone on
+  cellular ↔ laptop on home WiFi). `oh send` advertises a local
+  TURN bound to its LAN IP, which is unreachable from elsewhere;
+  this additional TURN on a cloud VPS is always reachable by
+  both peers. Static user/password — coturn's `lt-cred-mech`.
+-->
+<meta name="oh-public-turn-url" content="turn:3.238.149.237:3478">
+<meta name="oh-public-turn-user" content="openhost">
+<meta name="oh-public-turn-password" content="7eedd7df2a910a1acb05530865c07134">
 <title>oh — receive a file</title>
 <style>
   :root {

--- a/web/src/dialer/openhost_session.js
+++ b/web/src/dialer/openhost_session.js
@@ -55,6 +55,18 @@ export const BINDING_MODE_CERT_FP = 0x02;
 //      without a JS rebuild.
 //   3. `http://127.0.0.1:8080` — local dev default, matches
 //      `tools/oh-dev-relay.py`.
+/// Read the `<meta name="oh-public-turn-url">` tag (plus -user and
+/// -password) and return an RTCIceServer entry, or `null` if any of
+/// the three tags are missing.
+function publicTurnFromMeta() {
+  if (typeof document === "undefined") return null;
+  const url = document.querySelector('meta[name="oh-public-turn-url"]')?.content;
+  const user = document.querySelector('meta[name="oh-public-turn-user"]')?.content;
+  const password = document.querySelector('meta[name="oh-public-turn-password"]')?.content;
+  if (!url || !user || !password) return null;
+  return { urls: [url], username: user, credential: password };
+}
+
 function resolveDefaultRelay() {
   if (typeof window !== "undefined") {
     if (window.OH_RELAY_URL) return window.OH_RELAY_URL;
@@ -219,6 +231,15 @@ export async function dialOhUrl(ohUrl, opts = {}) {
         turnServer.urls[0],
       );
     }
+  }
+  // Public-internet TURN baked into the static deploy. Lets
+  // peers on different NATs (phone on cellular + laptop on home
+  // WiFi) relay through a shared cloud box when neither sender's
+  // own TURN (LAN-bound) is reachable.
+  const publicTurn = publicTurnFromMeta();
+  if (publicTurn) {
+    iceServers.push(publicTurn);
+    console.log("openhost dialer: public TURN advertised —", publicTurn.urls[0]);
   }
   const pc = new RTCPeerConnection({ iceServers });
   const dc = pc.createDataChannel("openhost", { ordered: true });


### PR DESCRIPTION
## Summary

Plumbs a third-party TURN relay through both `oh send` (env-var
triplet) and the web app (meta tags), so a browser on cellular and
a laptop on home WiFi have a guaranteed-reachable (relay ↔ relay)
ICE pair — which neither side's local TURN can provide.

## Infrastructure deployed

coturn on EC2 (ec2-3-238-149-237), UDP 3478 + 50000-50099 open in
the security group, static user/password auth (deliberately public
— baked into web meta tags). Private-IP peer ranges whitelisted
so same-LAN CreatePermission also succeeds.

## Test plan

- [x] Answer SDP carries `a=candidate:… 3.238.149.237 <port> typ relay` on sender side
- [x] Browser SDP carries same on dialer side
- [ ] **Real cross-network end-to-end**: user-driven (phone cellular + Mac home WiFi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)