### PR TITLE
⚡ Bolt: use BytesMut for O(1) inbound buffer consumption in daemon

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-28 - O(1) buffer consumption with BytesMut
+**Learning:** Using `BytesMut` for inbound network buffers allows $O(1)$ consumption via `advance(n)` instead of $O(N)$ via `Vec::drain(..n)`. This reduces memory copies during frame decoding in high-throughput data channels.
+**Action:** Always prefer `BytesMut` over `Vec<u8>` for streaming decoders where partial consumption is common.

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,8 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // BOLT OPTIMIZATION: Use BytesMut for O(1) buffer consumption via advance().
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +842,8 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        // BOLT OPTIMIZATION: O(1) consumption instead of O(N) drain.
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
💡 What: Switched the inbound frame buffer in `openhost-daemon`'s listener from `Vec<u8>` to `BytesMut`, and replaced $O(N)$ `drain(..n)` with $O(1)$ `advance(n)`.

🎯 Why: `Vec::drain` on the front of a vector requires shifting all remaining elements, which is $O(N)$ and leads to excessive memory copies during high-throughput frame decoding.

📊 Impact: Reduces memory copies and CPU usage in the data-channel listener loop. For a 16MiB payload (the `MAX_PAYLOAD_LEN`), this eliminates potentially thousands of shift operations as frames are consumed.

🔬 Measurement: Verified with `cargo test -p openhost-daemon`. Performance gain can be observed with benchmarks on high-throughput data channels (e.g. large file transfers).

---
*PR created automatically by Jules for task [5476333683817793632](https://jules.google.com/task/5476333683817793632) started by @vamzi*