### PR TITLE
⚡ Bolt: optimize inbound frame buffering with BytesMut

### DIFF
--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,8 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        // BOLT OPTIMIZATION: Use BytesMut for O(1) advance(n) instead of O(N) drain(..n).
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +200,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // BOLT OPTIMIZATION: Use BytesMut for O(1) advance(n) instead of O(N) drain(..n).
+    let buffer: Arc<Mutex<BytesMut>> =
+        Arc::new(Mutex::new(BytesMut::with_capacity(SCTP_SAFE_CHUNK_BYTES)));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +843,7 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
### 💡 What
Switched inbound data channel frame buffers from `Vec<u8>` to `bytes::BytesMut` in both the daemon and client crates.

### 🎯 Why
The previous implementation used `Vec::drain(..consumed)` to remove processed frame bytes from the buffer. `drain` is an **$O(N)$** operation that requires shifting all remaining bytes forward in memory. In a network protocol loop processing many frames, this creates significant CPU overhead and cache pressure. 

By switching to `bytes::BytesMut` and using `advance(consumed)`, we transition to an **$O(1)$** operation that merely updates an internal offset pointer, completely avoiding the memory shift.

### 📊 Impact
Eliminates $O(N)$ memory copying in the critical path of every inbound frame. This improves daemon and client efficiency, especially during high-throughput data transfers or when handling many small frames.

### 🔬 Measurement
Verified via workspace-wide test suite (`cargo test --workspace`). Performance gains can be observed via profiling (`perf` or `instruments`) by noting the reduction in time spent in `alloc::vec::Vec::drain`.

---
*PR created automatically by Jules for task [18169581559934911667](https://jules.google.com/task/18169581559934911667) started by @vamzi*