### PR TITLE
⚡ Bolt: optimize inbound frame buffering with BytesMut

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-22 - [Buffer Management Optimization]
+**Learning:** In Rust networking code, using `Vec<u8>` with `drain(..n)` for prefix consumption is an O(N) operation, which can become a bottleneck as buffer sizes grow or frame frequency increases. Switching to `bytes::BytesMut` with `advance(n)` reduces this to O(1).
+**Action:** Always prefer `BytesMut` and the `Buf` trait for inbound stream buffering and frame decoding loops.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +199,8 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // O(1) buffer consumption via bytes::Buf trait
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +841,8 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // O(1) buffer consumption via bytes::Buf trait
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -15,7 +15,7 @@
 #![cfg(feature = "real-network")]
 
 use openhost_daemon::config::{
-    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+    BindingModeConfig, Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
 };
 use openhost_daemon::App;
 use openhost_pkarr::{PkarrResolve, Resolver};
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
This PR optimizes the inbound frame decoding loop in both the `openhost-daemon` and `openhost-client` crates.

Previously, the daemon and client used a `Vec<u8>` to buffer inbound SCTP messages. When a complete frame was decoded, the consumed bytes were removed using `buf.drain(..consumed)`. In Rust, `drain` on a `Vec` is an $O(N)$ operation because it must shift all remaining elements to the front of the vector.

This change switches the buffer to `bytes::BytesMut` and uses `buf.advance(consumed)` from the `bytes::Buf` trait. `BytesMut::advance` is an $O(1)$ operation that simply adjusts the internal pointer, avoiding the redundant memory copy.

### Changes:
- **`openhost-daemon`**: Updated `wire_frame_loop` in `src/listener.rs` to use `BytesMut`.
- **`openhost-client`**: Updated `SessionInboundReader` in `src/session.rs` to use `BytesMut`.
- **Bug Fix**: Fixed a compilation error in `crates/openhost-daemon/tests/real_pkarr.rs` where `DtlsConfig` was initialized without the `allowed_binding_modes` field.

### Performance Impact:
- algorithmic complexity of buffer consumption shifted from $O(N)$ to $O(1)$.
- Reduced CPU overhead during high-throughput or high-concurrency data channel traffic.

### Verification:
- All workspace tests passed: `cargo test --workspace`
- Clippy and Fmt clean.

---
*PR created automatically by Jules for task [16999013291895529465](https://jules.google.com/task/16999013291895529465) started by @vamzi*