### PR TITLE
⚡ Bolt: Buffer and memory management optimizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Buffer and Memory Management Optimizations]
+**Learning:** Replacing `Vec<u8>::drain(..n)` with `bytes::BytesMut::advance(n)` provides a significant $O(N)$ to $O(1)$ performance boost for inbound message buffering. Additionally, avoiding temporary `String` allocations during HTTP header encoding using the `write!` macro and `HeaderValue::from(u64)` reduces GC/allocation pressure in high-frequency paths. Correctly pre-allocating `Vec::with_capacity` using known protocol constants (like `FRAME_V2_HEADER_LEN`) avoids unnecessary reallocations during frame encoding.
+**Action:** Always prefer `BytesMut` for stream-like buffering and `write!` for formatted output into existing buffers. Use protocol-specific constants for capacity hints.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,8 +15,8 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
-use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
+use bytes::{Buf, Bytes, BytesMut};
+use openhost_core::wire::{Frame, FrameType, FRAME_V2_HEADER_LEN, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
@@ -58,7 +58,9 @@ impl OpenhostSession {
     /// `body` may be empty.
     pub async fn request(&self, head_bytes: &[u8], body: Bytes) -> Result<ClientResponse> {
         // Send REQUEST_HEAD.
-        let mut wire: Vec<u8> = Vec::new();
+        // ⚡ Bolt: Pre-allocate exactly enough for v2 header + payload
+        // to avoid immediate reallocation during encode().
+        let mut wire: Vec<u8> = Vec::with_capacity(FRAME_V2_HEADER_LEN + head_bytes.len());
         Frame::new(FrameType::RequestHead, head_bytes.to_vec())
             .map_err(|e| ClientError::HttpRoundTrip(format!("build REQUEST_HEAD: {e}")))?
             .encode(&mut wire);
@@ -159,7 +161,9 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    // ⚡ Bolt: Use BytesMut for inbound buffering to replace O(N)
+    // Vec::drain with O(1) Buf::advance.
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +178,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +203,8 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // ⚡ Bolt: O(1) buffer advancement.
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -462,7 +463,11 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+
+    // ⚡ Bolt: Write directly into the pre-allocated buffer to avoid
+    // temporary String allocations from format!().
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -517,14 +522,21 @@ fn encode_response_head(
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
     // frame-split the response stream.
+
+    // ⚡ Bolt: Use HeaderValue::from(u64) to avoid redundant string
+    // formatting and parsing.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+
+    // ⚡ Bolt: Write directly into the pre-allocated buffer to avoid
+    // temporary String allocations from format!().
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,9 +23,9 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
-use openhost_core::wire::{Frame, FrameType};
+use openhost_core::wire::{Frame, FrameType, FRAME_V2_HEADER_LEN};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // ⚡ Bolt: Use BytesMut for inbound buffering to replace O(N)
+    // Vec::drain with O(1) Buf::advance.
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +843,8 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // ⚡ Bolt: O(1) buffer advancement.
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,
@@ -1069,7 +1072,7 @@ async fn dispatch_frame(
         }
         FrameType::Ping => {
             let pong = Frame::new(FrameType::Pong, Vec::new()).expect("Pong is empty");
-            let mut out = Vec::with_capacity(5);
+            let mut out = Vec::with_capacity(FRAME_V2_HEADER_LEN);
             pong.encode(&mut out);
             if let Err(err) = dc.send(&Bytes::from(out)).await {
                 tracing::warn!(?err, "openhostd: failed to send Pong");
@@ -1318,7 +1321,9 @@ async fn start_websocket_tunnel(
                             break;
                         }
                     };
-                    let mut wire = Vec::with_capacity(n + 5);
+                    // ⚡ Bolt: Pre-allocate exactly enough for v2 header + payload
+                    // to avoid immediate reallocation during encode().
+                    let mut wire = Vec::with_capacity(FRAME_V2_HEADER_LEN + n);
                     frame.encode(&mut wire);
                     if dc_upstream.send(&Bytes::from(wire)).await.is_err() {
                         break;
@@ -1426,7 +1431,9 @@ async fn emit_response(dc: &RTCDataChannel, resp: ForwardResponse) -> Result<(),
 
 /// Encode one frame and send it as its own data-channel message.
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<(), webrtc::Error> {
-    let mut buf = Vec::with_capacity(5 + frame.payload.len());
+    // ⚡ Bolt: Pre-allocate exactly enough for v2 header + payload
+    // to avoid immediate reallocation during encode().
+    let mut buf = Vec::with_capacity(FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf)).await?;
     Ok(())


### PR DESCRIPTION
### ⚡ Bolt: Buffer and memory management optimizations

#### 💡 What:
- Optimized HTTP header encoding in `crates/openhost-daemon/src/forward.rs` by using the `write!` macro to write directly into pre-allocated `Vec<u8>` buffers, and used `HeaderValue::from(u64)` for the `Content-Length` header.
- Fixed frame buffer pre-allocation in `crates/openhost-daemon/src/listener.rs` and `crates/openhost-client/src/session.rs` to use the correct `FRAME_V2_HEADER_LEN` constant (10 bytes).
- Replaced the `Vec<u8>` inbound message buffer with `bytes::BytesMut` in both the daemon and client, switching from $O(N)$ `drain(..consumed)` to $O(1)$ `advance(consumed)` for frame processing.

#### 🎯 Why:
- **Heap Allocations:** `format!(...)` creates a temporary `String` on the heap even when writing to an existing `Vec`. `write!` avoids this allocation.
- **Redundant Formatting:** `HeaderValue::from_str(&body_len.to_string())` involves both string formatting and parsing; `HeaderValue::from(u64)` is a direct conversion.
- **Reallocations:** Using an incorrect capacity hint (5 bytes instead of 10) for v2 frames caused an immediate reallocation during encoding.
- **Buffer Shifting:** `Vec::drain(..n)` is $O(N)$ as it must copy the remaining $N-n$ bytes to the front of the vector. `BytesMut::advance(n)` is $O(1)$ as it simply adjusts an internal pointer.

#### 📊 Impact:
- **Reduced Allocation Pressure:** Significant reduction in temporary heap allocations during the request/response cycle.
- **Improved Decoding Performance:** Inbound frame decoding is now $O(1)$ relative to the buffer size, which is critical for handling large numbers of small frames or high-throughput data channels.
- **Reduced Binary Size/Overhead:** Minor reduction in string processing overhead.

#### 🔬 Measurement:
- All workspace tests passed (`cargo test --workspace`).
- Syntax and type safety verified via `cargo check --workspace`.
- Algorithmic improvement from $O(N)$ to $O(1)$ for buffer advancement is a structural win that reduces latency in the daemon's message loop.

---
*PR created automatically by Jules for task [16753894838938637546](https://jules.google.com/task/16753894838938637546) started by @vamzi*