### PR TITLE
🛡️ Sentinel: [HIGH] Strict RFC 7230 HTTP header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-24 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling and Cache Poisoning via lenient header parsing.
+**Learning:** The previous hand-rolled parser accepted OBS-fold (line folding) and whitespace between the header name and colon. These ambiguities allow an attacker to craft requests that are interpreted differently by the openhost daemon and the upstream HTTP service, leading to request smuggling.
+**Prevention:** Strictly enforce RFC 7230 §3.2.4 by rejecting any request containing OBS-fold or whitespace before the header colon. Ensure header values are fully trimmed of OWS (SP/HTAB) to maintain consistent normalization.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,12 +380,29 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: "A recipient MUST [...] reject [OBS-fold]."
+            return Err(ForwardError::HeadParse(
+                "request contains OBS-fold (leading whitespace on header line)",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+            // field-name and colon."
+            return Err(ForwardError::HeadParse(
+                "request contains whitespace between header name and colon",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +799,43 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace")),
+            "expected HeadParse error for whitespace before colon, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A sender MUST NOT generate [OBS-fold] and a
+        // recipient MUST [...] reject [it]."
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Folding: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("OBS-fold")),
+            "expected HeadParse error for OBS-fold, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example   \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(
+            headers.get("host").unwrap().to_str().unwrap(),
+            "example",
+            "trailing whitespace should be trimmed"
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Lenient HTTP header parsing (OBS-fold, whitespace before colon).
🎯 Impact: HTTP Request Smuggling and Cache Poisoning.
🔧 Fix: Updated `parse_request_head` to strictly reject OBS-fold and whitespace before the header colon, and correctly trim header values.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon`, `parse_request_head_rejects_obs_fold`, and `parse_request_head_trims_trailing_whitespace_from_values`. All workspace tests pass.

---
*PR created automatically by Jules for task [786761162612283985](https://jules.google.com/task/786761162612283985) started by @vamzi*