### PR TITLE
🛡️ Sentinel: Enforce 32KB limit on HTTP request heads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Header Size Bounding for DoS Prevention
+**Vulnerability:** Memory-exhaustion Denial-of-Service (DoS).
+**Learning:** In protocol implementations where user-supplied frames are accumulated in memory (like HTTP request heads or bodies), a lack of explicit size limits allows an attacker to exhaust server RAM by sending arbitrarily large frames.
+**Prevention:** Enforce strict size limits at the earliest possible entry point (e.g., in the protocol listener's frame dispatch) and use defensive caps for all buffered data structures.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for an HTTP request head (request line +
+/// headers + trailing CRLF). 32KB is comfortably above the 8KB-16KB
+/// defaults of common web servers (nginx, apache) while bounding
+/// memory exhaustion DoS.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -70,6 +76,7 @@ type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
 
 /// One buffered HTTP response, ready for the listener to re-frame onto
 /// the data channel.
+#[derive(Debug)]
 pub struct ForwardResponse {
     /// HTTP/1.1 response head — status line + sanitised headers,
     /// terminated by `\r\n\r\n`.
@@ -83,6 +90,7 @@ pub struct ForwardResponse {
 /// Protocols`) and then tunnels raw bytes between the openhost data
 /// channel and `upstream` (a bidirectional TCP socket hyper hands off
 /// after the 101).
+#[derive(Debug)]
 pub struct WebSocketUpgrade {
     /// `HTTP/1.1 101 ...\r\n<headers>\r\n\r\n` bytes.
     pub head_bytes: Vec<u8>,
@@ -93,6 +101,7 @@ pub struct WebSocketUpgrade {
 /// What a successful `Forwarder::forward` produced: either a plain
 /// HTTP response the listener frames + re-emits, or a WebSocket
 /// upgrade the listener tunnels byte-for-byte.
+#[derive(Debug)]
 pub enum ForwardOutcome {
     /// Plain HTTP round-trip.
     Response(ForwardResponse),
@@ -183,6 +192,9 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadParse("request head too large"));
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -782,6 +794,26 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[tokio::test]
+    async fn forward_rejects_oversized_head() {
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            ..Default::default()
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+
+        // 32KB + 1 byte
+        let big_head = vec![b'A'; MAX_HEAD_BYTES + 1];
+        let result = fwd.forward(&big_head, Bytes::new()).await;
+        match result {
+            Err(ForwardError::HeadParse(msg)) if msg == "request head too large" => {}
+            other => panic!(
+                "expected HeadParse('request head too large'), got: {:?}",
+                other
+            ),
+        }
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -808,7 +808,7 @@ mod tests {
         let big_head = vec![b'A'; MAX_HEAD_BYTES + 1];
         let result = fwd.forward(&big_head, Bytes::new()).await;
         match result {
-            Err(ForwardError::HeadParse(msg)) if msg == "request head too large" => {}
+            Err(ForwardError::HeadParse("request head too large")) => {}
             other => panic!(
                 "expected HeadParse('request head too large'), got: {:?}",
                 other

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,40 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeding_cap_triggers_error_frame_and_teardown() -> DaemonResult<()>
+{
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // 32KB + 1 byte
+    let big_head_payload = vec![b'A'; 32 * 1024 + 1];
+    let req_head = Frame::new(FrameType::RequestHead, big_head_payload).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
Implemented a 32KB limit on HTTP request heads to protect the `openhost-daemon` from memory exhaustion DoS. The limit is enforced at the frame dispatch layer in `listener.rs` and as a secondary check in `forward.rs`. Comprehensive tests were added to verify the fix.

---
*PR created automatically by Jules for task [15860106057176239410](https://jules.google.com/task/15860106057176239410) started by @vamzi*