### PR TITLE
🛡️ Sentinel: [HIGH] Strict HTTP Header Parsing and Size Limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - Strict HTTP Header Parsing and Size Limits
+**Vulnerability:** HTTP request smuggling and memory exhaustion DoS via lenient header parsing (whitespace before colon, OBS-fold) and unbounded header sizes.
+**Learning:** Hand-rolled HTTP parsers must explicitly implement modern RFC 7230 constraints (e.g., §3.2.4) to prevent smuggling; global frame limits are insufficient for request-level security.
+**Prevention:** Enforce strict header name/colon separation, reject line folding, and apply per-transaction size caps before fully buffering headers in memory.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security limit.
+    #[error("request head exceeded {cap} byte cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Security limit on the size of an inbound HTTP request head (request
+/// line + headers + terminator). 32KB is comfortably above the needs
+/// of any well-behaved client and bounds memory exhaustion from
+/// oversized headers.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -341,6 +347,12 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadTooLarge {
+            cap: MAX_HEAD_BYTES,
+        });
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -380,10 +392,29 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+        // RFC 7230 §3.2.4: obsolete line folding (OBS-fold) is prohibited.
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (leading whitespace) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        if name.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+            return Err(ForwardError::HeadParse(
+                "whitespace not allowed in header name or before colon",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +813,45 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace not allowed in header name or before colon")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: obsolete line folding (leading whitespace)
+        // is prohibited.
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n  folded-header: value\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("obsolete line folding (leading whitespace) is not supported")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        // Verify that 2000 headers exceed 32KB for this test.
+        assert!(raw.len() > MAX_HEAD_BYTES);
+
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadTooLarge { cap: 32768 }));
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The HTTP forwarder was susceptible to HTTP request smuggling due to lenient header parsing (allowing whitespace before the colon and obsolete line folding) and memory exhaustion DoS due to the lack of a specific limit on HTTP request headers.

🎯 Impact: An attacker could potentially smuggle requests to the upstream service or exhaust the daemon's memory by sending extremely large HTTP headers.

🔧 Fix: 
- Introduced a 32KB `MAX_HEAD_BYTES` security limit.
- Hardened `parse_request_head` to strictly follow RFC 7230 §3.2.4.
- Enforced the size limit in the listener before the head is fully processed.

✅ Verification: 
- Added unit tests in `crates/openhost-daemon/src/forward.rs` covering:
  - Oversized headers rejection.
  - Whitespace before colon rejection.
  - Obsolete line folding rejection.
- All tests passed via `cargo test -p openhost-daemon`.

---
*PR created automatically by Jules for task [10503183009888097694](https://jules.google.com/task/10503183009888097694) started by @vamzi*