### PR TITLE
🛡️ Sentinel: [HIGH] HTTP header size limit and strict parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Strict HTTP Header Parsing and Size Limits
+**Vulnerability:** Resource exhaustion DoS via oversized HTTP request heads and potential request smuggling via loose header parsing (whitespace trimming, OBS-fold).
+**Learning:** Defaulting to `.trim()` on header names in a proxy is dangerous as it can lead to differential interpretation between the proxy and upstream. Enforcing strict RFC 7230 compliance (no whitespace before colon, no OBS-fold) is a critical defense-in-depth measure.
+**Prevention:** Always enforce explicit length caps on untrusted buffers before processing, and use strict parsers for protocol-sensitive fields like HTTP headers.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound `REQUEST_HEAD` payload exceeded the security limit.
+    #[error("request head exceeded {cap} byte cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Security limit for the `REQUEST_HEAD` frame. Set to 32KB to ensure
+/// large headers fit comfortably in SCTP transport chunks without
+/// manual fragmentation.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -341,6 +346,12 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadTooLarge {
+            cap: MAX_HEAD_BYTES,
+        });
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -380,10 +391,23 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+            return Err(ForwardError::HeadParse(
+                "header name contains forbidden whitespace",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -761,6 +785,38 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..MAX_HEAD_BYTES {
+            raw.push(if i % 2 == 0 { b'A' } else { b':' });
+        }
+        raw.extend_from_slice(b"\r\n\r\n");
+
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadTooLarge { cap } if cap == MAX_HEAD_BYTES));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("header name contains forbidden whitespace")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obsolete_line_folding() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("obsolete line folding (OBS-fold) is not supported")
+        ));
     }
 
     #[test]

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential memory exhaustion DoS via unbounded RequestHead frames and request smuggling via loose header parsing.
🎯 Impact: Attackers could crash the daemon with oversized headers or bypass security filters by exploiting differences in header interpretation.
🔧 Fix: Enforced a 32KB limit on request heads and implemented strict RFC 7230 header parsing (rejecting OBS-fold and whitespace before colons).
✅ Verification: Added unit tests in forward.rs and verified via `cargo test -p openhost-daemon`.

---
*PR created automatically by Jules for task [16216295535322875053](https://jules.google.com/task/16216295535322875053) started by @vamzi*