### PR TITLE
🛡️ Sentinel: strict HTTP header parsing and size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - Strict HTTP Header Parsing and Size Limits
+
+**Vulnerability:** HTTP header smuggling and Denial of Service (DoS). The daemon was trimming whitespace from header names, which could lead to parsing ambiguities (RFC 7230 §3.2.4). It also lacked a dedicated limit for the total size of the HTTP request head, potentially allowing memory exhaustion.
+
+**Learning:** Trimming header names (e.g., `Host : example`) instead of rejecting them strictly can cause "split-view" attacks if an upstream proxy handles the whitespace differently. Additionally, while individual data-channel frames are capped, the accumulated request head needs its own security boundary (set here to 32KB) to protect both the daemon and the upstream service.
+
+**Prevention:** Always use strict byte-level validation for protocol-critical fields like HTTP header names. Implement multi-layered size limits (early rejection in the listener + defense-in-depth in the forwarder) to protect against resource exhaustion.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound `REQUEST_HEAD` exceeded the security limit.
+    #[error("request head exceeded {limit} byte security limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Security limit for the `REQUEST_HEAD` frame payload. 32KB is enough
+/// for ~1000 headers and protects the daemon's RAM and the upstream
+/// from oversized-header attacks.
+pub(crate) const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -70,6 +75,7 @@ type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
 
 /// One buffered HTTP response, ready for the listener to re-frame onto
 /// the data channel.
+#[derive(Debug)]
 pub struct ForwardResponse {
     /// HTTP/1.1 response head — status line + sanitised headers,
     /// terminated by `\r\n\r\n`.
@@ -90,9 +96,19 @@ pub struct WebSocketUpgrade {
     pub upstream: Upgraded,
 }
 
+impl std::fmt::Debug for WebSocketUpgrade {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WebSocketUpgrade")
+            .field("head_bytes", &self.head_bytes)
+            .field("upstream", &"<Upgraded>")
+            .finish()
+    }
+}
+
 /// What a successful `Forwarder::forward` produced: either a plain
 /// HTTP response the listener frames + re-emits, or a WebSocket
 /// upgrade the listener tunnels byte-for-byte.
+#[derive(Debug)]
 pub enum ForwardOutcome {
     /// Plain HTTP round-trip.
     Response(ForwardResponse),
@@ -183,6 +199,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,7 +404,16 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        // RFC 7230 §3.2.4: No whitespace allowed between header name and ':'.
+        // Hand-rolled check to prevent header-smuggling / parsing ambiguity.
+        let name = &line[..colon];
+        if name.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+            return Err(ForwardError::HeadParse(
+                "whitespace is not allowed between header name and ':'",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +812,48 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_in_name() {
+        // Space before colon: "Host : ..."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace")));
+
+        // Tab before colon
+        let raw = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("whitespace")));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        // A head that's technically valid but exceeds MAX_HEAD_BYTES
+        // (32KB). We use forward() to test the limit enforcement.
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{:04}: some-value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        assert!(raw.len() > MAX_HEAD_BYTES);
+
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let res = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(fwd.forward(&raw, Bytes::new()));
+
+        match res {
+            Err(ForwardError::HeadTooLarge { limit }) => assert_eq!(limit, MAX_HEAD_BYTES),
+            other => panic!("expected HeadTooLarge error, got {:?}", other),
+        }
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -20,7 +20,7 @@ use crate::channel_binding::{
     ChannelBinder, ChannelBindingError, AUTH_NONCE_LEN, BINDING_TIMEOUT_SECS, EXPORTER_LABEL,
     EXPORTER_SECRET_LEN,
 };
-use crate::error::ListenerError;
+use crate::error::{ForwardError, ListenerError};
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
@@ -970,6 +970,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > crate::forward::MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = crate::forward::MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded security limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -1025,6 +1033,13 @@ async fn dispatch_frame(
                             );
                             let _ = emit_stub_502(dc).await;
                         }
+                    }
+                    Err(err @ ForwardError::HeadParse(_))
+                    | Err(err @ ForwardError::HeadTooLarge { .. })
+                    | Err(err @ ForwardError::BodyTooLarge { .. }) => {
+                        tracing::warn!(?err, "openhostd: request rejected; tearing down");
+                        let _ = send_error_frame(dc, &err.to_string()).await;
+                        return FrameOutcome::Teardown;
                     }
                     Err(err) => {
                         tracing::warn!(?err, "openhostd: forwarder failed; replying 502");

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,83 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a 33 KiB REQUEST_HEAD — well over the 32 KiB MAX_HEAD_BYTES cap.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{:04}: some-value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+
+    assert!(big_head.len() > 32 * 1024);
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait up to 5 s for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // "Host : ..." with space before colon.
+    let head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1\r\n\r\n";
+    let req_head = Frame::new(FrameType::RequestHead, head.to_vec()).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after malformed header name");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("whitespace"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
### 🛡️ Sentinel: Strict HTTP Header Parsing and Size Limits

This PR implements two key security enhancements for the `openhost-daemon`'s HTTP forwarder to mitigate Denial-of-Service (DoS) and header smuggling risks.

#### 🚨 Severity: MEDIUM
#### 💡 Vulnerability: 
1. **Unbounded Request Heads:** Malicious clients could send extremely large HTTP request heads, potentially causing memory exhaustion on the daemon or the upstream service.
2. **Permissive Header Parsing:** The daemon was trimming whitespace from header names (e.g., `Host : example`). RFC 7230 §3.2.4 explicitly forbids whitespace before the colon, and allowing it can lead to header smuggling or parsing ambiguities when communicating with upstream proxies.

#### 🎯 Impact:
- **DoS:** Memory exhaustion on the host running the daemon.
- **Header Smuggling:** Potential for an attacker to bypass security controls or inject headers that are interpreted differently by the daemon and the upstream service.

#### 🔧 Fix:
- Introduced `MAX_HEAD_BYTES` (32KB) security limit for `REQUEST_HEAD` frames.
- Enforced this limit early in the WebRTC listener's frame dispatcher.
- Modified `parse_request_head` to strictly reject whitespace in header names.
- Ensured security violations result in an explicit `ERROR` frame to the client followed by an immediate connection teardown, rather than a generic `502 Bad Gateway`.
- Added `Debug` implementations to internal forwarder types to facilitate robust integration testing.

#### ✅ Verification:
- **Unit Tests:** Added `parse_request_head_rejects_oversized_head` and `parse_request_head_rejects_whitespace_in_name` to `crates/openhost-daemon/src/forward.rs`.
- **Integration Tests:** Added `forwarder_request_head_exceeds_cap_rejects_and_tears_down` and `forwarder_rejects_whitespace_between_header_name_and_colon` to `crates/openhost-daemon/tests/forward.rs`.
- All tests (unit, integration, and full workspace) pass.
- Verified compliance with `cargo fmt` and `cargo clippy`.

---
*PR created automatically by Jules for task [8556588655201080502](https://jules.google.com/task/8556588655201080502) started by @vamzi*