### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling risks in header parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-09-19 - Strict HTTP Header Parsing
+**Vulnerability:** HTTP Request Smuggling / Response Splitting via permissive header parsing (accepting obs-fold and whitespace before colons).
+**Learning:** Hand-rolled HTTP parsers often miss RFC 7230 edge cases like `obs-fold` (obsolete line folding) and "whitespace before colon" which are common vectors for request smuggling.
+**Prevention:** Always follow RFC 7230 §3.2.4 strictly: reject any header line starting with whitespace and ensure no whitespace exists between the field name and the colon.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,10 +380,27 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: "A server that receives obs-fold... MUST...
+        // reject the message by returning 400 (Bad Request)".
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (obs-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is not allowed",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +799,32 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace before colon")),
+            "Expected 'whitespace before colon' error, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A sender MUST NOT generate obs-fold...
+        // A server that receives obs-fold... MUST... reject the message"
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Folding: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("obsolete line folding")),
+            "Expected 'obsolete line folding' error, got: {:?}",
+            err
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Permissive HTTP header parsing in `parse_request_head` allowed obsolete line folding (obs-fold) and whitespace between header names and colons.
🎯 Impact: These patterns can be exploited for HTTP request smuggling or response splitting attacks if the daemon is used in front of a more permissive upstream or if multiple requests are multiplexed incorrectly.
🔧 Fix: Updated the hand-rolled parser to strictly validate these RFC 7230 constraints and return a `HeadParse` error if violated.
✅ Verification: Added new unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_rejects_obs_fold` which now pass. Verified all existing tests still pass.

---
*PR created automatically by Jules for task [17822678807820188206](https://jules.google.com/task/17822678807820188206) started by @vamzi*