### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via header whitespace

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Strict HTTP Header Parsing
+**Vulnerability:** HTTP Request Smuggling via header whitespace.
+**Learning:** The hand-rolled HTTP/1.1 parser in `forward.rs` was using `.trim()` on header field names. RFC 7230 §3.2.4 explicitly forbids whitespace between the field name and the colon (`field-name ":" OWS field-value BWS`). Allowing whitespace could lead to request smuggling if a frontend proxy and this backend daemon interpret the header name differently.
+**Prevention:** Avoid `.trim()` on protocol-sensitive tokens. Use exact slicing and rely on strict validation libraries (like `http::HeaderName::from_bytes` on the raw slice) which correctly reject invalid characters including interior or trailing spaces.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,7 +383,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +782,18 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : localhost\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "expected HeadParse error for whitespace before colon, got {err:?}"
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: The hand-rolled HTTP/1.1 request head parser in `openhost-daemon` was using `.trim()` on header field names before the colon. 

🎯 **Impact**: RFC 7230 §3.2.4 strictly forbids whitespace between the header field name and the colon (`field-name ":" OWS field-value BWS`). Allowing whitespace could lead to **HTTP Request Smuggling** if a frontend proxy and this backend daemon interpret the header name differently (e.g., one rejects it while the other trims and accepts it).

🔧 **Fix**: Removed `.trim()` from the header name extraction in `parse_request_head`. The code now uses the raw bytes before the colon, letting `http::HeaderName::from_bytes` perform strict validation.

✅ **Verification**: 
- Added a new unit test `parse_request_head_rejects_whitespace_before_colon` in `crates/openhost-daemon/src/forward.rs`.
- Verified that the test fails before the fix and passes after.
- Ran the full `openhost-daemon` test suite to ensure no regressions.
- Verified code formatting with `cargo fmt`.

---
*PR created automatically by Jules for task [8232591423058497442](https://jules.google.com/task/8232591423058497442) started by @vamzi*