### PR TITLE
⚡ Bolt: optimize HTTP response head encoding and frame allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2025-05-22 - [Optimizing HTTP head encoding]
+**Learning:** Using 'format!' to generate HTTP status lines and header values in a loop introduces unnecessary intermediate 'String' allocations. These can be avoided by writing directly into a pre-allocated 'Vec<u8>' using the 'write!' macro. Similarly, 'HeaderValue::from(u64)' is more efficient than 'HeaderValue::from_str(&len.to_string())'.
+**Action:** Always prefer 'write!(buf, ...)' over 'buf.extend_from_slice(format!(...).as_bytes())' when working with byte buffers in hot paths.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -462,7 +463,10 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Use write! to encode directly into the pre-allocated Vec to avoid
+    // intermediate String allocations. Average reduction: ~1 allocation per head.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -519,12 +523,16 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Use write! to encode directly into the pre-allocated Vec to avoid
+    // intermediate String allocations. Average reduction: ~2 allocations per head
+    // (status line + Content-Length header value).
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -1318,7 +1318,7 @@ async fn start_websocket_tunnel(
                             break;
                         }
                     };
-                    let mut wire = Vec::with_capacity(n + 5);
+                    let mut wire = Vec::with_capacity(n + openhost_core::wire::FRAME_V2_HEADER_LEN);
                     frame.encode(&mut wire);
                     if dc_upstream.send(&Bytes::from(wire)).await.is_err() {
                         break;

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
💡 What:
- Optimized `encode_response_head` and `encode_websocket_response_head` in the daemon to use the `write!` macro, writing directly into pre-allocated byte buffers.
- Switched to `HeaderValue::from(u64)` for encoding `Content-Length`, avoiding intermediate string formatting and parsing.
- Corrected a magic number in `start_websocket_tunnel` frame allocation to use the `FRAME_V2_HEADER_LEN` constant.
- Fixed a compilation regression in `tests/real_pkarr.rs` where `DtlsConfig` was missing the `allowed_binding_modes` field.

🎯 Why:
- Each HTTP response head previously triggered 1-2 unnecessary heap allocations via `format!` and `to_string()`. While small, these add up in high-throughput scenarios.
- Hardcoded constants for frame headers are brittle; using the named constant improves maintainability.

📊 Impact:
- Reduces heap allocations by 2 per plain HTTP response and 1 per WebSocket upgrade response.
- Minor latency improvement in the request/response hot path.

🔬 Measurement:
- Verified via a temporary micro-benchmark and confirmed all workspace tests pass with `cargo test --workspace`.

---
*PR created automatically by Jules for task [7584163853455029025](https://jules.google.com/task/7584163853455029025) started by @vamzi*