### PR TITLE
⚡ Bolt: use BytesMut for O(1) inbound frame buffering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - BytesMut Panic Risk with put_slice
+**Learning:** Switching from `Vec<u8>` to `bytes::BytesMut` for performance (replacing $O(N)$ `drain` with $O(1)$ `advance`) introduces a panic risk if using `put_slice` without explicit `reserve`. `Vec::extend_from_slice` automatically grows, but `BytesMut::put_slice` panics if capacity is insufficient.
+**Action:** Use `BytesMut::extend_from_slice` (which handles reservation automatically) instead of `put_slice` when the input size is not strictly bounded, or call `reserve` manually.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,9 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        // Optimized inbound buffer: replace O(N) Vec::drain with O(1)
+        // BytesMut::advance. 64 KiB capacity covers typical HTTP heads.
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +201,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // Optimized inbound buffer: replace O(N) Vec::drain with O(1)
+    // BytesMut::advance. 64 KiB capacity covers typical HTTP heads.
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +843,7 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
💡 What: The optimization replaces `Vec<u8>::drain` with `bytes::BytesMut::advance` for inbound frame buffering in `openhost-daemon` and `openhost-client`.
🎯 Why: `Vec::drain(..n)` is an $O(N)$ operation that shifts remaining elements in memory on every frame received. `BytesMut::advance(n)` is $O(1)$ as it only adjusts internal pointers.
📊 Impact: Reduces CPU overhead for inbound traffic, especially noticeable for high-volume data channels with many small frames.
🔬 Measurement: Verified with the existing test suite (`cargo test --workspace`) to ensure frame decoding remains correct across both daemon and client.

---
*PR created automatically by Jules for task [13126295913666075779](https://jules.google.com/task/13126295913666075779) started by @vamzi*