### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,14 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head (request line + headers) exceeded the 32KB
+    /// security limit.
+    #[error("request head exceeded {limit} byte limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size of the HTTP request head (request line +
+/// headers + CRLFs). 32KB is enough for any reasonable request and
+/// protects the daemon from DoS via unbounded memory allocation during
+/// parsing.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +189,13 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense-in-depth: check head size before parsing even if the
+        // listener already checked it.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -338,9 +351,16 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// \r\n
 /// ```
 ///
-/// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
-/// obvious line-ending confusion (bare `\n` inside headers).
+/// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, oversized
+/// heads, and any obvious line-ending confusion (bare `\n` inside
+/// headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadTooLarge {
+            limit: MAX_HEAD_BYTES,
+        });
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -383,9 +403,20 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon." and "A proxy MUST reject any received
+        // request message that contains whitespace between a header
+        // field-name and colon".
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
+
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the
+        // value, and at the end of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -405,9 +436,7 @@ fn sanitize_request_headers(
     headers: &mut HeaderMap,
     host_override: &str,
 ) -> Result<(), ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(headers);
     for name in PROVENANCE_HEADERS {
         headers.remove(*name);
     }
@@ -429,12 +458,21 @@ fn sanitize_websocket_request_headers(
     headers: &mut HeaderMap,
     host_override: &str,
 ) -> Result<(), ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        if *name == "connection" || *name == "upgrade" {
-            continue;
+    // RFC 7230 §6.1 requires stripping even on WebSocket upgrades,
+    // but we MUST preserve the specific headers that drive the
+    // upgrade itself.
+    let dynamic = collect_dynamic_hop_by_hop(headers);
+    for name in dynamic {
+        if !name.eq_ignore_ascii_case("upgrade") && !name.eq_ignore_ascii_case("connection") {
+            headers.remove(name);
         }
-        headers.remove(*name);
     }
+    for name in HOP_BY_HOP_HEADERS {
+        if *name != "connection" && *name != "upgrade" {
+            headers.remove(*name);
+        }
+    }
+
     for name in PROVENANCE_HEADERS {
         headers.remove(*name);
     }
@@ -443,6 +481,35 @@ fn sanitize_websocket_request_headers(
     })?;
     headers.insert(http::header::HOST, host_value);
     Ok(())
+}
+
+/// Collect names of dynamic hop-by-hop headers from the `Connection`
+/// header field(s) per RFC 7230 §6.1.
+fn collect_dynamic_hop_by_hop(headers: &HeaderMap) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in headers.get_all(http::header::CONNECTION) {
+        if let Ok(s) = value.to_str() {
+            for part in s.split(',') {
+                let name = part.trim();
+                if !name.is_empty() {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Strip hop-by-hop headers per RFC 7230 §6.1. Removes both the
+/// fixed set in [`HOP_BY_HOP_HEADERS`] and any dynamic headers
+/// listed in the `Connection` header itself.
+fn strip_hop_by_hop_headers(headers: &mut HeaderMap) {
+    for name in collect_dynamic_hop_by_hop(headers) {
+        headers.remove(name);
+    }
+    for name in HOP_BY_HOP_HEADERS {
+        headers.remove(*name);
+    }
 }
 
 /// Re-encode an upstream WebSocket 101 response head into the bytes
@@ -454,12 +521,18 @@ fn encode_websocket_response_head(
     status: StatusCode,
     mut headers: HeaderMap,
 ) -> Result<Vec<u8>, ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        if *name == "connection" || *name == "upgrade" {
-            continue;
+    let dynamic = collect_dynamic_hop_by_hop(&headers);
+    for name in dynamic {
+        if !name.eq_ignore_ascii_case("upgrade") && !name.eq_ignore_ascii_case("connection") {
+            headers.remove(name);
         }
-        headers.remove(*name);
     }
+    for name in HOP_BY_HOP_HEADERS {
+        if *name != "connection" && *name != "upgrade" {
+            headers.remove(*name);
+        }
+    }
+
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
     out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
@@ -510,9 +583,8 @@ fn encode_response_head(
     mut headers: HeaderMap,
     body_len: usize,
 ) -> Result<Vec<u8>, ForwardError> {
-    for name in HOP_BY_HOP_HEADERS {
-        headers.remove(*name);
-    }
+    strip_hop_by_hop_headers(&mut headers);
+
     // Rewrite Content-Length to match the buffered body. The upstream
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
@@ -782,6 +854,79 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        // Add enough headers to exceed 32KB.
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+        assert!(raw.len() > MAX_HEAD_BYTES);
+
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES
+            }
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace between header name and colon is forbidden")
+        ));
+
+        let raw_tab = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err_tab = parse_request_head(raw_tab).unwrap_err();
+        assert!(matches!(
+            err_tab,
+            ForwardError::HeadParse("whitespace between header name and colon is forbidden")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nX-Custom:   value   \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("x-custom").unwrap(), "value");
+
+        let raw_tab = b"GET / HTTP/1.1\r\nX-Tab: \tvalue\t \r\n\r\n";
+        let (_, _, headers_tab) = parse_request_head(raw_tab).unwrap();
+        assert_eq!(headers_tab.get("x-tab").unwrap(), "value");
+    }
+
+    #[test]
+    fn strip_hop_by_hop_headers_removes_dynamic_headers() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            http::header::CONNECTION,
+            HeaderValue::from_static("X-Dynamic, X-Another"),
+        );
+        h.insert(
+            HeaderName::from_static("x-dynamic"),
+            HeaderValue::from_static("strip-me"),
+        );
+        h.insert(
+            HeaderName::from_static("x-another"),
+            HeaderValue::from_static("strip-me-too"),
+        );
+        h.insert(
+            HeaderName::from_static("x-keep"),
+            HeaderValue::from_static("stay"),
+        );
+
+        strip_hop_by_hop_headers(&mut h);
+        assert!(!h.contains_key("x-dynamic"));
+        assert!(!h.contains_key("x-another"));
+        assert!(h.contains_key("x-keep"));
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -970,6 +970,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > crate::forward::MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = crate::forward::MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -1027,8 +1035,26 @@ async fn dispatch_frame(
                         }
                     }
                     Err(err) => {
-                        tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
-                        let _ = emit_stub_502(dc).await;
+                        match err {
+                            // Client-side errors (malformed head, oversized head/body)
+                            // trigger an explicit ERROR frame and teardown.
+                            crate::error::ForwardError::HeadParse(_)
+                            | crate::error::ForwardError::HeadTooLarge { .. }
+                            | crate::error::ForwardError::BodyTooLarge { .. } => {
+                                tracing::warn!(
+                                    ?err,
+                                    "openhostd: client-side forwarder error; tearing down"
+                                );
+                                let _ = send_error_frame(dc, &err.to_string()).await;
+                                return FrameOutcome::Teardown;
+                            }
+                            // Upstream errors (unreachable, 502 from target) return
+                            // our own 502 stub and keep the DC alive.
+                            _ => {
+                                tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
+                                let _ = emit_stub_502(dc).await;
+                            }
+                        }
                     }
                 },
                 None => {

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -486,6 +486,113 @@ async fn forwarder_request_body_exceeding_cap_triggers_error_frame_and_teardown(
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a 33 KiB REQUEST_HEAD — over the 32 KB MAX_HEAD_BYTES limit.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+    assert!(big_head.len() > 32 * 1024);
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait up to 5 s for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("large") || diagnostic.contains("limit"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    let bad_head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1\r\n\r\n";
+    let req_head = Frame::new(FrameType::RequestHead, bad_head.to_vec()).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Rejection happens during forward (RequestEnd trigger), returning
+    // an ERROR frame (since it's a 400-class error from the forwarder).
+    let (err_frame, _) = wait_for_full_response_or_error(&session).await;
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("whitespace"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+/// Wait for a full response OR an error frame.
+async fn wait_for_full_response_or_error(session: &ClientSession) -> (Frame, Vec<u8>) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut head_frame: Option<Frame> = None;
+    let mut body_out: Vec<u8> = Vec::new();
+    let mut offset = 0usize;
+    let mut saw_end = false;
+
+    loop {
+        let bytes = session.received.lock().await.clone();
+        while offset < bytes.len() {
+            match Frame::try_decode(&bytes[offset..]) {
+                Ok(Some((frame, used))) => {
+                    offset += used;
+                    match frame.frame_type {
+                        FrameType::ResponseHead => head_frame = Some(frame),
+                        FrameType::ResponseBody => body_out.extend_from_slice(&frame.payload),
+                        FrameType::ResponseEnd => {
+                            saw_end = true;
+                            break;
+                        }
+                        FrameType::Error => return (frame, vec![]),
+                        other => panic!("unexpected response frame: {other:?}"),
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => panic!("frame decode failed: {e:?}"),
+            }
+        }
+        if saw_end {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("timed out waiting for response or error");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    (head_frame.unwrap(), body_out)
+}
+
+#[tokio::test]
 async fn ping_frame_is_answered_with_pong() -> DaemonResult<()> {
     let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
This PR hardens the `openhost-daemon` HTTP forwarding logic to align with RFC 7230 and protect against common proxy-related vulnerabilities.

### 🛡️ Security Hardening

- **DoS Protection:** Introduced a 32KB `MAX_HEAD_BYTES` limit for HTTP request heads. This prevents an attacker from exhausting daemon memory by sending an unbounded stream of headers. The check is enforced both in the listener (fail-early) and the forwarder (defense-in-depth).
- **Request Smuggling Prevention:** Strictly enforces RFC 7230 §3.2.4 by rejecting requests that contain whitespace between a header field-name and the colon.
- **RFC 7230 Compliance:** Enhanced hop-by-hop header stripping to remove both a fixed set of headers and any dynamic headers listed in the `Connection` field.
- **Fail Securely:** Updated the listener to distinguish between client-side protocol violations (which now trigger an explicit `ERROR` frame and immediate channel teardown) and upstream errors (which return a 502).

### ✅ Verification

- Added unit tests in `forward.rs` covering oversized heads, whitespace before colons, OWS trimming, and dynamic header stripping.
- Added integration tests in `tests/forward.rs` to verify that the daemon correctly rejects malformed or oversized heads and tears down the data channel.
- Ran the full test suite: `cargo test -p openhost-daemon`.
- Verified formatting and lints: `cargo fmt` and `cargo clippy`.

---
*PR created automatically by Jules for task [3384656196378477485](https://jules.google.com/task/3384656196378477485) started by @vamzi*