### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS via oversized HTTP request head

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Request Head Size Limit
+**Vulnerability:** Denial of Service (DoS) via memory exhaustion. The daemon was accumulating and parsing HTTP request heads of unbounded size, allowing an attacker to exhaust RAM by sending extremely large headers.
+**Learning:** Even when using a framed protocol (like openhost's data channel frames), application-layer payloads (like HTTP headers) must be explicitly capped before they are fully buffered or parsed. Framed length prefixes (up to 16MB in this repo) are often much larger than what is safe for specific sub-protocols like HTTP/1.1 headers.
+**Prevention:** Enforce strict size limits at the earliest possible entry point (the frame dispatcher) and provide defense-in-depth by re-verifying limits in the parsing logic.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for the HTTP request head (request line +
+/// headers), including the trailing `\r\n\r\n`. 32KB is a standard
+/// safe limit for most proxies (e.g. Nginx defaults to 8KB-32KB).
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +188,12 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense in depth: the listener should have already capped the
+        // REQUEST_HEAD frame, but we verify here too before parsing.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadParse("request head exceeds 32KB limit"));
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -341,6 +352,10 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadParse("request head exceeds 32KB limit"));
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -782,6 +797,21 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        // Build a head that is larger than 32KB.
+        let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..2000 {
+            big_head.extend_from_slice(format!("X-Header-{}: value\r\n", i).as_bytes());
+        }
+        big_head.extend_from_slice(b"\r\n");
+
+        assert!(big_head.len() > MAX_HEAD_BYTES);
+
+        let err = parse_request_head(&big_head).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("limit")));
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    "openhostd: REQUEST_HEAD exceeds 32KB limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,45 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Build a head that is larger than 32KB.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait up to 5 s for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no error frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Denial of Service (DoS) via memory exhaustion. The daemon was accumulating and parsing HTTP request heads of unbounded size.
🎯 Impact: An attacker could exhaust the daemon's RAM by sending extremely large headers within a `REQUEST_HEAD` frame.
🔧 Fix: Implemented a strict 32KB limit (`MAX_HEAD_BYTES`) on the request head size. The limit is enforced early in the frame dispatcher and re-verified during parsing for defense-in-depth.
✅ Verification: Added unit tests in `forward.rs` and an integration test in `tests/forward.rs` that verify oversized heads trigger an error frame and connection teardown. Verified all workspace tests pass.

---
*PR created automatically by Jules for task [4162324361838905314](https://jules.google.com/task/4162324361838905314) started by @vamzi*