### PR TITLE
🛡️ Sentinel: Enforce RequestHead size limits and strict RFC 7230 parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Strict RFC 7230 compliance in custom HTTP forwarders
+**Vulnerability:** Permissive HTTP header parsing and missing size limits on request heads in `openhost-daemon`.
+**Learning:** Even when HTTP is carried over a custom transport (like WebRTC data channels), the application-layer parser must strictly enforce RFC 7230 to prevent request smuggling and memory-exhaustion DoS. Custom hand-rolled parsers often miss edge cases like OBS-fold and OWS rules that mature libraries handle automatically.
+**Prevention:** Always enforce a hard cap on HTTP head frames before parsing. Reject OBS-fold and any whitespace between header names and colons. Strip both leading and trailing optional whitespace from values.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security limit.
+    #[error("request head exceeded {cap} byte cap")]
+    HeadTooLarge {
+        /// The limit in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Security limit for the inbound `REQUEST_HEAD` frame payload. 32KB is
+/// comfortably above the maximum practical HTTP/1.1 head and fits
+/// within a single SCTP data-channel chunk.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +188,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                cap: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,12 +390,31 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: Obsolete line folding (starting a line with
+        // whitespace) is forbidden in strict HTTP/1.1 parsers to
+        // mitigate request smuggling.
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is forbidden",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+
+        // RFC 7230 §3.2.4: No whitespace allowed between the header name
+        // and its colon.
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
+
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` before and after the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = MAX_HEAD_BYTES,
+                    got = frame.payload.len(),
+                    "openhostd: request head exceeded security cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,58 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send an oversized REQUEST_HEAD frame. MAX_HEAD_BYTES is 32KB.
+    let big_head = vec![0x41u8; 33 * 1024];
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let mut session = establish_connection(&app).await;
+
+    // "Host : x" is invalid per RFC 7230 §3.2.4.
+    let head = b"GET / HTTP/1.1\r\nHost : x\r\n\r\n";
+    let (resp_head, _body) = round_trip(&mut session, head, b"").await;
+    let head_text = std::str::from_utf8(&resp_head.payload).unwrap();
+
+    // Malformed inbound head should produce 502 (internal error/forwarder failure).
+    assert!(head_text.starts_with("HTTP/1.1 502 "));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Enforce RequestHead size limits and strict RFC 7230 parsing

### 🚨 Severity
HIGH

### 💡 Vulnerability
The `openhost-daemon` HTTP forwarder lacked a size limit on the `REQUEST_HEAD` frame payload before parsing, and the hand-rolled HTTP parser was permissive regarding header whitespace and obsolete line folding.

### 🎯 Impact
- **DoS:** A malicious client could send extremely large head frames (up to 16MB) to exhaust daemon memory.
- **Request Smuggling:** Permissive parsing (allowing whitespace before colons or OBS-fold) could be exploited to smuggle headers past the daemon to the upstream service.

### 🔧 Fix
1. Introduced a `MAX_HEAD_BYTES` (32KB) constant and enforced it in the listener's frame dispatcher.
2. Updated `parse_request_head` to:
   - Reject obsolete line folding (OBS-fold).
   - Reject whitespace between header name and colon.
   - Use `trim_matches([' ', '\t'])` to strip both leading and trailing OWS from header values per RFC 7230.
3. Added a `HeadTooLarge` error variant.

### ✅ Verification
- Added integration tests in `crates/openhost-daemon/tests/forward.rs`:
  - `forwarder_request_head_exceeds_cap_rejects_and_tears_down`
  - `forwarder_rejects_whitespace_between_header_name_and_colon`
- Verified all tests pass with `cargo test -p openhost-daemon`.
- Verified strict compliance with `fmt` and `clippy`.

---
*PR created automatically by Jules for task [10123266493611872263](https://jules.google.com/task/10123266493611872263) started by @vamzi*