### PR TITLE
⚡ Bolt: use BytesMut for zero-copy frame decoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [O(N) to O(1) buffer consumption with BytesMut]
+**Learning:** Using `Vec::drain(..n)` for inbound network buffers is a hidden performance killer in high-throughput data channels. In Rust, `Vec::drain` is $O(N)$ because it shifts all remaining elements.
+**Action:** Always prefer `bytes::BytesMut` for inbound buffers. Use `advance(n)` for $O(1)$ consumption and `split_to(n).freeze()` for zero-copy payload extraction.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,6 +2151,7 @@ name = "openhost-core"
 version = "0.2.0"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "chacha20poly1305",
  "crypto_box",
  "curve25519-dalek 4.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ hyper = { version = "1", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["client-legacy", "http1", "tokio"] }
 http = "1"
 http-body-util = "0.1"
+bytes = "1"
 
 [profile.release]
 lto = "thin"

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,7 +31,7 @@ use webrtc::peer_connection::RTCPeerConnection;
 pub struct ClientResponse {
     /// UTF-8 HTTP/1.1 response head, CRLF-separated, terminated by a
     /// blank line.
-    pub head_bytes: Vec<u8>,
+    pub head_bytes: Bytes,
     /// Body bytes (may be empty).
     pub body: Bytes,
 }
@@ -81,7 +81,7 @@ impl OpenhostSession {
             .map_err(|e| ClientError::HttpRoundTrip(format!("send: {e}")))?;
 
         // Read until RESPONSE_END.
-        let mut head_bytes_out: Option<Vec<u8>> = None;
+        let mut head_bytes_out: Option<Bytes> = None;
         let mut body_out: Vec<u8> = Vec::new();
         let deadline = std::time::Instant::now() + Duration::from_secs(30);
         loop {
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -197,9 +197,11 @@ impl SessionInboundReader {
             // Try to decode whatever's currently buffered.
             {
                 let mut buf = self.buffer.lock().await;
-                match Frame::try_decode(&buf) {
-                    Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+
+                // BOLT OPTIMIZATION: Use try_decode_mut for O(1) buffer consumption
+                // and zero-copy payload extraction.
+                match Frame::try_decode_mut(&mut buf) {
+                    Ok(Some(frame)) => {
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-core/Cargo.toml
+++ b/crates/openhost-core/Cargo.toml
@@ -25,6 +25,7 @@ subtle = { workspace = true }
 zbase32 = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
+bytes = { workspace = true }
 rand = { workspace = true }
 rand_core = { workspace = true }
 serde = { workspace = true }

--- a/crates/openhost-core/src/wire/mod.rs
+++ b/crates/openhost-core/src/wire/mod.rs
@@ -25,10 +25,11 @@
 //! returns `Ok(None)` when more bytes are needed and `Ok(Some((frame, consumed)))`
 //! when a complete frame is available.
 //!
-//! Payloads are plain `Vec<u8>`; higher-level code interprets them according to
+//! Payloads are `bytes::Bytes`; higher-level code interprets them according to
 //! [`FrameType`] (e.g. HTTP header text for [`FrameType::RequestHead`]).
 
 use crate::{Error, Result};
+use bytes::{Buf, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 
 /// Wire header length of the legacy v1 frame: `type(1) || length(4)`.
@@ -147,21 +148,26 @@ pub struct Frame {
     /// (AuthNonce/AuthClient/AuthHost, Ping/Pong) and for legacy v1
     /// frames (synthesised during decode).
     pub request_id: u32,
-    /// Frame payload bytes (length is implicit from the `Vec`).
-    pub payload: Vec<u8>,
+    /// Frame payload bytes (length is implicit from the `Bytes`).
+    pub payload: Bytes,
 }
 
 impl Frame {
     /// Create a new session-scoped frame (request_id = 0). Preserved for
     /// call sites that never care about demultiplexing — auth frames,
     /// pings, legacy tests. Validates per-type payload constraints.
-    pub fn new(frame_type: FrameType, payload: Vec<u8>) -> Result<Self> {
+    pub fn new(frame_type: FrameType, payload: impl Into<Bytes>) -> Result<Self> {
         Self::new_with_id(frame_type, REQUEST_ID_SESSION, payload)
     }
 
     /// Create a new frame with an explicit request_id. HTTP-transaction
     /// frames produced by the SW proxy / client session use this.
-    pub fn new_with_id(frame_type: FrameType, request_id: u32, payload: Vec<u8>) -> Result<Self> {
+    pub fn new_with_id(
+        frame_type: FrameType,
+        request_id: u32,
+        payload: impl Into<Bytes>,
+    ) -> Result<Self> {
+        let payload = payload.into();
         if payload.len() > MAX_PAYLOAD_LEN {
             return Err(Error::OversizedFrame {
                 requested: payload.len(),
@@ -237,6 +243,83 @@ impl Frame {
         }
     }
 
+    /// Try to decode one frame from a [`BytesMut`] buffer.
+    ///
+    /// BOLT OPTIMIZATION: zero-copy payload extraction via `split_to`
+    /// and O(1) buffer consumption via `advance`. Replaces the O(N)
+    /// `Vec::drain` pattern and avoids intermediate `Vec<u8>` clones.
+    pub fn try_decode_mut(buf: &mut BytesMut) -> Result<Option<Self>> {
+        if buf.is_empty() {
+            return Ok(None);
+        }
+
+        let (_version, frame_type, request_id, length, header_len) = if buf[0] == FRAME_V2_VERSION {
+            if buf.len() < FRAME_V2_HEADER_LEN {
+                return Ok(None);
+            }
+            let type_byte = buf[1];
+            let id_bytes: [u8; 4] = buf[2..6].try_into().expect("2..6 slice");
+            let len_bytes: [u8; 4] = buf[6..10].try_into().expect("6..10 slice");
+
+            let request_id = u32::from_be_bytes(id_bytes);
+            let length = u32::from_be_bytes(len_bytes) as usize;
+            let frame_type = FrameType::from_u8(type_byte)?;
+
+            (
+                FRAME_V2_VERSION,
+                frame_type,
+                request_id,
+                length,
+                FRAME_V2_HEADER_LEN,
+            )
+        } else {
+            if buf.len() < FRAME_HEADER_LEN {
+                return Ok(None);
+            }
+            let type_byte = buf[0];
+            let len_bytes: [u8; 4] = buf[1..5].try_into().expect("1..5 slice");
+
+            let length = u32::from_le_bytes(len_bytes) as usize;
+            let frame_type = FrameType::from_u8(type_byte)?;
+
+            (
+                type_byte,
+                frame_type,
+                REQUEST_ID_SESSION,
+                length,
+                FRAME_HEADER_LEN,
+            )
+        };
+
+        if length > MAX_PAYLOAD_LEN {
+            return Err(Error::OversizedFrame {
+                requested: length,
+                limit: MAX_PAYLOAD_LEN,
+            });
+        }
+
+        if frame_type.payload_must_be_empty() && length != 0 {
+            return Err(Error::MalformedFrame(
+                "frame type forbids payload but length is non-zero",
+            ));
+        }
+
+        if buf.len() < header_len + length {
+            return Ok(None);
+        }
+
+        // Consume header.
+        buf.advance(header_len);
+        // Extract payload zero-copy.
+        let payload = buf.split_to(length).freeze();
+
+        Ok(Some(Self {
+            frame_type,
+            request_id,
+            payload,
+        }))
+    }
+
     fn try_decode_v1(buf: &[u8]) -> Result<Option<(Self, usize)>> {
         if buf.len() < FRAME_HEADER_LEN {
             return Ok(None);
@@ -265,7 +348,7 @@ impl Frame {
             return Ok(None);
         }
 
-        let payload = buf[FRAME_HEADER_LEN..total].to_vec();
+        let payload = Bytes::copy_from_slice(&buf[FRAME_HEADER_LEN..total]);
         Ok(Some((
             Self {
                 frame_type,
@@ -307,7 +390,7 @@ impl Frame {
             return Ok(None);
         }
 
-        let payload = buf[FRAME_V2_HEADER_LEN..total].to_vec();
+        let payload = Bytes::copy_from_slice(&buf[FRAME_V2_HEADER_LEN..total]);
         Ok(Some((
             Self {
                 frame_type,
@@ -358,7 +441,7 @@ mod tests {
         let bytes = frame.encode_to_vec();
         let (decoded, _) = Frame::try_decode(&bytes).unwrap().unwrap();
         assert_eq!(decoded.request_id, id);
-        assert_eq!(decoded.payload, b"hello");
+        assert_eq!(decoded.payload, &b"hello"[..]);
     }
 
     #[test]
@@ -373,7 +456,7 @@ mod tests {
         let (decoded, consumed) = Frame::try_decode(&v1).unwrap().unwrap();
         assert_eq!(decoded.frame_type, FrameType::RequestBody);
         assert_eq!(decoded.request_id, REQUEST_ID_SESSION);
-        assert_eq!(decoded.payload, payload);
+        assert_eq!(decoded.payload, &payload[..]);
         assert_eq!(consumed, v1.len());
     }
 

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -700,7 +700,7 @@ fn wire_data_channel_handler(
 /// appended to on `RequestBody`, consumed on `RequestEnd`.
 #[derive(Default)]
 struct RequestInProgress {
-    head_payload: Option<Vec<u8>>,
+    head_payload: Option<Bytes>,
     body: BytesMut,
 }
 
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -839,9 +839,10 @@ async fn wire_frame_loop(
             let mut buf = buffer.lock().await;
             buf.extend_from_slice(&msg.data);
             loop {
-                match Frame::try_decode(&buf) {
-                    Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                // BOLT OPTIMIZATION: Use try_decode_mut for O(1) buffer consumption
+                // and zero-copy payload extraction.
+                match Frame::try_decode_mut(&mut buf) {
+                    Ok(Some(frame)) => {
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,
@@ -1042,7 +1043,7 @@ async fn dispatch_frame(
             let tx_opt = ws_tunnel.lock().await.clone();
             match tx_opt {
                 Some(tx) => {
-                    if tx.send(Bytes::from(frame.payload.clone())).is_err() {
+                    if tx.send(frame.payload.clone()).is_err() {
                         // Upstream tunnel task dropped the receiver →
                         // the upgraded TCP socket closed. Tear the DC
                         // down so the client notices.

--- a/crates/openhost-pkarr-wasm/src/core.rs
+++ b/crates/openhost-pkarr-wasm/src/core.rs
@@ -486,7 +486,7 @@ pub fn decode_frame(buf: &[u8]) -> Result<Option<DecodedFrame>> {
         Ok(None) => Ok(None),
         Ok(Some((frame, consumed))) => Ok(Some(DecodedFrame {
             frame_type: frame.frame_type.as_u8(),
-            payload: frame.payload,
+            payload: frame.payload.to_vec(),
             consumed,
         })),
         Err(e) => Err(Error::Frame(e.to_string())),


### PR DESCRIPTION
Optimized inbound frame decoding by replacing $O(N)$ `Vec::drain` with $O(1)$ `bytes::BytesMut` consumption and implementing zero-copy payload extraction.

---
*PR created automatically by Jules for task [10481315879910370763](https://jules.google.com/task/10481315879910370763) started by @vamzi*