### PR TITLE
🛡️ Sentinel: harden HTTP forwarder (RFC 7230 compliance)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Strict HTTP Header Parsing and Sanitization
+**Vulnerability:** HTTP request smuggling and DoS risks via malformed or oversized headers in the custom forwarder.
+**Learning:** Custom HTTP forwarders must strictly adhere to RFC 7230. Static hop-by-hop header lists are insufficient; the `Connection` header must be parsed to identify dynamic hop-by-hop headers. Additionally, allowing whitespace between a header name and colon can lead to interpretation differences between the daemon and upstream services.
+**Prevention:** Centralize header sanitization logic. Use a dedicated helper like `strip_hop_by_hop_headers` that handles both static and dynamic lists. Enforce explicit security limits (e.g., `MAX_HEAD_BYTES`) at the earliest possible entry point.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security limit.
+    #[error("request head exceeded {limit} byte limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -34,6 +34,12 @@ use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
 use std::time::Duration;
 
+/// Security limit for the total size of an inbound request's line +
+/// headers (the `REQUEST_HEAD` frame payload). 32KB is comfortably
+/// above any real-world browser request while bounding memory
+/// exhaustion by a hostile client.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Default connect timeout when reaching the upstream. Localhost should
 /// complete in microseconds; 2 seconds is comfortably above the worst
 /// case and still bounds a misconfigured target from wedging a request.
@@ -183,6 +189,11 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,9 +394,21 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name
+        // and colon. [...] A recipient MUST reject any received request message
+        // that contains whitespace between a header field-name and colon".
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon",
+            ));
+        }
+        let name = name.trim();
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        // We trim both ends to ensure trailing OWS is also stripped.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -405,9 +428,7 @@ fn sanitize_request_headers(
     headers: &mut HeaderMap,
     host_override: &str,
 ) -> Result<(), ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(headers, false);
     for name in PROVENANCE_HEADERS {
         headers.remove(*name);
     }
@@ -429,12 +450,7 @@ fn sanitize_websocket_request_headers(
     headers: &mut HeaderMap,
     host_override: &str,
 ) -> Result<(), ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        if *name == "connection" || *name == "upgrade" {
-            continue;
-        }
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(headers, true);
     for name in PROVENANCE_HEADERS {
         headers.remove(*name);
     }
@@ -454,12 +470,7 @@ fn encode_websocket_response_head(
     status: StatusCode,
     mut headers: HeaderMap,
 ) -> Result<Vec<u8>, ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        if *name == "connection" || *name == "upgrade" {
-            continue;
-        }
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(&mut headers, true);
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
     out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
@@ -510,9 +521,7 @@ fn encode_response_head(
     mut headers: HeaderMap,
     body_len: usize,
 ) -> Result<Vec<u8>, ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(&mut headers, false);
     // Rewrite Content-Length to match the buffered body. The upstream
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
@@ -533,6 +542,47 @@ fn encode_response_head(
     }
     out.extend_from_slice(b"\r\n");
     Ok(out)
+}
+
+/// Strip hop-by-hop headers per RFC 7230 §6.1.
+///
+/// Removes the static list in [`HOP_BY_HOP_HEADERS`] plus any headers
+/// listed in the `Connection` header itself.
+///
+/// If `keep_upgrade` is true, the `Connection` and `Upgrade` headers
+/// are preserved — used by the WebSocket-upgrade path to allow the
+/// RFC 6455 handshake to complete.
+fn strip_hop_by_hop_headers(headers: &mut HeaderMap, keep_upgrade: bool) {
+    // 1. Collect names from the `Connection` header(s).
+    let mut to_remove = Vec::new();
+    for value in headers.get_all(http::header::CONNECTION) {
+        if let Ok(s) = value.to_str() {
+            for name in s.split(',') {
+                let name = name.trim();
+                if !name.is_empty() {
+                    if let Ok(header_name) = HeaderName::from_bytes(name.as_bytes()) {
+                        to_remove.push(header_name);
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Remove names from the static list.
+    for name in HOP_BY_HOP_HEADERS {
+        if keep_upgrade && (*name == "connection" || *name == "upgrade") {
+            continue;
+        }
+        headers.remove(*name);
+    }
+
+    // 3. Remove names collected from the `Connection` header.
+    for name in to_remove {
+        if keep_upgrade && (name == http::header::CONNECTION || name == http::header::UPGRADE) {
+            continue;
+        }
+        headers.remove(name);
+    }
 }
 
 /// Best-effort conversion from an `http::Error` into a stable
@@ -784,6 +834,46 @@ mod tests {
         assert!(matches!(err, ForwardError::HeadParse(_)));
     }
 
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace between header name and colon")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_trims_leading_and_trailing_ows() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example.com  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
+    }
+
+    #[test]
+    fn strip_hop_by_hop_headers_removes_headers_listed_in_connection() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("X-Custom-Hop"),
+        );
+        h.insert(
+            HeaderName::from_static("x-custom-hop"),
+            HeaderValue::from_static("remove-me"),
+        );
+        h.insert(
+            HeaderName::from_static("x-keep-me"),
+            HeaderValue::from_static("stay"),
+        );
+
+        strip_hop_by_hop_headers(&mut h, false);
+        assert!(!h.contains_key("x-custom-hop"));
+        assert!(!h.contains_key(http::header::CONNECTION));
+        assert_eq!(h.get("x-keep-me").unwrap(), "stay");
+    }
+
     // --- Response head encoder --------------------------------------
 
     #[test]
@@ -897,5 +987,33 @@ mod tests {
         let target: Uri = "http://127.0.0.1:8080".parse().unwrap();
         let uri = combine_target_and_path(&target, "http://evil.example/foo").unwrap();
         assert_eq!(uri.to_string(), "http://127.0.0.1:8080/foo");
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        // The check moved to `Forwarder::forward`, so `parse_request_head` itself
+        // doesn't enforce it anymore. We test it via a mock Forwarder if needed,
+        // but here we just verify `MAX_HEAD_BYTES` exists and is enforced in forward().
+        let fwd = Forwarder {
+            target: "http://127.0.0.1".parse().unwrap(),
+            host_override: "x".into(),
+            client: LegacyClient::builder(TokioExecutor::new()).build(HttpConnector::new()),
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let res = fwd.forward(&raw, Bytes::new()).await;
+            assert!(matches!(res, Err(ForwardError::HeadTooLarge { .. })));
+        });
     }
 }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -970,6 +970,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > crate::forward::MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = crate::forward::MAX_HEAD_BYTES,
+                    "openhostd: request head too large; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,65 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a huge REQUEST_HEAD frame.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no ERROR frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let mut session = establish_connection(&app).await;
+
+    let head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1\r\n\r\n";
+    let (resp_head, _body) = round_trip(&mut session, head, b"").await;
+    let head_text = std::str::from_utf8(&resp_head.payload).unwrap();
+
+    // The forwarder currently returns 502 when parse_request_head fails.
+    assert!(head_text.starts_with("HTTP/1.1 502 "));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** HTTP request smuggling and DoS risks in the custom forwarder due to loose header parsing and missing head size limits.
🎯 **Impact:** Malicious clients could exhaust daemon memory by sending oversized headers or bypass security filters/smuggle requests to upstream services by exploiting interpretations of malformed headers.
🔧 **Fix:** 
- Defined `MAX_HEAD_BYTES` (32KB) to bound memory consumption for request headers.
- Updated `parse_request_head` to strictly reject whitespace before colons and trim OWS.
- Refactored sanitization to dynamically strip headers listed in the `Connection` field, covering both static and dynamic hop-by-hop headers.
- Added defense-in-depth size checks in both the protocol listener and the forwarder.
✅ **Verification:** Verified via new unit tests in `src/forward.rs` and integration tests in `tests/forward.rs`. All workspace tests pass.

---
*PR created automatically by Jules for task [7916040957530542418](https://jules.google.com/task/7916040957530542418) started by @vamzi*