### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden HTTP header parsing and enforce size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Harden HTTP Header Parsing
+**Vulnerability:** Memory Exhaustion DoS and HTTP Request Smuggling.
+**Learning:** Hand-rolled HTTP parsers must strictly follow RFC 7230 §3.2.4 (reject OBS-fold and whitespace before colon) to prevent smuggling, and enforce explicit size limits on headers before buffering to prevent DoS.
+**Prevention:** Always bound inbound frame sizes and use strict byte-level checks for protocol grammar.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,14 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for an inbound HTTP request head.
+///
+/// Set to 32KB — comfortably above any legitimate browser request while
+/// bounding memory exhaustion DoS.
+///
+/// Exported for use in the listener's frame dispatcher.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -341,6 +349,10 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadParse("request head exceeds size limit"));
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -380,12 +392,28 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: Reject obsolete line folding (OBS-fold).
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("obsolete line folding is rejected"));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before header colon is rejected",
+            ));
+        }
+        let name = name.trim_matches([' ', '\t']);
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -781,6 +809,37 @@ mod tests {
     fn parse_request_head_rejects_header_without_colon() {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A sender MUST NOT generate HTTP/1.1 message
+        // headers containing line folding... A server that receives such
+        // a message... MUST reject the message".
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n  folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        // 2000 headers * ~20 bytes/header > 32KB
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+        let err = parse_request_head(&raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
     }
 

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = MAX_HEAD_BYTES,
+                    got = frame.payload.len(),
+                    "openhostd: request head too large; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,45 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeding_cap_triggers_error_frame_and_teardown() -> DaemonResult<()>
+{
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // MAX_HEAD_BYTES is 32KB. Send a 40KB head.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Harden HTTP header parsing and enforce size limits

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The custom HTTP parser in `openhost-daemon` lacked a size limit on the request head (leading to memory exhaustion DoS) and was too permissive regarding header formatting (allowing OBS-fold and whitespace before colons).
🎯 **Impact:** 
1. **DoS:** A malicious client could send a massive `REQUEST_HEAD` frame to exhaust daemon memory.
2. **Smuggling:** Permissive parsing of whitespace around header colons can lead to HTTP request smuggling or desynchronization when the daemon forwards to an upstream that applies different rules.
🔧 **Fix:** 
- Defined `MAX_HEAD_BYTES` (32KB).
- Updated `parse_request_head` to strictly follow RFC 7230 §3.2.4.
- Updated the listener's frame dispatcher to reject oversized heads before buffering.
✅ **Verification:** 
- New unit tests in `forward.rs` cover the RFC 7230 constraints and the size limit.
- A new integration test in `tests/forward.rs` verifies that oversized heads trigger an ERROR frame and connection teardown.
- All 125+ tests in the daemon crate pass.


---
*PR created automatically by Jules for task [9123948623761415491](https://jules.google.com/task/9123948623761415491) started by @vamzi*