### PR TITLE
⚡ Bolt: optimize response head encoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Optimize response head encoding
+**Learning:** Using `format!` to build HTTP status lines in hot paths like the forwarder creates unnecessary intermediate `String` allocations. Since we already use a pre-allocated `Vec<u8>` with `with_capacity`, writing directly to it via the `write!` macro from `std::io::Write` is more efficient.
+**Action:** Prefer `write!` over `format!` when encoding protocol headers or status lines into an existing buffer.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -462,7 +463,10 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT OPTIMIZATION: Use write! to encode the status line directly into the
+    // pre-allocated Vec, avoiding an intermediate String allocation.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -524,7 +528,10 @@ fn encode_response_head(
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT OPTIMIZATION: Use write! to encode the status line directly into the
+    // pre-allocated Vec, avoiding an intermediate String allocation.
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec always succeeds");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What: Replaced `format!(...).as_bytes()` with direct `write!` to the pre-allocated `Vec<u8>` in `encode_response_head` and `encode_websocket_response_head`.
🎯 Why: Constructing the HTTP status line with `format!` creates an intermediate heap-allocated `String`, which is then immediately converted to bytes and copied. Writing directly to the buffer eliminates this allocation.
📊 Impact: Eliminates one heap allocation per forwarded HTTP response and WebSocket upgrade. In high-throughput scenarios, this reduces allocator pressure and improves tail latency.
🔬 Measurement: Verified by `cargo test -p openhost-daemon --lib forward::tests`.

---
*PR created automatically by Jules for task [18311124494155387948](https://jules.google.com/task/18311124494155387948) started by @vamzi*