### PR TITLE
🛡️ Sentinel: [HIGH] Fix lenient HTTP header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Strict HTTP Header Parsing in Daemon Forwarder
+**Vulnerability:** Lenient HTTP/1.1 header parsing in `openhost-daemon` allowed whitespace between header names and colons, and accepted OBS-fold (header lines starting with whitespace).
+**Learning:** Hand-rolled HTTP parsers often miss RFC 7230 §3.2.4 constraints, which can be exploited for HTTP request smuggling if the upstream server has different parsing leniency.
+**Prevention:** Always validate header names strictly: they must not end with whitespace, and header lines must not start with whitespace (unless explicitly handling OBS-fold by normalization).

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,12 +380,27 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: OBS-fold (line starting with SP or HTAB) is
+        // forbidden in new implementations and must be rejected to
+        // mitigate request smuggling.
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("header line starts with whitespace (OBS-fold)"));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("whitespace before header colon"));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -897,5 +912,30 @@ mod tests {
         let target: Uri = "http://127.0.0.1:8080".parse().unwrap();
         let uri = combine_target_and_path(&target, "http://evil.example/foo").unwrap();
         assert_eq!(uri.to_string(), "http://127.0.0.1:8080/foo");
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "Should reject whitespace before colon"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A proxy MUST either reject such a message
+        // or replace each received OBS fold with one or more SP
+        // characters prior to forwarding". We choose to reject.
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n Folder: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "Should reject OBS-fold"
+        );
     }
 }

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -384,7 +384,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         // forbidden in new implementations and must be rejected to
         // mitigate request smuggling.
         if line.starts_with([' ', '\t']) {
-            return Err(ForwardError::HeadParse("header line starts with whitespace (OBS-fold)"));
+            return Err(ForwardError::HeadParse(
+                "header line starts with whitespace (OBS-fold)",
+            ));
         }
 
         let colon = line


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Lenient HTTP/1.1 header parsing in `openhost-daemon`. It allowed whitespace between header field-names and the colon, and it accepted OBS-fold (header lines starting with whitespace).
🎯 Impact: Inconsistent interpretation of HTTP messages between `openhost-daemon` and an upstream server could lead to HTTP request smuggling.
🔧 Fix: Strictly enforced RFC 7230 §3.2.4 in `parse_request_head`. The parser now rejects requests with whitespace before the colon or with OBS-fold.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_rejects_obs_fold` which confirm the rejection. All existing tests pass.

---
*PR created automatically by Jules for task [1235437430214775521](https://jules.google.com/task/1235437430214775521) started by @vamzi*