### PR TITLE
🛡️ Sentinel: Hardened HTTP header parsing and enforced size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Strict HTTP Header Parsing & Size Limits]
+**Vulnerability:** Memory-exhaustion DoS via unbounded HTTP request headers and potential Request Smuggling via non-compliant header parsing (whitespace before colon, OBS-fold).
+**Learning:** Even internal protocol bridges (DataChannel to localhost HTTP) must enforce strict RFC 7230 compliance and resource limits, as they represent the application's attack surface. Relying on `.trim()` during parsing can inadvertently normalize invalid/dangerous inputs.
+**Prevention:** Always enforce a `MAX_HEAD_BYTES` limit before allocating/cloning header buffers and use strict parsing that rejects any deviation from the expected RFC format (no whitespace between field-name and colon, no line folding).

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security cap.
+    #[error("request head exceeded {cap} byte cap")]
+    HeadTooLarge {
+        /// The security maximum in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for the inbound `REQUEST_HEAD` frame payload
+/// (HTTP/1.1 request line + headers). 32KB is comfortably above the
+/// 4-8KB defaults of Nginx/Apache while providing a hard bound against
+/// memory-exhaustion DoS.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +189,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                cap: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,10 +391,24 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: No whitespace allowed between field-name and colon.
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -20,8 +20,10 @@ use crate::channel_binding::{
     ChannelBinder, ChannelBindingError, AUTH_NONCE_LEN, BINDING_TIMEOUT_SECS, EXPORTER_LABEL,
     EXPORTER_SECRET_LEN,
 };
-use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::error::{ForwardError, ListenerError};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -856,7 +858,14 @@ async fn wire_frame_loop(
                             &local_dtls_fp,
                         )
                         .await;
-                        if let FrameOutcome::Teardown = outcome {
+
+                        let is_error = if let FrameOutcome::Error(ref reason) = outcome {
+                            let _ = send_error_frame(&dc, reason).await;
+                            true
+                        } else {
+                            false
+                        };
+                        if is_error || matches!(outcome, FrameOutcome::Teardown) {
                             let _ = dc.close().await;
                             buf.clear();
                             request.lock().await.reset();
@@ -881,6 +890,9 @@ async fn wire_frame_loop(
 enum FrameOutcome {
     Continue,
     Teardown,
+    /// Protocol or security violation. `dispatch_frame` returns this to
+    /// trigger an `ERROR` frame emission before `Teardown`.
+    Error(String),
 }
 
 /// Top-level dispatch. Gates on [`BindingState`]: until the channel
@@ -927,10 +939,9 @@ async fn dispatch_frame(
                 ?frame.frame_type,
                 "openhostd: frame arrived before data channel opened; tearing down"
             );
-            let _ = send_error_frame(dc, "frame before channel opened").await;
             *binding.lock().await = BindingState::Failed;
             binding_done.notify_waiters();
-            return FrameOutcome::Teardown;
+            return FrameOutcome::Error("frame before channel opened".to_string());
         }
         BindingSnapshot::AwaitingAuthClient { nonce } => {
             if frame.frame_type != FrameType::AuthClient {
@@ -938,17 +949,12 @@ async fn dispatch_frame(
                     ?frame.frame_type,
                     "openhostd: non-AuthClient frame before binding completed; tearing down"
                 );
-                let _ = send_error_frame(
-                    dc,
-                    &format!(
-                        "expected AuthClient before any other frame (got 0x{:02x})",
-                        frame.frame_type.as_u8()
-                    ),
-                )
-                .await;
                 *binding.lock().await = BindingState::Failed;
                 binding_done.notify_waiters();
-                return FrameOutcome::Teardown;
+                return FrameOutcome::Error(format!(
+                    "expected AuthClient before any other frame (got 0x{:02x})",
+                    frame.frame_type.as_u8()
+                ));
             }
             return handle_auth_client(
                 frame,
@@ -970,6 +976,13 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded cap; tearing down"
+                );
+                return FrameOutcome::Error("request head too large".to_string());
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -979,8 +992,7 @@ async fn dispatch_frame(
             let mut req = request.lock().await;
             if req.head_payload.is_none() {
                 tracing::warn!("openhostd: REQUEST_BODY before REQUEST_HEAD; tearing down");
-                let _ = send_error_frame(dc, "REQUEST_BODY before REQUEST_HEAD").await;
-                return FrameOutcome::Teardown;
+                return FrameOutcome::Error("REQUEST_BODY before REQUEST_HEAD".to_string());
             }
             // Always cap the accumulated body — even on the stub-502 path
             // where the bytes will be discarded on REQUEST_END. Without
@@ -991,8 +1003,7 @@ async fn dispatch_frame(
                 .unwrap_or(STUB_MAX_BODY_BYTES);
             if req.body.len().saturating_add(frame.payload.len()) > cap {
                 tracing::warn!(cap, "openhostd: request body exceeded cap; tearing down");
-                let _ = send_error_frame(dc, "request body too large").await;
-                return FrameOutcome::Teardown;
+                return FrameOutcome::Error("request body too large".to_string());
             }
             req.body.extend_from_slice(&frame.payload);
             FrameOutcome::Continue
@@ -1004,8 +1015,7 @@ async fn dispatch_frame(
                     Some(h) => (h, std::mem::take(&mut req.body)),
                     None => {
                         tracing::warn!("openhostd: REQUEST_END without REQUEST_HEAD; tearing down");
-                        let _ = send_error_frame(dc, "REQUEST_END without REQUEST_HEAD").await;
-                        return FrameOutcome::Teardown;
+                        return FrameOutcome::Error("REQUEST_END without REQUEST_HEAD".to_string());
                     }
                 }
             };
@@ -1025,6 +1035,19 @@ async fn dispatch_frame(
                             );
                             let _ = emit_stub_502(dc).await;
                         }
+                    }
+                    Err(ForwardError::HeadParse(reason)) => {
+                        tracing::warn!(
+                            reason,
+                            "openhostd: request head parse failed; tearing down"
+                        );
+                        return FrameOutcome::Error(format!("request head parse failed: {reason}"));
+                    }
+                    Err(ForwardError::HeadTooLarge { cap }) => {
+                        tracing::warn!(cap, "openhostd: request head exceeded cap; tearing down");
+                        return FrameOutcome::Error(format!(
+                            "request head exceeded {cap} byte cap"
+                        ));
                     }
                     Err(err) => {
                         tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
@@ -1053,8 +1076,7 @@ async fn dispatch_frame(
                 }
                 None => {
                     tracing::warn!("openhostd: WS_FRAME before websocket upgrade; tearing down");
-                    let _ = send_error_frame(dc, "WS_FRAME before upgrade").await;
-                    FrameOutcome::Teardown
+                    FrameOutcome::Error("WS_FRAME before upgrade".to_string())
                 }
             }
         }
@@ -1064,8 +1086,7 @@ async fn dispatch_frame(
             // websocket` header. Receiving it from a client is a
             // protocol violation.
             tracing::warn!("openhostd: unexpected WS_UPGRADE frame; tearing down");
-            let _ = send_error_frame(dc, "WS_UPGRADE frames are reserved").await;
-            FrameOutcome::Teardown
+            FrameOutcome::Error("WS_UPGRADE frames are reserved".to_string())
         }
         FrameType::Ping => {
             let pong = Frame::new(FrameType::Pong, Vec::new()).expect("Pong is empty");
@@ -1095,8 +1116,7 @@ async fn dispatch_frame(
                 ?frame.frame_type,
                 "openhostd: client sent unexpected frame type; tearing down"
             );
-            let _ = send_error_frame(dc, "unexpected frame type from client").await;
-            FrameOutcome::Teardown
+            FrameOutcome::Error("unexpected frame type from client".to_string())
         }
         // Auth frames after binding is complete are a protocol violation.
         // Spec §7.1 says binding runs once per DC; a client wishing to
@@ -1106,12 +1126,10 @@ async fn dispatch_frame(
                 ?frame.frame_type,
                 "openhostd: auth frame after binding completed; tearing down"
             );
-            let _ = send_error_frame(
-                dc,
-                "auth frame after binding completed; re-binding requires a new data channel",
+            FrameOutcome::Error(
+                "auth frame after binding completed; re-binding requires a new data channel"
+                    .to_string(),
             )
-            .await;
-            FrameOutcome::Teardown
         }
     }
 }

--- a/crates/openhost-daemon/tests/security_repro.rs
+++ b/crates/openhost-daemon/tests/security_repro.rs
@@ -1,0 +1,153 @@
+mod support;
+
+use bytes::Bytes;
+use openhost_core::wire::{Frame, FrameType};
+use openhost_daemon::config::{
+    Config, DtlsConfig, ForwardConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+};
+use openhost_daemon::{App, Result as DaemonResult};
+use openhost_pkarr::Transport;
+use std::sync::Arc;
+use std::time::Duration;
+use support::{establish_connection, NoopTransport};
+use tempfile::TempDir;
+use webrtc::data_channel::RTCDataChannel;
+
+fn test_config(dir: &TempDir, upstream_port: u16) -> Config {
+    Config {
+        identity: IdentityConfig {
+            store: IdentityStore::Fs {
+                path: dir.path().join("identity.key"),
+            },
+        },
+        pkarr: PkarrConfig {
+            relays: vec![],
+            republish_secs: 3600,
+            offer_poll: Default::default(),
+        },
+        dtls: DtlsConfig {
+            cert_path: dir.path().join("dtls.pem"),
+            rotate_secs: 3600,
+            allowed_binding_modes: vec![
+                openhost_daemon::config::BindingModeConfig::Exporter,
+                openhost_daemon::config::BindingModeConfig::CertFp,
+            ],
+        },
+        forward: Some(ForwardConfig {
+            target: Some(format!("http://127.0.0.1:{upstream_port}")),
+            host_override: None,
+            max_body_bytes: 1024 * 1024,
+            websockets: None,
+        }),
+        log: LogConfig::default(),
+        pairing: Default::default(),
+        turn: Default::default(),
+    }
+}
+
+async fn build_daemon(upstream_port: u16) -> (TempDir, App) {
+    let tmp = TempDir::new().unwrap();
+    let cfg = test_config(&tmp, upstream_port);
+    let app = App::build_with_transport(cfg, Arc::new(NoopTransport) as Arc<dyn Transport>)
+        .await
+        .expect("daemon builds");
+    (tmp, app)
+}
+
+async fn send_frame_fragmented(dc: &RTCDataChannel, ty: FrameType, payload: Vec<u8>) {
+    let frame = Frame::new(ty, payload).expect("frame constructs");
+    let mut out = Vec::new();
+    frame.encode(&mut out);
+
+    // Split into 16KB chunks to avoid Sctp(ErrOutboundPacketTooLarge)
+    for chunk in out.chunks(16384) {
+        dc.send(&Bytes::copy_from_slice(chunk))
+            .await
+            .expect("send chunk");
+    }
+}
+
+#[tokio::test]
+async fn rejects_whitespace_before_colon_in_header() -> DaemonResult<()> {
+    let (_tmp, app) = build_daemon(8080).await;
+    let session = establish_connection(&app).await;
+
+    // "Host : localhost" has a space before the colon.
+    let head = b"GET / HTTP/1.1\r\nHost : localhost\r\n\r\n";
+    send_frame_fragmented(&session.dc, FrameType::RequestHead, head.to_vec()).await;
+    send_frame_fragmented(&session.dc, FrameType::RequestEnd, vec![]).await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut saw_error = false;
+    loop {
+        let bytes = session.received.lock().await.clone();
+        let mut offset = 0;
+        while let Ok(Some((frame, used))) = Frame::try_decode(&bytes[offset..]) {
+            offset += used;
+            if frame.frame_type == FrameType::Error {
+                saw_error = true;
+                break;
+            }
+        }
+        if saw_error || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        saw_error,
+        "Daemon should have rejected header with whitespace before colon with an ERROR frame"
+    );
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn rejects_oversized_request_head() -> DaemonResult<()> {
+    let (_tmp, app) = build_daemon(8080).await;
+    let session = establish_connection(&app).await;
+
+    // Create a ~48KB header.
+    let mut head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..800 {
+        head.extend_from_slice(
+            format!("X-Long-Header-{:04}: {}\r\n", i, "v".repeat(40)).as_bytes(),
+        );
+    }
+    head.extend_from_slice(b"\r\n");
+
+    assert!(head.len() > 32 * 1024);
+
+    send_frame_fragmented(&session.dc, FrameType::RequestHead, head).await;
+    send_frame_fragmented(&session.dc, FrameType::RequestEnd, vec![]).await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    let mut saw_error = false;
+    loop {
+        let bytes = session.received.lock().await.clone();
+        let mut offset = 0;
+        while let Ok(Some((frame, used))) = Frame::try_decode(&bytes[offset..]) {
+            offset += used;
+            if frame.frame_type == FrameType::Error {
+                saw_error = true;
+                break;
+            }
+        }
+        if saw_error || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    assert!(
+        saw_error,
+        "Daemon should have rejected oversized RequestHead with an ERROR frame"
+    );
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Hardened HTTP header parsing and enforced size limits

🚨 **Severity:** HIGH
💡 **Vulnerability:** The daemon lacked a hard limit on the size of inbound `REQUEST_HEAD` frames, making it vulnerable to memory-exhaustion DoS. Additionally, the HTTP header parser was overly permissive, accepting whitespace before the colon and not explicitly rejecting OBS-fold, which can lead to request smuggling or splitting.
🎯 **Impact:** An attacker could crash the daemon by sending extremely large header frames or potentially bypass security controls/smuggle requests to the upstream service.
🔧 **Fix:**
- Enforced a `MAX_HEAD_BYTES` (32KB) limit on `REQUEST_HEAD` payloads.
- Updated `parse_request_head` to strictly reject whitespace before colons and OBS-fold.
- Refactored `listener.rs` to ensure `ERROR` frames are consistently sent to the client before connection teardown on security violations.
✅ **Verification:** Added `crates/openhost-daemon/tests/security_repro.rs` which verifies that both oversized heads and non-compliant headers are correctly rejected. Ran `cargo test -p openhost-daemon` and all 125 tests passed.

---
*PR created automatically by Jules for task [8489663305472467456](https://jules.google.com/task/8489663305472467456) started by @vamzi*