### PR TITLE
🛡️ Sentinel: [HIGH] Strict HTTP header parsing to prevent smuggling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Strict HTTP Header Parsing
+**Vulnerability:** HTTP Request Smuggling / Header Injection via lenient parsing.
+**Learning:** Leniently trimming whitespace before colons and allowing obsolete line folding (OBS-fold) can lead to desynchronization between proxies, potentially allowing an attacker to smuggle a second request or inject headers.
+**Prevention:** Strictly adhere to RFC 7230 §3.2.4: reject headers with whitespace between field-name and colon, and reject lines starting with whitespace (OBS-fold).

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,10 +380,27 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: "A sender MUST NOT generate OBS-fold... a
+            // recipient MAY reject". openhost strictly rejects it.
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: "No whitespace is allowed between the
+            // header field-name and colon."
+            return Err(ForwardError::HeadParse(
+                "header field-name MUST NOT be followed by whitespace",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())

--- a/crates/openhost-daemon/tests/security_repro.rs
+++ b/crates/openhost-daemon/tests/security_repro.rs
@@ -1,0 +1,50 @@
+use bytes::Bytes;
+use openhost_daemon::config::ForwardConfig;
+use openhost_daemon::error::ForwardError;
+use openhost_daemon::forward::Forwarder;
+
+#[tokio::test]
+async fn test_whitespace_before_colon_in_header_rejected() {
+    let cfg = ForwardConfig {
+        target: Some("http://127.0.0.1:8080".into()),
+        host_override: None,
+        max_body_bytes: 1024,
+        websockets: None,
+    };
+    let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+
+    // Header with space before colon: "Host : example.com"
+    let head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1:8080\r\n\r\n";
+    let body = Bytes::new();
+
+    let result = fwd.forward(head, body).await;
+    assert!(matches!(
+        result,
+        Err(ForwardError::HeadParse(
+            "header field-name MUST NOT be followed by whitespace"
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn test_leading_whitespace_in_header_rejected() {
+    let cfg = ForwardConfig {
+        target: Some("http://127.0.0.1:8080".into()),
+        host_override: None,
+        max_body_bytes: 1024,
+        websockets: None,
+    };
+    let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+
+    // Leading whitespace (obsolete line folding)
+    let head = b"GET / HTTP/1.1\r\n Host: 127.0.0.1:8080\r\n\r\n";
+    let body = Bytes::new();
+
+    let result = fwd.forward(head, body).await;
+    assert!(matches!(
+        result,
+        Err(ForwardError::HeadParse(
+            "obsolete line folding (OBS-fold) is not supported"
+        ))
+    ));
+}


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Lenient HTTP header parsing allowed whitespace before colons and obsolete line folding (OBS-fold).
🎯 Impact: Potential HTTP Request Smuggling or Header Injection if an upstream proxy handles these malformed headers differently than the daemon.
🔧 Fix: Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to strictly reject whitespace between the header name and colon, and to reject lines starting with whitespace (OBS-fold), as mandated by RFC 7230 §3.2.4.
✅ Verification: Added a new integration test `crates/openhost-daemon/tests/security_repro.rs` covering both cases and verified that all existing `openhost-daemon` tests pass.

---
*PR created automatically by Jules for task [2558028042461239642](https://jules.google.com/task/2558028042461239642) started by @vamzi*