### PR TITLE
🛡️ Sentinel: Harden HTTP forwarder against DoS and smuggling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Security Journal
+
+## 2025-05-14 - Harden HTTP forwarder against DoS and smuggling
+**Vulnerability:** The HTTP parser was too permissive, allowing bare CR/LF, obsolete line folding, and whitespace before colons, which can be exploited for request smuggling. Additionally, there was no limit on the size of the HTTP request head, leading to memory-exhaustion DoS risks.
+**Learning:** Custom HTTP parsers must strictly adhere to RFC 7230 to prevent smuggling. Furthermore, application-level limits (like `MAX_HEAD_BYTES`) must be coordinated with transport-level limits (like SCTP's MTU/chunk size) to avoid transmission failures for large payloads.
+**Prevention:** Always enforce strict RFC compliance in parsers and set explicit size limits on all buffered inputs.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,13 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum size of an HTTP request head (request line + headers) in bytes.
+/// RFC 7230 doesn't mandate a limit, but most servers cap it at 8-16KB;
+/// we pick 32KB as a generous upper bound that still prevents memory
+/// exhaustion DoS from hostile clients while fitting comfortably within
+/// SCTP transport chunks.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -341,6 +348,10 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadParse("request head too large"));
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -354,6 +365,10 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
     let request_line = lines
         .next()
         .ok_or(ForwardError::HeadParse("empty request head"))?;
+
+    if request_line.contains(['\r', '\n']) {
+        return Err(ForwardError::HeadParse("bare CR/LF in request line"));
+    }
 
     let mut parts = request_line.split(' ');
     let method_str = parts
@@ -380,12 +395,42 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+
+        // RFC 7230 §3.2.4: "A recipient MUST ... reject any received request
+        // message that contains ... obsolete line folding"
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding is not supported",
+            ));
+        }
+
+        // RFC 7230 §3.2.4: "A recipient MUST ... reject any received request
+        // message that contains a bare CR"
+        if line.contains(['\r', '\n']) {
+            return Err(ForwardError::HeadParse("bare CR/LF in header line"));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("whitespace before colon in header"));
+        }
+
+        if name.is_empty() {
+            return Err(ForwardError::HeadParse("empty header name"));
+        }
+
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )`
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +827,44 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        raw.extend(vec![b'x'; MAX_HEAD_BYTES]);
+        raw.extend_from_slice(b"\r\n\r\n");
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("too large")));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace before colon")));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obsolete_folding() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Continued: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("obsolete line folding")));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_bare_lf_in_header() {
+        // split("\r\n") means a bare \n shows up INSIDE a "line"
+        let raw = b"GET / HTTP/1.1\r\nHost: example\nEvil: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("bare CR/LF")));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows() {
+        let raw = b"GET / HTTP/1.1\r\nHost:   example.com   \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD too large; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,40 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeding_cap_triggers_error_frame_and_teardown() -> DaemonResult<()>
+{
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send an oversized REQUEST_HEAD.
+    let head = vec![b'x'; openhost_daemon::forward::MAX_HEAD_BYTES + 1];
+    let req_head = Frame::new(FrameType::RequestHead, head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("REQUEST_HEAD too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🛡️ Sentinel: Harden HTTP forwarder against DoS and smuggling

### 🚨 Severity: HIGH

### 💡 Vulnerability:
1. **Memory-exhaustion DoS:** Malicious clients could send unbounded `REQUEST_HEAD` frames, potentially exhausting the daemon's RAM since headers were buffered before validation.
2. **Request Smuggling / Splitting:** The custom HTTP parser was overly permissive, accepting bare CR/LF characters, obsolete line folding (header lines starting with SP/HTAB), and whitespace before colons. These are classic vectors for bypassing security controls or poisoning upstream caches.

### 🎯 Impact:
Exploitation could lead to service unavailability (DoS) or unauthorized access to upstream resources via request smuggling if the upstream server has different parsing leniency.

### 🔧 Fix:
- Defined `MAX_HEAD_BYTES = 32 * 1024` in `forward.rs`.
- Enforced this limit in `listener.rs` at the frame dispatch level for early rejection.
- Refactored `parse_request_head` in `forward.rs` to strictly follow RFC 7230:
  - Reject bare CR or LF in request and header lines.
  - Reject obsolete line folding.
  - Reject whitespace between header name and colon.
  - Reject empty header names.
  - Properly trim leading/trailing OWS from header values.

### ✅ Verification:
- Added unit tests in `forward.rs` for all new rejection cases and OWS trimming.
- Added an integration test in `tests/forward.rs` verifying that oversized `REQUEST_HEAD` frames trigger an `ERROR` frame and immediate channel teardown.
- Verified all 102 unit tests and all integration tests pass with `cargo test -p openhost-daemon`.
- Verified code formatting with `cargo fmt`.

---
*PR created automatically by Jules for task [4009956449687794109](https://jules.google.com/task/4009956449687794109) started by @vamzi*