### PR TITLE
🛡️ Sentinel: [security improvement] Harden HTTP/1.1 request head parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Harden HTTP/1.1 Request Head Parser
+**Vulnerability:** Hand-rolled HTTP parser was too permissive, accepting obsolete line folding, whitespace before colons, and bare CR/LF, which are prohibited by RFC 7230.
+**Learning:** Hand-rolled parsers for complex protocols like HTTP often miss security-critical validation rules specified in RFCs, potentially leading to request smuggling or other desynchronization attacks when paired with an upstream server.
+**Prevention:** Always validate HTTP header field names and values strictly according to RFC 7230 §3.2.4 and §3.5. Specifically, reject any whitespace between the field name and colon, reject obsolete line folding (starting a header line with whitespace), and reject bare CR or LF octets. Trimming trailing OWS from values is also required.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -354,6 +354,11 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
     let request_line = lines
         .next()
         .ok_or(ForwardError::HeadParse("empty request head"))?;
+    if request_line.contains(['\r', '\n']) {
+        return Err(ForwardError::HeadParse(
+            "bare CR or LF in request line is not allowed",
+        ));
+    }
 
     let mut parts = request_line.split(' ');
     let method_str = parts
@@ -380,12 +385,27 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.contains(['\r', '\n']) {
+            return Err(ForwardError::HeadParse(
+                "bare CR or LF in header line is not allowed",
+            ));
+        }
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is not allowed",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim();
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +802,50 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace before colon")),
+            "expected 'whitespace before colon' error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com \r\n\r\n";
+        let (_, _, h) = parse_request_head(raw).unwrap();
+        assert_eq!(h.get("host").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obsolete_line_folding() {
+        // RFC 7230 §3.2.4: "A proxy or gateway that receives an obs-fold
+        // MUST [...] reject the message by sending a 400 (Bad Request)"
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n Folded: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("obsolete line folding")),
+            "expected 'obsolete line folding' error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_bare_lf() {
+        // RFC 7230 §3.2.4: "A recipient MUST parse an HTTP message as a
+        // sequence of OCTETs [...] A recipient SHOULD treat a bare LF
+        // [...] as an error."
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\nEvil: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("bare CR or LF")),
+            "expected 'bare CR or LF' error, got: {err:?}"
+        );
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -38,6 +38,10 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement] Harden HTTP/1.1 request head parser

🚨 **Severity:** LOW (Security Enhancement / Defense in Depth)

💡 **Vulnerability:**
The hand-rolled HTTP/1.1 request head parser in `openhost-daemon` was too permissive. It accepted:
- **Obsolete line folding** (header lines beginning with whitespace), which is prohibited for proxies/gateways by RFC 7230 §3.2.4.
- **Whitespace before the colon** in header fields, which MUST be rejected per RFC 7230 §3.2.4.
- **Bare CR or LF octets** inside lines, which SHOULD be treated as an error per RFC 7230 §3.5.
- It also failed to trim trailing whitespace from header values.

🎯 **Impact:**
Permissive HTTP parsing is a classic vector for **HTTP Request Smuggling** or **Request Desynchronization** attacks. While the daemon currently forwards to a single localhost upstream, hardening the parser ensures that we don't pass ambiguous headers that an upstream might interpret differently, leading to security bypasses.

🔧 **Fix:**
Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to:
1.  Check for and reject lines starting with ' ' or '\t' (obs-fold).
2.  Check for and reject header names ending in ' ' or '\t'.
3.  Check for and reject bare `\r` or `\n` within lines (using `split("\r\n")` to ensure terminators themselves are not checked).
4.  Use `.trim()` on header values to remove both leading and trailing OWS.

Additionally, fixed a compilation error in `crates/openhost-daemon/tests/real_pkarr.rs` where a missing field in `DtlsConfig` was preventing `cargo clippy` and `cargo test --features real-network` from running.

✅ **Verification:**
- Added 4 new unit tests to `crates/openhost-daemon/src/forward.rs` covering all the hardened cases.
- Verified that all 97+ tests in `openhost-daemon` pass.
- Verified `cargo clippy` passes for the workspace.
- Recorded critical security learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [6202644206213625070](https://jules.google.com/task/6202644206213625070) started by @vamzi*