### PR TITLE
⚡ Bolt: optimize inbound buffering and header encoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,13 @@
+# Bolt's Journal - Critical Performance Learnings
+
+## 2025-03-24 - Initializing Journal
+**Learning:** Starting the mission to optimize openhost.
+**Action:** Follow the profiling and optimization process.
+
+## 2025-03-24 - [Optimizing Inbound Buffering & Header Encoding]
+**Learning:** Using `Vec::drain(..n)` on inbound buffers is $O(N)$ and can become a bottleneck as the buffer grows. Switching to `BytesMut` and `advance(n)` provides $O(1)$ complexity. Additionally, using `HeaderValue::from(u64)` and `write!` macro for HTTP encoding avoids redundant string allocations.
+**Action:** Always prefer `BytesMut` for stream/frame buffering and use allocation-free header constructors where possible.
+
+## 2025-03-24 - [Broken Test: real_pkarr.rs]
+**Learning:** The `real_pkarr.rs` integration test is gated by a feature and easily falls out of sync when core configuration structs (like `DtlsConfig`) are updated.
+**Action:** If a workspace member's tests fail after a structural change, check gated integration tests like `real_pkarr.rs` for missing fields.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,8 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    // Optimization: Use BytesMut for O(1) advance instead of O(N) drain.
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +175,8 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        // Optimization: Pre-allocate 64 KiB for the inbound buffer.
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +184,8 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                let mut guard = buf.lock().await;
+                bytes::BufMut::put_slice(&mut *guard, &msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +202,8 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // O(1) advance.
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -27,6 +27,7 @@ use crate::error::ForwardError;
 use bytes::Bytes;
 use http::header::{HeaderName, HeaderValue};
 use http::{HeaderMap, Method, Request, StatusCode, Uri};
+use std::io::Write;
 use http_body_util::{BodyExt, Full, Limited};
 use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
@@ -462,7 +463,9 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Optimization: Use write! macro to avoid temporary String allocation from format!.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -517,14 +520,17 @@ fn encode_response_head(
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
     // frame-split the response stream.
+    // Optimization: Use HeaderValue::from(u64) to avoid string formatting and parsing.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Optimization: Use write! macro to avoid temporary String allocation from format!.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -27,12 +27,12 @@ use crate::error::ForwardError;
 use bytes::Bytes;
 use http::header::{HeaderName, HeaderValue};
 use http::{HeaderMap, Method, Request, StatusCode, Uri};
-use std::io::Write;
 use http_body_util::{BodyExt, Full, Limited};
 use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // Optimization: Use BytesMut for efficient O(1) buffer draining.
+    // Pre-allocate 64 KiB to avoid frequent re-allocations for typical requests.
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -837,11 +839,13 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            // Use put_slice for BytesMut.
+            bytes::BufMut::put_slice(&mut *buf, &msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // O(1) advance instead of O(N) drain.
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -15,7 +15,7 @@
 #![cfg(feature = "real-network")]
 
 use openhost_daemon::config::{
-    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+    BindingModeConfig, Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
 };
 use openhost_daemon::App;
 use openhost_pkarr::{PkarrResolve, Resolver};
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
### 💡 What: The optimization implemented
- In `crates/openhost-daemon/src/listener.rs` and `crates/openhost-client/src/session.rs`, I replaced `Arc<Mutex<Vec<u8>>>` with `Arc<Mutex<BytesMut>>` for the inbound frame buffer.
- Replaced `buf.drain(..consumed)` with `buf.advance(consumed)`, which moves the complexity of removing processed bytes from $O(N)$ to $O(1)$.
- In `crates/openhost-daemon/src/forward.rs`, I optimized the HTTP response head encoding by using the `write!` macro directly into the output vector and using `HeaderValue::from(u64)` for the `Content-Length` header.

### 🎯 Why: The performance problem it solves
- `Vec::drain` performs a memory move of all remaining bytes, which can be expensive as the buffer grows with multiple inbound frames.
- `format!` allocates a temporary `String` before converting it to bytes, which adds unnecessary allocation overhead in the response path.
- `HeaderValue::from_str(&val.to_string())` involves both string formatting and parsing, whereas `HeaderValue::from(u64)` is a direct conversion.

### 📊 Impact: Expected performance improvement
- Redirection of inbound traffic should see lower CPU overhead, especially for large request/response streams.
- Reduced allocation pressure in the daemon's hot path for each forwarded request.

### 🔬 Measurement: How to verify the improvement
- `cargo test --workspace` ensures no regressions.
- Algorithmic improvement from $O(N)$ to $O(1)$ for buffer draining.
- Avoidance of temporary `String` allocations in header encoding.

---
*PR created automatically by Jules for task [5678499182494522697](https://jules.google.com/task/5678499182494522697) started by @vamzi*