### PR TITLE
🛡️ Sentinel: [security improvement] Zeroize sensitive cryptographic materials

### DIFF
--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -40,9 +40,9 @@ use ed25519_dalek::Signature;
 use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
-use zeroize::Zeroize;
 use std::sync::Arc;
 use thiserror::Error;
+use zeroize::Zeroize;
 
 // Wire-level constants shared with `openhost-client`'s client-side
 // binder. The canonical source is `openhost-core::channel_binding_wire`;

--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -40,6 +40,7 @@ use ed25519_dalek::Signature;
 use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
+use zeroize::Zeroize;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -158,7 +159,7 @@ impl ChannelBinder {
         let client_pk = PublicKey::from_bytes(&client_pk_bytes)
             .map_err(|_| ChannelBindingError::MalformedClientPk)?;
 
-        let auth = derive_auth(
+        let mut auth = derive_auth(
             exporter_secret,
             &self.host_pk_bytes,
             &client_pk_bytes,
@@ -166,12 +167,15 @@ impl ChannelBinder {
         )?;
 
         let signature = Signature::from_bytes(&sig_bytes);
-        client_pk
+        let result = client_pk
             .as_dalek()
             .verify_strict(&auth, &signature)
-            .map_err(|_| ChannelBindingError::VerifyFailed)?;
+            .map_err(|_| ChannelBindingError::VerifyFailed);
 
-        Ok(client_pk)
+        auth.zeroize();
+        sig_bytes.zeroize();
+
+        result.map(|_| client_pk)
     }
 
     /// Produce the `AuthHost` payload: 64-byte signature over
@@ -184,13 +188,14 @@ impl ChannelBinder {
         client_pk: &PublicKey,
     ) -> Result<[u8; AUTH_HOST_PAYLOAD_LEN], ChannelBindingError> {
         let client_pk_bytes = client_pk.to_bytes();
-        let auth = derive_auth(
+        let mut auth = derive_auth(
             exporter_secret,
             &self.host_pk_bytes,
             &client_pk_bytes,
             nonce,
         )?;
         let signature = self.identity.sign(&auth);
+        auth.zeroize();
         Ok(signature.to_bytes())
     }
 }

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -15,6 +15,7 @@ use crate::error::{KeyStoreError, Result as DaemonResult};
 use async_trait::async_trait;
 use openhost_core::identity::{SigningKey, SIGNING_KEY_LEN};
 use std::path::{Path, PathBuf};
+use zeroize::Zeroize;
 
 /// Crate-local result alias for keystore operations.
 pub type Result<T> = core::result::Result<T, KeyStoreError>;
@@ -61,7 +62,7 @@ impl FsKeyStore {
 #[async_trait]
 impl KeyStore for FsKeyStore {
     async fn load(&self) -> Result<Option<SigningKey>> {
-        let bytes = match tokio::fs::read(&self.path).await {
+        let mut bytes = match tokio::fs::read(&self.path).await {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e.into()),
@@ -71,7 +72,10 @@ impl KeyStore for FsKeyStore {
         }
         let mut seed = [0u8; SIGNING_KEY_LEN];
         seed.copy_from_slice(&bytes);
-        Ok(Some(SigningKey::from_bytes(&seed)))
+        bytes.zeroize();
+        let sk = SigningKey::from_bytes(&seed);
+        seed.zeroize();
+        Ok(Some(sk))
     }
 
     async fn store(&self, sk: &SigningKey) -> Result<()> {
@@ -81,8 +85,9 @@ impl KeyStore for FsKeyStore {
             }
         }
 
-        let seed = sk.to_bytes();
+        let mut seed = sk.to_bytes();
         write_mode_0600(&self.path, &seed).await?;
+        seed.zeroize();
         Ok(())
     }
 }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,7 +26,6 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
-use zeroize::Zeroize;
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -45,6 +44,7 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
+use zeroize::Zeroize;
 
 /// Ensures the rustls CryptoProvider is installed exactly once per
 /// process. Required in rustls 0.23+ because the crate no longer picks

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -26,6 +26,7 @@ use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
+use zeroize::Zeroize;
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1152,7 +1153,7 @@ async fn handle_auth_client(
     binding_mode: BindingMode,
     local_dtls_fp: &[u8; 32],
 ) -> FrameOutcome {
-    let binding_secret =
+    let mut binding_secret =
         match derive_binding_secret(dtls_transport, binding_mode, local_dtls_fp).await {
             Ok(bytes) => bytes,
             Err(reason) => {
@@ -1191,6 +1192,7 @@ async fn handle_auth_client(
     let host_sig = match binder.sign_host(&binding_secret, nonce, &client_pk) {
         Ok(sig) => sig,
         Err(err) => {
+            binding_secret.zeroize();
             tracing::warn!(?err, "openhostd: sign_host failed; tearing down");
             let _ = send_error_frame(dc, "host signing failed").await;
             *binding.lock().await = BindingState::Failed;
@@ -1198,6 +1200,8 @@ async fn handle_auth_client(
             return FrameOutcome::Teardown;
         }
     };
+
+    binding_secret.zeroize();
 
     if let Err(err) = send_frame(
         dc,

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -28,8 +28,8 @@ use openhost_pkarr::{
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use zeroize::Zeroize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use zeroize::Zeroize;
 
 /// Domain-separation salt for the allowlist-salt derivation. Stable across
 /// openhost protocol versions so a daemon rebooted on the same identity

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -28,6 +28,7 @@ use openhost_pkarr::{
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use zeroize::Zeroize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Domain-separation salt for the allowlist-salt derivation. Stable across
@@ -77,8 +78,9 @@ impl SharedState {
     /// is derived deterministically from `identity` via HKDF-SHA256 (see
     /// the struct-level doc for the scheme).
     pub fn new(identity: &SigningKey, dtls_fp: [u8; DTLS_FINGERPRINT_LEN]) -> Self {
-        let seed = identity.to_bytes();
+        let mut seed = identity.to_bytes();
         let hk = Hkdf::<Sha256>::new(Some(ALLOW_SALT_HKDF_SALT), &seed);
+        seed.zeroize();
         let mut salt = [0u8; SALT_LEN];
         hk.expand(&[], &mut salt)
             .expect("HKDF expansion to 32 bytes cannot fail");

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -15,7 +15,7 @@
 #![cfg(feature = "real-network")]
 
 use openhost_daemon::config::{
-    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+    BindingModeConfig, Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
 };
 use openhost_daemon::App;
 use openhost_pkarr::{PkarrResolve, Resolver};
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
Implemented defense-in-depth memory zeroization for sensitive cryptographic secrets in `openhost-daemon`. Intermediate buffers containing Ed25519 seeds, DTLS exporter secrets, and derived authentication bytes are now explicitly zeroized immediately after use. This ensures that sensitive data is not leaked via memory inspection or after-the-fact dumps if the process memory is compromised.

---
*PR created automatically by Jules for task [11786113811417778134](https://jules.google.com/task/11786113811417778134) started by @vamzi*