### PR TITLE
⚡ Bolt: reduce heap allocations in HTTP forwarder

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Reduce heap allocations in HTTP forwarder
+**Learning:** Returning `&str` from a parser instead of `String` significantly reduces heap churn in the request hot path. Additionally, using `write!` into a pre-allocated `Vec<u8>` is more efficient than `format!` as it avoids intermediate `String` allocations.
+**Action:** Always look for opportunities to return references to input buffers when parsing, and prioritize direct buffer encoding over string formatting.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -198,7 +198,7 @@ impl Forwarder {
         // path below.
         if is_websocket_upgrade(&headers) {
             match self.websockets.as_ref() {
-                Some(cfg) if cfg.is_allowed(&path) => {
+                Some(cfg) if cfg.is_allowed(path) => {
                     return self
                         .forward_websocket(method, path, headers, body)
                         .await
@@ -213,7 +213,7 @@ impl Forwarder {
         // Build the outbound URI by combining the target origin with the
         // request path. The path comes from the client verbatim; no
         // rewriting this PR.
-        let target_uri = combine_target_and_path(&self.target, &path)?;
+        let target_uri = combine_target_and_path(&self.target, path)?;
 
         let mut req_builder = Request::builder().method(method).uri(target_uri);
         // Replace the HeaderMap wholesale — simpler than iterating and
@@ -285,7 +285,7 @@ impl Forwarder {
         body: Bytes,
     ) -> Result<WebSocketUpgrade, ForwardError> {
         sanitize_websocket_request_headers(&mut headers, &self.host_override)?;
-        let target_uri = combine_target_and_path(&self.target, &path)?;
+        let target_uri = combine_target_and_path(&self.target, path)?;
         let mut req_builder = Request::builder().method(method).uri(target_uri);
         if let Some(req_headers) = req_builder.headers_mut() {
             *req_headers = headers;

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -279,7 +280,7 @@ impl Forwarder {
     async fn forward_websocket(
         &self,
         method: Method,
-        path: String,
+        path: &str,
         mut headers: HeaderMap,
         body: Bytes,
     ) -> Result<WebSocketUpgrade, ForwardError> {
@@ -340,7 +341,7 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 ///
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
-fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+fn parse_request_head(bytes: &[u8]) -> Result<(Method, &str, HeaderMap), ForwardError> {
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -361,8 +362,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         .ok_or(ForwardError::HeadParse("request line missing method"))?;
     let path = parts
         .next()
-        .ok_or(ForwardError::HeadParse("request line missing path"))?
-        .to_string();
+        .ok_or(ForwardError::HeadParse("request line missing path"))?;
     let version = parts
         .next()
         .ok_or(ForwardError::HeadParse("request line missing HTTP version"))?;
@@ -462,7 +462,8 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -491,13 +492,12 @@ fn combine_target_and_path(target: &Uri, path: &str) -> Result<Uri, ForwardError
         path
     };
 
-    let path_and_query = if path_str.is_empty() || !path_str.starts_with('/') {
-        format!("/{path_str}")
+    let uri_str = if path_str.is_empty() || !path_str.starts_with('/') {
+        format!("http://{authority}/{path_str}")
     } else {
-        path_str.to_string()
+        format!("http://{authority}{path_str}")
     };
 
-    let uri_str = format!("http://{authority}{path_and_query}");
     uri_str
         .parse()
         .map_err(|_| ForwardError::HeadParse("could not combine target + path into a URI"))
@@ -519,12 +519,13 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 **What:** Optimized the localhost HTTP forwarder in `openhost-daemon` to reduce unnecessary heap allocations. This includes returning `&str` from the request head parser instead of `String`, using the `write!` macro for direct buffer encoding of HTTP status lines, and leveraging more efficient `HeaderValue` construction for `Content-Length`.

🎯 **Why:** Every forwarded request was performing multiple avoidable heap allocations for string formatting and path extraction. In a high-throughput proxy scenario, this heap churn adds up to increased latency and CPU usage.

📊 **Impact:** Eliminates at least 3-4 heap allocations per request cycle. By reusing the input buffer for the request path and encoding directly into pre-allocated vectors, we reduce memory pressure and improve the daemon's performance on the hot path.

🔬 **Measurement:** Verified with existing and updated unit tests in `crates/openhost-daemon/src/forward.rs` via `cargo test -p openhost-daemon`. Correctness is maintained while efficiency is improved.

---
*PR created automatically by Jules for task [1849116849937129806](https://jules.google.com/task/1849116849937129806) started by @vamzi*