### PR TITLE
⚡ Bolt: optimize answer fragment reassembly and TXT encoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-31 - [Optimized DNS Fragment Reassembly]
+**Learning:** Reassembling DNS fragments by repeated probes with `packet.resource_records(name)` is O(N*M). A single pass over `all_resource_records()` with a `BTreeMap` is much more efficient for fragmented records.
+**Action:** Always prefer a single pass over packet records when reassembling multiple related labels.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1027,22 +1027,12 @@ fn build_multi_string_txt(value: &str) -> Result<TXT<'static>> {
         value.is_ascii(),
         "build_multi_string_txt expects ASCII; multi-byte UTF-8 would be split mid-code-point"
     );
-    // `simple_dns::TXT::with_string` borrows the input string for the
-    // lifetime of the returned TXT. To hand back a `TXT<'static>` we
-    // collect every chunk into an owned `Vec<String>` that outlives
-    // the loop's borrows, then call `into_owned()` at the end to
-    // internalise those borrows.
-    let chunks: Vec<String> = value
-        .as_bytes()
-        .chunks(DNS_CHARACTER_STRING_MAX)
-        .map(|c| {
-            core::str::from_utf8(c)
-                .expect("caller guaranteed ASCII")
-                .to_string()
-        })
-        .collect();
+    // BOLT OPTIMIZATION: Build the TXT record directly from byte chunks of the
+    // input string. This avoids the intermediate `Vec<String>` and multiple
+    // `to_string()` allocations for each 255-byte segment.
     let mut txt = TXT::new();
-    for s in &chunks {
+    for chunk in value.as_bytes().chunks(DNS_CHARACTER_STRING_MAX) {
+        let s = core::str::from_utf8(chunk).expect("caller guaranteed ASCII");
         txt = txt
             .with_string(s)
             .map_err(|e| PkarrError::TxtBuildFailed(e.to_string()))?;
@@ -1098,22 +1088,58 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // BOLT OPTIMIZATION: replace the per-fragment `collect_single_txt` probes
+    // with a single pass over `packet.all_resource_records()` (O(M + N log N)
+    // where M is total RRs and N is matching fragments). This avoids N*M
+    // repeated probes.
+    let mut fragments_found = std::collections::BTreeMap::new();
+
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            // BOLT OPTIMIZATION: Perform a zero-allocation fast-path prefix check
+            // on the first DNS label bytes before full string normalization.
+            if let Some(label) = rr.name.iter().next() {
+                let label_bytes = label.as_ref();
+                if label_bytes.starts_with(base.as_bytes()) {
+                    let label_str =
+                        core::str::from_utf8(label_bytes).map_err(|_| PkarrError::InvalidUtf8)?;
+                    if label_str.len() > base.len() && label_str.as_bytes()[base.len()] == b'-' {
+                        if let Ok(idx) = label_str[base.len() + 1..].parse::<u8>() {
+                            if fragments_found.contains_key(&idx) {
+                                return Err(PkarrError::MultipleOpenhostRecords);
+                            }
+                            // Reassemble TXT character-strings.
+                            let mut text = String::new();
+                            for (key, value) in txt.iter_raw() {
+                                text.push_str(
+                                    core::str::from_utf8(key)
+                                        .map_err(|_| PkarrError::InvalidUtf8)?,
+                                );
+                                if let Some(v) = value {
+                                    text.push('=');
+                                    text.push_str(
+                                        core::str::from_utf8(v)
+                                            .map_err(|_| PkarrError::InvalidUtf8)?,
+                                    );
+                                }
+                            }
+                            fragments_found.insert(idx, text);
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    let Some(first_text) = fragments_found.get(&0) else {
         return Ok(None);
     };
     let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
     let first = decode_fragment(&first_bytes)?;
     if first.idx != 0 {
+        // Defensive: BTreeMap lookup for key 0 guaranteed this, but keep
+        // the check for consistency with decode_fragment's contract.
         return Err(PkarrError::MalformedCanonical(
             "answer fragment 0 carries non-zero idx",
         ));
@@ -1123,10 +1149,11 @@ pub fn decode_answer_fragments_from_packet(
     let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
     fragments.push(first);
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
+        let text = fragments_found
+            .get(&i)
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is incomplete (missing fragments)",
+            ))?;
         let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
         let frag = decode_fragment(&bytes)?;
         if frag.total != total {


### PR DESCRIPTION
This PR implements two performance optimizations in the `openhost-pkarr` crate:

1.  **Efficient Answer Fragment Reassembly**: The `decode_answer_fragments_from_packet` function now performs a single pass over all resource records in a packet, using a `BTreeMap` to bucket-sort fragments by their index. This replaces the previous approach of repeated probes, which was O(N*M) where N is the number of fragments and M is the total number of records.
2.  **Zero-Allocation TXT Encoding**: The `build_multi_string_txt` function has been refactored to build the `TXT` record directly from string slices of the input, avoiding the creation of an intermediate `Vec<String>` and multiple `String` allocations for each 255-byte DNS character-string segment.

These changes make the signalling loop more efficient and reduce memory pressure during packet encoding and decoding.

---
*PR created automatically by Jules for task [14994521817586332617](https://jules.google.com/task/14994521817586332617) started by @vamzi*