### PR TITLE
🛡️ Sentinel: [HIGH] Strict RFC 7230 §3.2.4 compliance in HTTP forwarder

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Strict RFC 7230 §3.2.4 Enforcement in HTTP Forwarder
+**Vulnerability:** The hand-rolled HTTP/1.1 parser in the daemon's forwarder was too lenient, allowing whitespace between header names and colons, and accepting obsolete line folding (obs-fold).
+**Learning:** Hand-rolled parsers often default to "helpful" behavior (like `.trim()` on header names) that violates strict protocol specifications. In HTTP, this leniency is a primary vector for request smuggling and cache poisoning when proxies and backends disagree on header boundaries.
+**Prevention:** Always parse protocol-defined tokens strictly against their ABNF. Header names in RFC 7230 are `token`s which do not include whitespace. Explicitly reject `obs-fold` and whitespace-before-colon as mandated by the "MUST reject" clauses in the RFC.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,10 +380,21 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.as_bytes().iter().any(|&b| b == b' ' || b == b'\t') {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is not allowed",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +793,34 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon. [...] A server MUST reject any received
+        // request message that contains whitespace between a header
+        // field-name and colon"
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace before colon")),
+            "expected error for whitespace before colon, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A server MUST reject any received request
+        // message that contains [...] obsolete line folding"
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n Folded-Header: value\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("obsolete line folding")),
+            "expected error for obs-fold, got: {:?}",
+            err
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Lenient HTTP/1.1 header parsing allowed whitespace before the colon and obsolete line folding (obs-fold).
🎯 Impact: This could be exploited for HTTP request smuggling or cache poisoning if an upstream service interprets these malformed headers differently than the openhost daemon.
🔧 Fix: Updated `parse_request_head` in `openhost-daemon` to explicitly reject lines starting with whitespace and header names containing whitespace.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_rejects_obs_fold` which confirm the fix. Verified all tests pass.

---
*PR created automatically by Jules for task [14459409162341267200](https://jules.google.com/task/14459409162341267200) started by @vamzi*