### PR TITLE
🛡️ Sentinel: [HIGH] Hardened HTTP parsing and resource limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Hardened HTTP parsing and resource limits in openhost-daemon
+**Vulnerability:** Memory exhaustion DoS via oversized HTTP request heads and request smuggling/splitting via non-compliant header parsing.
+**Learning:** The hand-rolled HTTP parser in `forward.rs` was too permissive, accepting bare CR/LF, obsolete line folding, and whitespace before colons, which are known vectors for request smuggling. It also lacked a dedicated size limit for the header block, separate from the body cap.
+**Prevention:** Always enforce a explicit size limit (`MAX_HEAD_BYTES`) on HTTP heads before re-framing. Use a strict parser that rejects RFC 7230 violations (bare CR/LF, folding, leading/trailing whitespace around field names).

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for the HTTP request head (status line + headers).
+/// Matches the limit used by `openhost-pkarr` for decompressed records
+/// to prevent memory exhaustion from oversized headers.
+pub const MAX_HEAD_BYTES: usize = 64 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -70,6 +75,7 @@ type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
 
 /// One buffered HTTP response, ready for the listener to re-frame onto
 /// the data channel.
+#[derive(Debug)]
 pub struct ForwardResponse {
     /// HTTP/1.1 response head — status line + sanitised headers,
     /// terminated by `\r\n\r\n`.
@@ -83,6 +89,7 @@ pub struct ForwardResponse {
 /// Protocols`) and then tunnels raw bytes between the openhost data
 /// channel and `upstream` (a bidirectional TCP socket hyper hands off
 /// after the 101).
+#[derive(Debug)]
 pub struct WebSocketUpgrade {
     /// `HTTP/1.1 101 ...\r\n<headers>\r\n\r\n` bytes.
     pub head_bytes: Vec<u8>,
@@ -93,6 +100,7 @@ pub struct WebSocketUpgrade {
 /// What a successful `Forwarder::forward` produced: either a plain
 /// HTTP response the listener frames + re-emits, or a WebSocket
 /// upgrade the listener tunnels byte-for-byte.
+#[derive(Debug)]
 pub enum ForwardOutcome {
     /// Plain HTTP round-trip.
     Response(ForwardResponse),
@@ -183,6 +191,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadParse(
+                "request head exceeds MAX_HEAD_BYTES",
+            ));
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,12 +393,36 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: Reject bare CR or LF in the header block to
+        // prevent request smuggling and line-ending confusion.
+        if line.contains(['\r', '\n']) {
+            return Err(ForwardError::HeadParse("bare CR or LF in header block"));
+        }
+
+        // RFC 7230 §3.2.4: Obsolete line folding (starting with SP or
+        // HTAB) MUST be rejected.
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: Whitespace between the field-name and colon
+        // MUST be rejected as it can be used for request smuggling.
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is not allowed",
+            ));
+        }
+
+        // RFC 7230 §3.2: OWS = *( SP / HTAB )
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +819,68 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace before colon is not allowed")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obsolete_folding() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n fold\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("obsolete line folding is not supported")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_bare_lf() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\nEvil: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        // `head.split("\r\n")` will include the bare `\n` in one of the
+        // "lines", which our new `contains` check will catch.
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("bare CR or LF in header block")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
+    }
+
+    #[test]
+    fn forward_rejects_oversized_head() {
+        // Need a Forwarder instance.
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let big_head = vec![b'x'; MAX_HEAD_BYTES + 1];
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let err = fwd.forward(&big_head, Bytes::new()).await.unwrap_err();
+            assert!(matches!(
+                err,
+                ForwardError::HeadParse("request head exceeds MAX_HEAD_BYTES")
+            ));
+        });
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeds MAX_HEAD_BYTES; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Memory exhaustion DoS via oversized HTTP request heads and request smuggling/splitting via non-compliant header parsing.
🎯 Impact: An attacker could crash the daemon by sending a very large header block, or perform request smuggling/splitting attacks against the upstream service by exploiting the permissive header parser.
🔧 Fix:
- Introduced `MAX_HEAD_BYTES` (64KB) limit for HTTP request heads.
- Enforced this limit in both `listener.rs` (pre-cloning) and `forward.rs`.
- Hardened `parse_request_head` to reject bare CR/LF, obsolete line folding, and whitespace before the colon in header field names, per RFC 7230.
- Improved header value sanitization by trimming OWS from both ends.
- Implemented `Debug` for `ForwardOutcome` and related types to facilitate testing.
✅ Verification: Added comprehensive unit tests in `forward.rs` covering all new security checks. All 102 unit tests and all integration tests in `openhost-daemon` passed.

---
*PR created automatically by Jules for task [3967246948342909752](https://jules.google.com/task/3967246948342909752) started by @vamzi*