### PR TITLE
🛡️ Sentinel: [security improvement] Memory Hardening for Secrets

### DIFF
--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -41,6 +41,7 @@ use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
 use std::sync::Arc;
+use zeroize::Zeroize;
 use thiserror::Error;
 
 // Wire-level constants shared with `openhost-client`'s client-side
@@ -158,7 +159,7 @@ impl ChannelBinder {
         let client_pk = PublicKey::from_bytes(&client_pk_bytes)
             .map_err(|_| ChannelBindingError::MalformedClientPk)?;
 
-        let auth = derive_auth(
+        let mut auth = derive_auth(
             exporter_secret,
             &self.host_pk_bytes,
             &client_pk_bytes,
@@ -166,12 +167,14 @@ impl ChannelBinder {
         )?;
 
         let signature = Signature::from_bytes(&sig_bytes);
-        client_pk
+        let res = client_pk
             .as_dalek()
             .verify_strict(&auth, &signature)
-            .map_err(|_| ChannelBindingError::VerifyFailed)?;
+            .map_err(|_| ChannelBindingError::VerifyFailed);
 
-        Ok(client_pk)
+        auth.zeroize();
+
+        res.map(|_| client_pk)
     }
 
     /// Produce the `AuthHost` payload: 64-byte signature over
@@ -184,13 +187,14 @@ impl ChannelBinder {
         client_pk: &PublicKey,
     ) -> Result<[u8; AUTH_HOST_PAYLOAD_LEN], ChannelBindingError> {
         let client_pk_bytes = client_pk.to_bytes();
-        let auth = derive_auth(
+        let mut auth = derive_auth(
             exporter_secret,
             &self.host_pk_bytes,
             &client_pk_bytes,
             nonce,
         )?;
         let signature = self.identity.sign(&auth);
+        auth.zeroize();
         Ok(signature.to_bytes())
     }
 }

--- a/crates/openhost-daemon/src/channel_binding.rs
+++ b/crates/openhost-daemon/src/channel_binding.rs
@@ -41,8 +41,8 @@ use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
 use rand_core::RngCore;
 use std::sync::Arc;
-use zeroize::Zeroize;
 use thiserror::Error;
+use zeroize::Zeroize;
 
 // Wire-level constants shared with `openhost-client`'s client-side
 // binder. The canonical source is `openhost-core::channel_binding_wire`;

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -15,6 +15,7 @@ use crate::error::{KeyStoreError, Result as DaemonResult};
 use async_trait::async_trait;
 use openhost_core::identity::{SigningKey, SIGNING_KEY_LEN};
 use std::path::{Path, PathBuf};
+use zeroize::Zeroize;
 
 /// Crate-local result alias for keystore operations.
 pub type Result<T> = core::result::Result<T, KeyStoreError>;
@@ -61,17 +62,24 @@ impl FsKeyStore {
 #[async_trait]
 impl KeyStore for FsKeyStore {
     async fn load(&self) -> Result<Option<SigningKey>> {
-        let bytes = match tokio::fs::read(&self.path).await {
+        let mut bytes = match tokio::fs::read(&self.path).await {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e.into()),
         };
         if bytes.len() != SIGNING_KEY_LEN {
-            return Err(KeyStoreError::WrongSize { got: bytes.len() });
+            let got = bytes.len();
+            bytes.zeroize();
+            return Err(KeyStoreError::WrongSize { got });
         }
         let mut seed = [0u8; SIGNING_KEY_LEN];
         seed.copy_from_slice(&bytes);
-        Ok(Some(SigningKey::from_bytes(&seed)))
+        let sk = SigningKey::from_bytes(&seed);
+
+        bytes.zeroize();
+        seed.zeroize();
+
+        Ok(Some(sk))
     }
 
     async fn store(&self, sk: &SigningKey) -> Result<()> {
@@ -81,9 +89,11 @@ impl KeyStore for FsKeyStore {
             }
         }
 
-        let seed = sk.to_bytes();
-        write_mode_0600(&self.path, &seed).await?;
-        Ok(())
+        let mut seed = sk.to_bytes();
+        let res = write_mode_0600(&self.path, &seed).await;
+        seed.zeroize();
+
+        res.map_err(Into::into)
     }
 }
 

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -32,6 +32,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Once};
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
+use zeroize::Zeroizing;
 use webrtc::api::setting_engine::SettingEngine;
 use webrtc::api::{APIBuilder, API};
 use webrtc::data_channel::data_channel_message::DataChannelMessage;
@@ -1154,7 +1155,7 @@ async fn handle_auth_client(
 ) -> FrameOutcome {
     let binding_secret =
         match derive_binding_secret(dtls_transport, binding_mode, local_dtls_fp).await {
-            Ok(bytes) => bytes,
+            Ok(bytes) => Zeroizing::new(bytes),
             Err(reason) => {
                 tracing::warn!(
                     ?binding_mode,

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -32,7 +32,6 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Once};
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
-use zeroize::Zeroizing;
 use webrtc::api::setting_engine::SettingEngine;
 use webrtc::api::{APIBuilder, API};
 use webrtc::data_channel::data_channel_message::DataChannelMessage;
@@ -45,6 +44,7 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
+use zeroize::Zeroizing;
 
 /// Ensures the rustls CryptoProvider is installed exactly once per
 /// process. Required in rustls 0.23+ because the crate no longer picks

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -28,8 +28,8 @@ use openhost_pkarr::{
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use zeroize::Zeroize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use zeroize::Zeroize;
 
 /// Domain-separation salt for the allowlist-salt derivation. Stable across
 /// openhost protocol versions so a daemon rebooted on the same identity

--- a/crates/openhost-daemon/src/publish.rs
+++ b/crates/openhost-daemon/src/publish.rs
@@ -28,6 +28,7 @@ use openhost_pkarr::{
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use zeroize::Zeroize;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Domain-separation salt for the allowlist-salt derivation. Stable across
@@ -77,11 +78,12 @@ impl SharedState {
     /// is derived deterministically from `identity` via HKDF-SHA256 (see
     /// the struct-level doc for the scheme).
     pub fn new(identity: &SigningKey, dtls_fp: [u8; DTLS_FINGERPRINT_LEN]) -> Self {
-        let seed = identity.to_bytes();
+        let mut seed = identity.to_bytes();
         let hk = Hkdf::<Sha256>::new(Some(ALLOW_SALT_HKDF_SALT), &seed);
         let mut salt = [0u8; SALT_LEN];
         hk.expand(&[], &mut salt)
             .expect("HKDF expansion to 32 bytes cannot fail");
+        seed.zeroize();
         Self {
             dtls_fp: RwLock::new(dtls_fp),
             salt,

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -38,6 +38,10 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
🛡️ Sentinel: add explicit zeroization for sensitive intermediate buffers

This security enhancement implements **defense-in-depth** memory hardening by ensuring that sensitive secrets (private key seeds, DTLS exporter secrets, and derived authentication tokens) are explicitly cleared from memory immediately after use.

### 🔧 Fix:
- **`identity_store.rs`**: Explicitly calls `.zeroize()` on buffers containing the raw Ed25519 seed during both `load` and `store` operations.
- **`publish.rs`**: Zeroizes the identity seed immediately after deriving the per-host allowlist salt.
- **`listener.rs`**: Utilizes `zeroize::Zeroizing` (RAII) to ensure the channel-binding secret is cleared when it goes out of scope.
- **`channel_binding.rs`**: Explicitly zeroizes the intermediate `auth` buffer used for signing and verification.
- **`real_pkarr.rs`**: Fixed a pre-existing compilation error in the integration test by correctly initializing `DtlsConfig`.

### ✅ Verification:
- Ran `cargo test --workspace` and verified all 200+ tests pass.
- Verified that `identity_store::tests::wrong_size_file_is_error` handles zeroization correctly while still reporting the error correctly.
- Manual inspection confirmed all sensitive buffers are either shadowed as mutable for zeroization or wrapped in `Zeroizing` containers.

---
*PR created automatically by Jules for task [13917971443231073183](https://jules.google.com/task/13917971443231073183) started by @vamzi*