### PR TITLE
🛡️ Sentinel: Strict RFC 7230 header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-05-22 - Strict HTTP/1.1 Header Parsing (RFC 7230)
+**Vulnerability:** HTTP Request Smuggling/Splitting risk due to loose header parsing (accepting whitespace before colons and obsolete line folding).
+**Learning:** Hand-rolled HTTP parsers in `openhost-daemon` were vulnerable to classic smuggling patterns by being too permissive with Optional White Space (OWS) and OBS-fold.
+**Prevention:** Strictly enforce RFC 7230 §3.2.4: reject whitespace between header name and colon, reject lines starting with whitespace (OBS-fold), and trim both leading and trailing OWS from values.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,12 +380,20 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("obsolete line folding (OBS-fold) is not supported"));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("invalid header name: whitespace before colon"));
+        }
+
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +790,35 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("invalid header name")),
+            "Whitespace before colon MUST be rejected; got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n Foo: bar\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("obsolete line folding")),
+            "Obsolete line folding MUST be rejected; got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -381,7 +381,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
     let mut headers = HeaderMap::new();
     for line in lines {
         if line.starts_with([' ', '\t']) {
-            return Err(ForwardError::HeadParse("obsolete line folding (OBS-fold) is not supported"));
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
         }
         let colon = line
             .find(':')
@@ -389,7 +391,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
         let name = &line[..colon];
         if name.ends_with([' ', '\t']) {
-            return Err(ForwardError::HeadParse("invalid header name: whitespace before colon"));
+            return Err(ForwardError::HeadParse(
+                "invalid header name: whitespace before colon",
+            ));
         }
 
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement]

💡 **Vulnerability:** The `openhost-daemon` utilized a hand-rolled HTTP/1.1 header parser that was overly permissive. It accepted whitespace between header names and colons, and didn't explicitly reject obsolete line folding (OBS-fold), both of which are common vectors for HTTP Request Smuggling and Splitting attacks when parsed inconsistently by upstreams.

🎯 **Impact:** An attacker could potentially smuggle requests or inject headers that would be interpreted differently by the `openhost-daemon` and the configured upstream service, potentially leading to unauthorized access or cache poisoning.

🔧 **Fix:** Strictly enforced RFC 7230 §3.2.4 in `parse_request_head`:
- Added a check to reject lines starting with whitespace (OBS-fold).
- Added a check to reject whitespace between the header name and its colon.
- Updated the value parser to use `trim_matches([' ', '\t'])` to strip both leading and trailing optional whitespace.

✅ **Verification:**
- Added new unit tests in `crates/openhost-daemon/src/forward.rs` covering:
  - `parse_request_head_rejects_whitespace_before_colon`
  - `parse_request_head_rejects_obs_fold`
  - `parse_request_head_trims_trailing_whitespace`
- All 100 unit tests in `openhost-daemon` pass.
- Full workspace tests pass.

---
*PR created automatically by Jules for task [17499078996471765149](https://jules.google.com/task/17499078996471765149) started by @vamzi*