### PR TITLE
🛡️ Sentinel: [security improvement] Strict HTTP header parsing and head size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-05 - Strict HTTP Parsing and Head Size Limits
+**Vulnerability:** Hand-rolled HTTP parser allowed whitespace between header names and colons (RFC 7230 §3.2.4 violation), accepted OBS-fold, and lacked head size limits, risking request smuggling and memory exhaustion (DoS).
+**Learning:** Hand-rolled parsers often miss subtle RFC requirements that have significant security implications. Defense-in-depth is necessary even when using robust libraries like Hyper, as the initial framing layer (data channel listener) might still be vulnerable.
+**Prevention:** Always enforce strict RFC compliance in parsers, implement explicit resource limits at the earliest possible entry point, and add regression tests for known smuggling vectors.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,14 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head (headers) exceeded the `MAX_HEAD_BYTES`
+    /// security limit.
+    #[error("request head exceeded {cap} byte cap")]
+    HeadTooLarge {
+        /// The limit in bytes.
+        cap: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted length (bytes) of a framed `REQUEST_HEAD` payload.
+/// 32KB is comfortably above every realistic HTTP/1.1 head we expect to
+/// proxy and protects the daemon's memory from unbounded growth.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +188,12 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                cap: MAX_HEAD_BYTES,
+            });
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,10 +391,24 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (OBS-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
+        let name = name.trim();
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -761,6 +786,57 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: x\r\n Folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("obsolete line folding (OBS-fold) is not supported")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : x\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace between header name and colon is forbidden")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        // Build a head that's just over 32KB.
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        assert!(raw.len() > MAX_HEAD_BYTES);
+
+        let fwd = Forwarder {
+            target: "http://127.0.0.1".parse().unwrap(),
+            host_override: "x".into(),
+            client: LegacyClient::builder(TokioExecutor::new())
+                .build::<_, Full<Bytes>>(HttpConnector::new()),
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+
+        let result = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(fwd.forward(&raw, Bytes::new()));
+        assert!(matches!(
+            result,
+            Err(ForwardError::HeadTooLarge {
+                cap: MAX_HEAD_BYTES
+            })
+        ));
     }
 
     #[test]

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -970,6 +970,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > crate::forward::MAX_HEAD_BYTES {
+                tracing::warn!(
+                    cap = crate::forward::MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,48 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    use openhost_daemon::forward::MAX_HEAD_BYTES;
+
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Build a head that's just over 32KB.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+    assert!(big_head.len() > MAX_HEAD_BYTES);
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Hand-rolled HTTP parser allowed whitespace between header names and colons (RFC 7230 §3.2.4), accepted OBS-fold, and lacked head size limits.
🎯 Impact: Request smuggling vulnerabilities and potential memory exhaustion (DoS).
🔧 Fix: Enforced strict RFC 7230 compliance in `parse_request_head` and implemented a 32KB `MAX_HEAD_BYTES` limit in both the listener and forwarder.
✅ Verification: Added unit tests in `forward.rs` for smuggling vectors and an integration test in `tests/forward.rs` for the head size limit.

---
*PR created automatically by Jules for task [16164635636939091065](https://jules.google.com/task/16164635636939091065) started by @vamzi*