### PR TITLE
⚡ Bolt: use BytesMut for O(1) frame consumption

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Transition to Bytes/BytesMut for Frame Processing
+**Learning:** Using `Vec<u8>` with `drain(..n)` for network buffers results in O(N) performance due to byte shifting. Moving to `bytes::BytesMut` and `advance(n)` provides O(1) consumption. Furthermore, using `bytes::Bytes` for frame payloads enables zero-copy slicing from the inbound buffer, significantly reducing allocations in high-throughput data channels.
+**Action:** Use `BytesMut` for all inbound protocol buffers and `Bytes` for immutable data chunks passed between layers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ name = "openhost-core"
 version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "chacha20poly1305",
  "crypto_box",
  "curve25519-dalek 4.1.3",

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,7 +31,7 @@ use webrtc::peer_connection::RTCPeerConnection;
 pub struct ClientResponse {
     /// UTF-8 HTTP/1.1 response head, CRLF-separated, terminated by a
     /// blank line.
-    pub head_bytes: Vec<u8>,
+    pub head_bytes: Bytes,
     /// Body bytes (may be empty).
     pub body: Bytes,
 }
@@ -81,7 +81,7 @@ impl OpenhostSession {
             .map_err(|e| ClientError::HttpRoundTrip(format!("send: {e}")))?;
 
         // Read until RESPONSE_END.
-        let mut head_bytes_out: Option<Vec<u8>> = None;
+        let mut head_bytes_out: Option<Bytes> = None;
         let mut body_out: Vec<u8> = Vec::new();
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
         loop {
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -197,9 +197,10 @@ impl SessionInboundReader {
             // Try to decode whatever's currently buffered.
             {
                 let mut buf = self.buffer.lock().await;
-                match Frame::try_decode(&buf) {
-                    Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                // BOLT OPTIMIZATION: use try_decode_mut for O(1) consumption via advance()
+                // and zero-copy payload slicing into Bytes.
+                match Frame::try_decode_mut(&mut buf) {
+                    Ok(Some(frame)) => {
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-core/Cargo.toml
+++ b/crates/openhost-core/Cargo.toml
@@ -12,6 +12,7 @@ readme.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+bytes = "1"
 ed25519-dalek = { workspace = true }
 x25519-dalek = { workspace = true }
 curve25519-dalek = { workspace = true }

--- a/crates/openhost-core/src/wire/mod.rs
+++ b/crates/openhost-core/src/wire/mod.rs
@@ -25,10 +25,11 @@
 //! returns `Ok(None)` when more bytes are needed and `Ok(Some((frame, consumed)))`
 //! when a complete frame is available.
 //!
-//! Payloads are plain `Vec<u8>`; higher-level code interprets them according to
+//! Payloads are [`bytes::Bytes`]; higher-level code interprets them according to
 //! [`FrameType`] (e.g. HTTP header text for [`FrameType::RequestHead`]).
 
 use crate::{Error, Result};
+use bytes::{Buf, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 
 /// Wire header length of the legacy v1 frame: `type(1) || length(4)`.
@@ -147,21 +148,26 @@ pub struct Frame {
     /// (AuthNonce/AuthClient/AuthHost, Ping/Pong) and for legacy v1
     /// frames (synthesised during decode).
     pub request_id: u32,
-    /// Frame payload bytes (length is implicit from the `Vec`).
-    pub payload: Vec<u8>,
+    /// Frame payload bytes (length is implicit from the [`Bytes`]).
+    pub payload: Bytes,
 }
 
 impl Frame {
     /// Create a new session-scoped frame (request_id = 0). Preserved for
     /// call sites that never care about demultiplexing — auth frames,
     /// pings, legacy tests. Validates per-type payload constraints.
-    pub fn new(frame_type: FrameType, payload: Vec<u8>) -> Result<Self> {
+    pub fn new<P: Into<Bytes>>(frame_type: FrameType, payload: P) -> Result<Self> {
         Self::new_with_id(frame_type, REQUEST_ID_SESSION, payload)
     }
 
     /// Create a new frame with an explicit request_id. HTTP-transaction
     /// frames produced by the SW proxy / client session use this.
-    pub fn new_with_id(frame_type: FrameType, request_id: u32, payload: Vec<u8>) -> Result<Self> {
+    pub fn new_with_id<P: Into<Bytes>>(
+        frame_type: FrameType,
+        request_id: u32,
+        payload: P,
+    ) -> Result<Self> {
+        let payload = payload.into();
         if payload.len() > MAX_PAYLOAD_LEN {
             return Err(Error::OversizedFrame {
                 requested: payload.len(),
@@ -265,7 +271,7 @@ impl Frame {
             return Ok(None);
         }
 
-        let payload = buf[FRAME_HEADER_LEN..total].to_vec();
+        let payload = Bytes::copy_from_slice(&buf[FRAME_HEADER_LEN..total]);
         Ok(Some((
             Self {
                 frame_type,
@@ -307,7 +313,7 @@ impl Frame {
             return Ok(None);
         }
 
-        let payload = buf[FRAME_V2_HEADER_LEN..total].to_vec();
+        let payload = Bytes::copy_from_slice(&buf[FRAME_V2_HEADER_LEN..total]);
         Ok(Some((
             Self {
                 frame_type,
@@ -316,6 +322,79 @@ impl Frame {
             },
             total,
         )))
+    }
+
+    /// Try to decode one frame from the front of `buf` and advance the
+    /// buffer. Returns `Ok(Some(frame))` on success, `Ok(None)` if more
+    /// bytes are required, or `Err(_)` on malformed bytes.
+    ///
+    /// This is the preferred way to decode frames as it provides $O(1)$
+    /// consumption and zero-copy payload slicing.
+    pub fn try_decode_mut(buf: &mut BytesMut) -> Result<Option<Self>> {
+        if buf.is_empty() {
+            return Ok(None);
+        }
+
+        let (header_len, length) = if buf[0] == FRAME_V2_VERSION {
+            if buf.len() < FRAME_V2_HEADER_LEN {
+                return Ok(None);
+            }
+            let length = u32::from_be_bytes(buf[6..10].try_into().unwrap()) as usize;
+            (FRAME_V2_HEADER_LEN, length)
+        } else {
+            if buf.len() < FRAME_HEADER_LEN {
+                return Ok(None);
+            }
+            let length = u32::from_le_bytes(buf[1..5].try_into().unwrap()) as usize;
+            (FRAME_HEADER_LEN, length)
+        };
+
+        if length > MAX_PAYLOAD_LEN {
+            return Err(Error::OversizedFrame {
+                requested: length,
+                limit: MAX_PAYLOAD_LEN,
+            });
+        }
+
+        let total = header_len + length;
+        if buf.len() < total {
+            return Ok(None);
+        }
+
+        // We have a full frame. Re-run validation without slicing to
+        // avoid double-work, then advance.
+        if buf[0] == FRAME_V2_VERSION {
+            let type_byte = buf[1];
+            let request_id = u32::from_be_bytes(buf[2..6].try_into().unwrap());
+            let frame_type = FrameType::from_u8(type_byte)?;
+            if frame_type.payload_must_be_empty() && length != 0 {
+                return Err(Error::MalformedFrame(
+                    "frame type forbids payload but length is non-zero",
+                ));
+            }
+            buf.advance(FRAME_V2_HEADER_LEN);
+            let payload = buf.split_to(length).freeze();
+            Ok(Some(Self {
+                frame_type,
+                request_id,
+                payload,
+            }))
+        } else {
+            let type_byte = buf[0];
+            let frame_type = FrameType::from_u8(type_byte)?;
+            if frame_type.payload_must_be_empty() && length != 0 {
+                return Err(Error::MalformedFrame(
+                    "frame type forbids payload but length is non-zero",
+                ));
+            }
+            buf.advance(FRAME_HEADER_LEN);
+            let payload = buf.split_to(length).freeze();
+            Ok(Some(Self {
+                frame_type,
+                request_id: REQUEST_ID_SESSION,
+                payload,
+            }))
+        }
     }
 }
 
@@ -358,7 +437,7 @@ mod tests {
         let bytes = frame.encode_to_vec();
         let (decoded, _) = Frame::try_decode(&bytes).unwrap().unwrap();
         assert_eq!(decoded.request_id, id);
-        assert_eq!(decoded.payload, b"hello");
+        assert_eq!(decoded.payload, b"hello"[..]);
     }
 
     #[test]
@@ -373,7 +452,7 @@ mod tests {
         let (decoded, consumed) = Frame::try_decode(&v1).unwrap().unwrap();
         assert_eq!(decoded.frame_type, FrameType::RequestBody);
         assert_eq!(decoded.request_id, REQUEST_ID_SESSION);
-        assert_eq!(decoded.payload, payload);
+        assert_eq!(decoded.payload, payload[..]);
         assert_eq!(consumed, v1.len());
     }
 
@@ -502,6 +581,43 @@ mod tests {
         let (d2, n2) = Frame::try_decode(&buf[n1..]).unwrap().unwrap();
         assert_eq!(d2, f2);
         assert_eq!(n1 + n2, buf.len());
+    }
+
+    #[test]
+    fn try_decode_mut_roundtrips() {
+        let f1 = Frame::new_with_id(FrameType::ResponseBody, 42, b"hello".to_vec()).unwrap();
+        let f2 = Frame::new(FrameType::ResponseEnd, vec![]).unwrap();
+        let mut buf = BytesMut::new();
+        let mut wire = Vec::new();
+        f1.encode(&mut wire);
+        f2.encode(&mut wire);
+        buf.extend_from_slice(&wire);
+
+        let d1 = Frame::try_decode_mut(&mut buf).unwrap().unwrap();
+        assert_eq!(d1, f1);
+        assert_eq!(d1.payload, b"hello"[..]);
+
+        let d2 = Frame::try_decode_mut(&mut buf).unwrap().unwrap();
+        assert_eq!(d2, f2);
+        assert!(d2.payload.is_empty());
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn try_decode_mut_legacy_v1() {
+        let payload = b"legacy-body".to_vec();
+        let mut v1 = Vec::new();
+        v1.push(FrameType::RequestBody.as_u8());
+        v1.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        v1.extend_from_slice(&payload);
+
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&v1);
+
+        let decoded = Frame::try_decode_mut(&mut buf).unwrap().unwrap();
+        assert_eq!(decoded.frame_type, FrameType::RequestBody);
+        assert_eq!(decoded.payload, payload[..]);
+        assert!(buf.is_empty());
     }
 
     #[test]

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -700,7 +700,7 @@ fn wire_data_channel_handler(
 /// appended to on `RequestBody`, consumed on `RequestEnd`.
 #[derive(Default)]
 struct RequestInProgress {
-    head_payload: Option<Vec<u8>>,
+    head_payload: Option<Bytes>,
     body: BytesMut,
 }
 
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // BOLT OPTIMIZATION: use BytesMut for O(1) consumption via advance()
+    let buffer: Arc<Mutex<BytesMut>> =
+        Arc::new(Mutex::new(BytesMut::with_capacity(SCTP_SAFE_CHUNK_BYTES)));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -839,9 +841,9 @@ async fn wire_frame_loop(
             let mut buf = buffer.lock().await;
             buf.extend_from_slice(&msg.data);
             loop {
-                match Frame::try_decode(&buf) {
-                    Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                // BOLT OPTIMIZATION: use try_decode_mut for O(1) consumption and zero-copy payload
+                match Frame::try_decode_mut(&mut buf) {
+                    Ok(Some(frame)) => {
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,
@@ -1042,7 +1044,7 @@ async fn dispatch_frame(
             let tx_opt = ws_tunnel.lock().await.clone();
             match tx_opt {
                 Some(tx) => {
-                    if tx.send(Bytes::from(frame.payload.clone())).is_err() {
+                    if tx.send(frame.payload.clone()).is_err() {
                         // Upstream tunnel task dropped the receiver →
                         // the upgraded TCP socket closed. Tear the DC
                         // down so the client notices.
@@ -1068,7 +1070,7 @@ async fn dispatch_frame(
             FrameOutcome::Teardown
         }
         FrameType::Ping => {
-            let pong = Frame::new(FrameType::Pong, Vec::new()).expect("Pong is empty");
+            let pong = Frame::new(FrameType::Pong, Bytes::new()).expect("Pong is empty");
             let mut out = Vec::with_capacity(5);
             pong.encode(&mut out);
             if let Err(err) = dc.send(&Bytes::from(out)).await {
@@ -1201,7 +1203,7 @@ async fn handle_auth_client(
 
     if let Err(err) = send_frame(
         dc,
-        Frame::new(FrameType::AuthHost, host_sig.to_vec())
+        Frame::new(FrameType::AuthHost, Bytes::from(host_sig.to_vec()))
             .expect("64-byte host signature fits the frame cap"),
     )
     .await
@@ -1517,7 +1519,7 @@ mod tests {
 
         let (decoded_head, consumed_head) = Frame::try_decode(&wire).unwrap().unwrap();
         assert_eq!(decoded_head.frame_type, FrameType::ResponseHead);
-        assert_eq!(decoded_head.payload, RESPONSE_502_HEAD);
+        assert_eq!(decoded_head.payload, RESPONSE_502_HEAD[..]);
 
         let (decoded_end, consumed_end) =
             Frame::try_decode(&wire[consumed_head..]).unwrap().unwrap();

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -486,7 +486,7 @@ pub fn decode_frame(buf: &[u8]) -> Result<Option<DecodedFrame>> {
         Ok(None) => Ok(None),
         Ok(Some((frame, consumed))) => Ok(Some(DecodedFrame {
             frame_type: frame.frame_type.as_u8(),
-            payload: frame.payload,
+            payload: frame.payload.to_vec(),
             consumed,
         })),
         Err(e) => Err(Error::Frame(e.to_string())),


### PR DESCRIPTION
⚡ Bolt: use BytesMut for O(1) frame consumption

💡 What:
- Added \`bytes\` dependency to \`openhost-core\`.
- Refactored \`Frame\` to use \`Bytes\` for the payload field instead of \`Vec<u8>\`.
- Implemented \`Frame::try_decode_mut(&mut BytesMut)\` for efficient, zero-copy decoding.
- Updated \`openhost-client\`'s \`SessionInboundReader\` and \`openhost-daemon\`'s \`wire_frame_loop\` to use \`BytesMut\` buffers.

🎯 Why:
The previous implementation used \`Vec<u8>\` with \`drain(..n)\` for inbound frame buffering, which is an O(N) operation due to byte shifting. It also performed a full copy of each frame payload into a new \`Vec<u8>\`.

📊 Impact:
- Transitioned inbound buffer consumption from O(N) to O(1) using \`BytesMut::advance\`.
- Eliminated one full copy per frame payload by using zero-copy \`Bytes\` slicing.
- Reduced overall allocations and CPU usage in the data path.

🔬 Measurement:
Verified by running the full test suite (\`cargo test\`) across \`openhost-core\`, \`openhost-client\`, and \`openhost-daemon\`. New unit tests in \`openhost-core\` specifically verify the correctness of the \`BytesMut\`-based decoding logic.

---
*PR created automatically by Jules for task [17350743882615098630](https://jules.google.com/task/17350743882615098630) started by @vamzi*