### PR TITLE
⚡ Bolt: optimize inbound frame buffering and pre-allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-23 - [O(1) Frame Buffering]
+**Learning:** Using `Vec::drain(..consumed)` for inbound frame buffering in `openhost-daemon` and `openhost-client` was an O(N) operation, shifting the entire remaining buffer on every frame.
+**Action:** Use `bytes::BytesMut` and `buf.advance(consumed)` for O(1) buffer management in all streaming/framing code.

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -689,7 +689,7 @@ impl Drop for PeerConnectionGuard {
 }
 
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<()> {
-    let mut buf = Vec::with_capacity(5 + frame.payload.len());
+    let mut buf = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf))
         .await

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -689,7 +689,8 @@ impl Drop for PeerConnectionGuard {
 }
 
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<()> {
-    let mut buf = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
+    let mut buf =
+        Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf))
         .await

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,8 +15,8 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
-use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use openhost_core::wire::{Frame, FrameType, FRAME_V2_HEADER_LEN, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
@@ -58,7 +58,7 @@ impl OpenhostSession {
     /// `body` may be empty.
     pub async fn request(&self, head_bytes: &[u8], body: Bytes) -> Result<ClientResponse> {
         // Send REQUEST_HEAD.
-        let mut wire: Vec<u8> = Vec::new();
+        let mut wire: Vec<u8> = Vec::with_capacity(FRAME_V2_HEADER_LEN + head_bytes.len());
         Frame::new(FrameType::RequestHead, head_bytes.to_vec())
             .map_err(|e| ClientError::HttpRoundTrip(format!("build REQUEST_HEAD: {e}")))?
             .encode(&mut wire);
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +182,7 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                buf.lock().await.put_slice(&msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +199,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -837,11 +837,11 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,
@@ -1069,7 +1069,7 @@ async fn dispatch_frame(
         }
         FrameType::Ping => {
             let pong = Frame::new(FrameType::Pong, Vec::new()).expect("Pong is empty");
-            let mut out = Vec::with_capacity(5);
+            let mut out = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN);
             pong.encode(&mut out);
             if let Err(err) = dc.send(&Bytes::from(out)).await {
                 tracing::warn!(?err, "openhostd: failed to send Pong");
@@ -1318,7 +1318,7 @@ async fn start_websocket_tunnel(
                             break;
                         }
                     };
-                    let mut wire = Vec::with_capacity(n + 5);
+                    let mut wire = Vec::with_capacity(n + openhost_core::wire::FRAME_V2_HEADER_LEN);
                     frame.encode(&mut wire);
                     if dc_upstream.send(&Bytes::from(wire)).await.is_err() {
                         break;
@@ -1426,7 +1426,7 @@ async fn emit_response(dc: &RTCDataChannel, resp: ForwardResponse) -> Result<(),
 
 /// Encode one frame and send it as its own data-channel message.
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<(), webrtc::Error> {
-    let mut buf = Vec::with_capacity(5 + frame.payload.len());
+    let mut buf = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf)).await?;
     Ok(())

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -1426,7 +1426,8 @@ async fn emit_response(dc: &RTCDataChannel, resp: ForwardResponse) -> Result<(),
 
 /// Encode one frame and send it as its own data-channel message.
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<(), webrtc::Error> {
-    let mut buf = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
+    let mut buf =
+        Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf)).await?;
     Ok(())

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![], // default_allowed_binding_modes() is private, but this test doesn't dial
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
💡 What:
- Switched inbound frame buffers from Vec<u8> to bytes::BytesMut in both openhost-daemon and openhost-client.
- Updated frame removal to use buf.advance(consumed), changing complexity from O(N) to O(1).
- Fixed frame buffer pre-allocations to use FRAME_V2_HEADER_LEN (10 bytes) instead of legacy 5 bytes or zero.
- Fixed a latent build failure in real_pkarr.rs integration test caused by missing fields in DtlsConfig.

🎯 Why:
- Vec::drain(..n) is an O(N) operation that shifts all subsequent bytes. In high-throughput scenarios, this becomes a significant bottleneck.
- Accurate with_capacity calls avoid immediate re-allocations when protocol frames are encoded.

📊 Impact:
- Reduces frame consumption complexity from O(N) to O(1).
- Eliminates redundant allocations during frame encoding.

🔬 Measurement:
- Verified via cargo test --workspace.
- Code review confirmed idiomatic performance win.

---
*PR created automatically by Jules for task [13854928185322121513](https://jules.google.com/task/13854928185322121513) started by @vamzi*