### PR TITLE
⚡ Bolt: optimize pkarr answer reassembly to O(M)

### DIFF
--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,19 +1098,46 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Single pass over all resource records to collect answer fragments for
+    // this client, bucket-sorting by their numeric `-<idx>` suffix.
+    // O(M) where M is the total number of resource records in the packet.
+    let mut fragments_found = vec![None; 256];
+    let base_lower = base.to_lowercase();
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            let name_str = rr.name.to_string().to_lowercase();
+            let name_str = name_str.trim_end_matches('.');
+            if let Some(suffix) = name_str.strip_prefix(&base_lower) {
+                if let Some(idx_str) = suffix.strip_prefix('-') {
+                    let idx_part = idx_str.split('.').next().unwrap_or("");
+                    if let Ok(idx) = idx_part.parse::<u8>() {
+                        if fragments_found[idx as usize].is_some() {
+                            return Err(PkarrError::MultipleOpenhostRecords);
+                        }
+                        let mut out = String::new();
+                        for (key, value) in txt.iter_raw() {
+                            out.push_str(
+                                core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?,
+                            );
+                            if let Some(v) = value {
+                                out.push('=');
+                                out.push_str(
+                                    core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?,
+                                );
+                            }
+                        }
+                        fragments_found[idx as usize] = Some(out);
+                    }
+                }
+            }
+        }
+    }
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    // Missing zero-fragment ⇒ no answer for us.
+    let Some(first_text) = fragments_found[0].take() else {
         return Ok(None);
     };
+
     let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
     let first = decode_fragment(&first_bytes)?;
     if first.idx != 0 {
@@ -1123,10 +1150,11 @@ pub fn decode_answer_fragments_from_packet(
     let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
     fragments.push(first);
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
+        let text = fragments_found[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
         let frag = decode_fragment(&bytes)?;
         if frag.total != total {


### PR DESCRIPTION
Optimized the `decode_answer_fragments_from_packet` function in `openhost-pkarr` to improve performance during answer reassembly. The new implementation uses a single pass over all resource records in the Pkarr packet, bucket-sorting answer fragments into a temporary buffer. This eliminates the previous O(N*M) bottleneck where N was the number of fragments and M was the total records. All validation logic and existing tests are preserved.

---
*PR created automatically by Jules for task [2679581010580205114](https://jules.google.com/task/2679581010580205114) started by @vamzi*