### PR TITLE
🛡️ Sentinel: Enforce MAX_HEAD_BYTES on HTTP request heads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - [Memory Exhaustion via Unbounded HTTP Request Head]
+**Vulnerability:** The daemon accumulated `REQUEST_HEAD` frame payloads into memory without an explicit size limit. A malicious client could send a multi-megabyte `REQUEST_HEAD` frame (up to `MAX_PAYLOAD_LEN` = 16MiB) or multiple large heads to exhaust daemon memory.
+**Learning:** While higher-level protocols like HTTP often have these limits, the daemon's framing layer must also enforce them to prevent resource exhaustion before the payload is even handed to the parser.
+**Prevention:** Always enforce strict size limits on unauthenticated or untrusted input buffers, especially those that are accumulated per-session.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum allowed size for an HTTP request head (request line +
+/// headers). 64KB is comfortably above any real-world requirement and
+/// bounds memory exhaustion from malicious clients.
+pub const MAX_HEAD_BYTES: usize = 64 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +188,9 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadParse("request head too large"));
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -341,6 +349,9 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadParse("request head too large"));
+    }
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    "openhostd: REQUEST_HEAD exceeded MAX_HEAD_BYTES; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();


### PR DESCRIPTION
🚨 Severity: ENHANCEMENT
💡 Vulnerability: The daemon lacked an explicit limit on the size of inbound `REQUEST_HEAD` frames, allowing up to 16MiB per request to be buffered in memory before parsing.
🎯 Impact: Potential memory exhaustion (DoS) from malicious or misbehaving clients.
🔧 Fix: Enforced a 64KB `MAX_HEAD_BYTES` limit in `listener.rs` (pre-cloning) and `forward.rs` (pre-parsing).
✅ Verification: Verified via `cargo test -p openhost-daemon` and manual code inspection.

---
*PR created automatically by Jules for task [2562973634632883315](https://jules.google.com/task/2562973634632883315) started by @vamzi*