### PR TITLE
🛡️ Sentinel: [security improvement] Zeroize sensitive channel-binding material

### DIFF
--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -42,6 +42,7 @@ use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
 use std::sync::Arc;
 use thiserror::Error;
+use zeroize::Zeroizing;
 
 // Wire-level constants shared with `openhost-client`'s client-side
 // binder. The canonical source is `openhost-core::channel_binding_wire`;
@@ -168,7 +169,7 @@ impl ChannelBinder {
         let signature = Signature::from_bytes(&sig_bytes);
         client_pk
             .as_dalek()
-            .verify_strict(&auth, &signature)
+            .verify_strict(&*auth, &signature)
             .map_err(|_| ChannelBindingError::VerifyFailed)?;
 
         Ok(client_pk)
@@ -190,7 +191,7 @@ impl ChannelBinder {
             &client_pk_bytes,
             nonce,
         )?;
-        let signature = self.identity.sign(&auth);
+        let signature = self.identity.sign(&*auth);
         Ok(signature.to_bytes())
     }
 }
@@ -200,9 +201,9 @@ fn derive_auth(
     host_pk: &[u8; 32],
     client_pk: &[u8; 32],
     nonce: &[u8; AUTH_NONCE_LEN],
-) -> Result<[u8; 32], ChannelBindingError> {
+) -> Result<Zeroizing<[u8; 32]>, ChannelBindingError> {
     match auth_bytes_bound(exporter_secret, host_pk, client_pk, nonce) {
-        Ok(auth) => Ok(auth),
+        Ok(auth) => Ok(Zeroizing::new(auth)),
         Err(openhost_core::Error::BufferTooSmall { have, .. }) => {
             Err(ChannelBindingError::ExporterLength(have))
         }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -44,6 +44,7 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
+use zeroize::Zeroizing;
 
 /// Ensures the rustls CryptoProvider is installed exactly once per
 /// process. Required in rustls 0.23+ because the crate no longer picks
@@ -1231,7 +1232,7 @@ async fn derive_binding_secret(
     dtls_transport: &RTCDtlsTransport,
     binding_mode: BindingMode,
     local_dtls_fp: &[u8; 32],
-) -> Result<Vec<u8>, &'static str> {
+) -> Result<Zeroizing<Vec<u8>>, &'static str> {
     match binding_mode {
         BindingMode::Exporter => {
             let exporter = dtls_transport
@@ -1241,7 +1242,7 @@ async fn derive_binding_secret(
             if exporter.len() != EXPORTER_SECRET_LEN {
                 return Err("DTLS exporter returned wrong length");
             }
-            Ok(exporter)
+            Ok(Zeroizing::new(exporter))
         }
         BindingMode::CertFp => {
             // Spec/04-security.md §4.1 says both sides hash *the host's*
@@ -1255,7 +1256,7 @@ async fn derive_binding_secret(
             // latent since PR #28.3 because the pre-compact-offer
             // dial path could not reach the binding step from a real
             // browser.
-            Ok(local_dtls_fp.to_vec())
+            Ok(Zeroizing::new(local_dtls_fp.to_vec()))
         }
     }
 }

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -38,6 +38,10 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Zeroize sensitive channel-binding material

This patch introduces a security enhancement by using the `zeroize` crate to ensure that sensitive cryptographic secrets are cleared from memory after use. This is a "defense-in-depth" practice to prevent sensitive data from lingering in memory where it might be exposed via memory dumps or side-channel attacks.

Specifically:
- In `crates/openhost-daemon/src/listener.rs`, the DTLS exporter secret is now wrapped in a `Zeroizing<Vec<u8>>`.
- In `crates/openhost-daemon/src/channel_binding.rs`, the derived authentication bytes are now wrapped in a `Zeroizing<[u8; 32]>`.
- Fixed a compilation error in `crates/openhost-daemon/tests/real_pkarr.rs` where `DtlsConfig` was missing the `allowed_binding_modes` field.

All workspace tests and lints pass.


---
*PR created automatically by Jules for task [4345432357867609911](https://jules.google.com/task/4345432357867609911) started by @vamzi*