### PR TITLE
⚡ Bolt: optimize inbound frame buffering with BytesMut

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - BytesMut optimization for inbound buffers
+**Learning:** Replacing `Vec<u8>::drain(..n)` with `BytesMut::advance(n)` shifts complexity from O(N) to O(1) by using pointer manipulation instead of shifting memory. `BytesMut::extend_from_slice` is an inherent method and doesn't require importing the `BufMut` trait, while `advance` requires the `Buf` trait.
+**Action:** Use `BytesMut` for all stream-like inbound buffers. Always import `bytes::Buf` when using `advance`.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +199,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::with_capacity(64 * 1024)));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +841,7 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -15,7 +15,7 @@
 #![cfg(feature = "real-network")]
 
 use openhost_daemon::config::{
-    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+    BindingModeConfig, Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
 };
 use openhost_daemon::App;
 use openhost_pkarr::{PkarrResolve, Resolver};
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
💡 What: Replaced \`Vec<u8>\` with \`BytesMut\` for inbound data channel buffers in both \`openhost-daemon\` and \`openhost-client\`.

🎯 Why: \`Vec::drain(..n)\` is an O(N) operation because it requires shifting all remaining bytes in the vector to the front. \`BytesMut::advance(n)\` is an O(1) operation using pointer manipulation.

📊 Impact: Reduces CPU overhead for processing inbound frames, especially when the buffer contains multiple pending frames or large payloads.

🔬 Measurement: \`cargo test --workspace\` confirms correctness. Algorithmic complexity for frame consumption improved from O(N) to O(1).

---
*PR created automatically by Jules for task [10575803631016096485](https://jules.google.com/task/10575803631016096485) started by @vamzi*