### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via parsing ambiguity

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,10 +380,20 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (leading whitespace) in header is forbidden",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +792,32 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("whitespace")),
+            "expected error about whitespace before colon, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A server MUST reject any received request
+        // message that contains an obsolete line fold".
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Custom: folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("whitespace") || msg.contains("fold")),
+            "expected error about obs-fold, got: {:?}",
+            err
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Permissive HTTP/1.1 header parsing allowed obsolete line folding (obs-fold) and whitespace between header names and colons.
🎯 Impact: This could lead to HTTP Request Smuggling (CWE-444) if a desynchronization occurs between the openhost daemon and an upstream or downstream proxy/server.
🔧 Fix: Strictly enforce RFC 7230 §3.2.4 in `parse_request_head` by rejecting leading whitespace and whitespace before the colon.
✅ Verification: New unit tests `parse_request_head_rejects_obs_fold` and `parse_request_head_rejects_whitespace_before_colon` pass, along with the full workspace test suite.

---
*PR created automatically by Jules for task [456109430059324381](https://jules.google.com/task/456109430059324381) started by @vamzi*