### PR TITLE
🛡️ Sentinel: [security improvement] Strict HTTP parsing and head size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-31 - [Strict HTTP Parsing and Head Size Limits]
+**Vulnerability:** Hand-rolled HTTP parser was lenient with header name whitespace (e.g., "Host :") and obsolete line folding, which can lead to HTTP request smuggling. Additionally, there was no size limit on the `RequestHead` frame, leading to potential memory exhaustion DoS.
+**Learning:** Hand-rolled parsers often miss RFC edge cases that established libraries handle. Security limits must be enforced as early as possible in the pipeline (at the listener level) to prevent resource exhaustion before parsing.
+**Prevention:** Always use strict parsing rules for protocol-sensitive text. Enforce explicit size limits on all inbound buffers and frames.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security cap (MAX_HEAD_BYTES).
+    #[error("request head exceeded {cap} byte security cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -34,6 +34,12 @@ use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
 use std::time::Duration;
 
+/// Maximum permitted size of an HTTP request head (request line +
+/// headers) in bytes. 32KB is comfortably above the 8-16KB defaults of
+/// most servers while still bounding memory exhaustion and fitting
+/// within a few SCTP chunks.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Default connect timeout when reaching the upstream. Localhost should
 /// complete in microseconds; 2 seconds is comfortably above the worst
 /// case and still bounds a misconfigured target from wedging a request.
@@ -183,6 +189,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                cap: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,12 +391,22 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is not allowed",
+            ));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +803,39 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let result = parse_request_head(raw);
+        assert!(
+            result.is_err(),
+            "should reject whitespace before colon, but got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A sender MUST NOT generate obsolete
+        // line folding ... a recipient SHOULD reject it."
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n X-Fold: yes\r\n\r\n";
+        let result = parse_request_head(raw);
+        assert!(
+            result.is_err(),
+            "should reject obsolete line folding, but got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_ows() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com  \t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded security cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -1027,8 +1037,29 @@ async fn dispatch_frame(
                         }
                     }
                     Err(err) => {
-                        tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
-                        let _ = emit_stub_502(dc).await;
+                        use crate::error::ForwardError;
+                        match err {
+                            ForwardError::HeadParse(reason) => {
+                                tracing::warn!(
+                                    reason,
+                                    "openhostd: request head parse failed; tearing down"
+                                );
+                                let _ = send_error_frame(dc, reason).await;
+                                return FrameOutcome::Teardown;
+                            }
+                            ForwardError::HeadTooLarge { cap } => {
+                                tracing::warn!(
+                                    cap,
+                                    "openhostd: request head too large; tearing down"
+                                );
+                                let _ = send_error_frame(dc, "request head too large").await;
+                                return FrameOutcome::Teardown;
+                            }
+                            _ => {
+                                tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
+                                let _ = emit_stub_502(dc).await;
+                            }
+                        }
                     }
                 },
                 None => {

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,76 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // "Host : ..." should be rejected.
+    let head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1\r\n\r\n";
+    let req_head = Frame::new(FrameType::RequestHead, head.to_vec()).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after malformed header name");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    // 32KB is the planned MAX_HEAD_BYTES. Send 33KB of headers.
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    let mut head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        head.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+    }
+    head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    assert!(String::from_utf8_lossy(&err_frame.payload).contains("head"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability:
1. The hand-rolled HTTP parser was lenient with header name whitespace (RFC 7230 §3.2.4 violation) and supported obsolete line folding (OBS-fold). This can lead to HTTP request smuggling.
2. There was no size limit on the \`RequestHead\` frame, allowing an attacker to exhaust daemon memory by sending extremely large header blocks.

🎯 Impact:
1. Request smuggling could bypass security controls or poison caches.
2. Memory exhaustion leads to Denial of Service (DoS) for the daemon.

🔧 Fix:
1. Updated \`parse_request_head\` in \`forward.rs\` to strictly reject whitespace between header names and colons.
2. Updated \`parse_request_head\` to reject OBS-fold lines (lines starting with space or tab).
3. Updated header value trimming to correctly include trailing Optional WhiteSpace (OWS).
4. Defined \`MAX_HEAD_BYTES = 32KB\` and enforced it in \`listener.rs\` (at the frame dispatch level) and \`forward.rs\` (as defense-in-depth).
5. Updated error handling to ensure these violations trigger an \`ERROR\` frame and connection teardown.

✅ Verification:
1. Added unit tests in \`crates/openhost-daemon/src/forward.rs\` for strict whitespace, OBS-fold rejection, and trailing OWS trimming.
2. Added integration tests in \`crates/openhost-daemon/tests/forward.rs\` for \`MAX_HEAD_BYTES\` enforcement and malformed header rejection.
3. Verified that all 100+ tests in \`openhost-daemon\` pass.
4. Performed \`cargo fmt\` and \`cargo clippy\` checks.

---
*PR created automatically by Jules for task [3292146497197037236](https://jules.google.com/task/3292146497197037236) started by @vamzi*