### PR TITLE
⚡ Bolt: optimize HTTP response head encoding

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -462,7 +463,8 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -519,12 +521,13 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What:
- Replaced `format!(...).as_bytes()` with `write!(out, ...)` macro in `encode_response_head` and `encode_websocket_response_head` to avoid temporary `String` allocations.
- Replaced `HeaderValue::from_str(&body_len.to_string())` with `HeaderValue::from(body_len as u64)` in `encode_response_head` to avoid `String` allocation for the `Content-Length` header.

🎯 Why:
- Every forwarded HTTP response in the daemon goes through `encode_response_head`. Avoiding heap allocations for the status line and common headers reduces GC pressure and improves latency in the request forwarding hot path.

📊 Impact:
- Eliminates 2 heap allocations per forwarded HTTP response.

🔬 Measurement:
- Verified via `cargo test -p openhost-daemon --lib forward::tests`.

---
*PR created automatically by Jules for task [7136088834982420547](https://jules.google.com/task/7136088834982420547) started by @vamzi*