### PR TITLE
🛡️ Sentinel: [MEDIUM] Hardened HTTP header parsing and added REQUEST_HEAD size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Header Parsing and Frame Size Limits
+**Vulnerability:** Memory exhaustion DoS via oversized REQUEST_HEAD frames and potential HTTP Request Smuggling via ambiguous header whitespace.
+**Learning:** Hand-rolled HTTP parsers in the forwarder path must strictly enforce RFC 7230 §3.2.4 (no whitespace before colons, no OBS-folds) to prevent smuggling when talking to upstream backends. Additionally, application-layer framing requires explicit per-frame-type size limits (like MAX_HEAD_BYTES) even if the transport has its own chunk limits, to prevent unbounded buffering of request metadata.
+**Prevention:** Always apply strict white-list parsing for HTTP headers and enforce early size rejections in the frame dispatcher before payload processing.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for the `REQUEST_HEAD` payload (32KB).
+/// Prevents memory exhaustion DoS from oversized request headers.
+/// Set to 32KB to comfortably fit within common SCTP data channel
+/// message limits while allowing reasonably large headers.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -380,10 +386,28 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+        // RFC 7230 §3.2.4: No whitespace before the colon.
+        // Also reject leading whitespace (OBS-fold) as we don't support it.
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "header line contains illegal leading whitespace",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "header name must not be followed by whitespace before the colon",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -761,6 +785,25 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_around_header_name() {
+        // RFC 7230 §3.2.4: No whitespace before the colon.
+        let cases = [
+            b"GET / HTTP/1.1\r\nHost : example\r\n\r\n".as_slice(),
+            b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n".as_slice(),
+            b"GET / HTTP/1.1\r\n Host: example\r\n\r\n".as_slice(),
+            b"GET / HTTP/1.1\r\n\tHost: example\r\n\r\n".as_slice(),
+        ];
+        for case in cases {
+            let err = parse_request_head(case).unwrap_err();
+            assert!(
+                matches!(err, ForwardError::HeadParse(_)),
+                "failed to reject case: {:?}",
+                std::str::from_utf8(case)
+            );
+        }
     }
 
     #[test]

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = MAX_HEAD_BYTES,
+                    actual = frame.payload.len(),
+                    "openhostd: REQUEST_HEAD exceeded security limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential memory exhaustion DoS via oversized \`REQUEST_HEAD\` frames and potential HTTP request smuggling due to permissive header whitespace handling.
🎯 Impact: A malicious client could cause the daemon to allocate large amounts of memory or smuggle headers to upstream services by exploiting ambiguous whitespace in HTTP headers.
🔧 Fix:
- Introduced \`MAX_HEAD_BYTES\` (32KB) limit for \`REQUEST_HEAD\` frames.
- Enforced the size limit early in the frame dispatcher.
- Hardened \`parse_request_head\` to strictly reject whitespace before colons and leading whitespace (OBS-fold) per RFC 7230 §3.2.4.
- Added regression tests for the new parser restrictions.
✅ Verification: Ran \`cargo test -p openhost-daemon\` and verified all tests passed, including new regression tests for header parsing.

---
*PR created automatically by Jules for task [17703957535467074964](https://jules.google.com/task/17703957535467074964) started by @vamzi*