### PR TITLE
🛡️ Sentinel: [security improvement] Enforce request head limits and harden RFC 7230 compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Request Head Security Limits and RFC 7230 Hardening
+**Vulnerability:** Lack of size limits on REQUEST_HEAD frames and non-strict parsing of header name/colon whitespace.
+**Learning:** Without explicit bounds on the `head_payload` before parsing, a malicious client can exhaust memory or cause a DoS. Additionally, lenient header parsing (allowing whitespace before the colon) can lead to HTTP Request Smuggling.
+**Prevention:** Always enforce a maximum size for headers (e.g., 32KB) at the earliest possible entry point and strictly reject RFC 7230 violations in the parser.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound `REQUEST_HEAD` payload exceeded the 32KB security limit.
+    #[error("request head exceeded {limit} byte cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,12 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Security limit for the request head (request line + headers +
+/// \r\n\r\n). 32KB is enough for any legitimate set of headers (browsers
+/// usually cap at 8-16KB) while bounding memory use from a malicious
+/// client.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +189,15 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense-in-depth: the listener already caps the HEAD frame,
+        // but we verify here too so a malformed listener cannot
+        // overflow our parser.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,9 +398,19 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon." Rejection prevents smuggling.
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        // Stripping both leading and trailing OWS is required.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +807,38 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace between header name and colon is forbidden")
+        ));
+    }
+
+    #[test]
+    fn forwarder_rejects_oversized_head() {
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let big_head = vec![b'x'; MAX_HEAD_BYTES + 1];
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let res = fwd.forward(&big_head, Bytes::new()).await;
+            assert!(matches!(res, Err(ForwardError::HeadTooLarge { .. })));
+        });
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -20,8 +20,10 @@ use crate::channel_binding::{
     ChannelBinder, ChannelBindingError, AUTH_NONCE_LEN, BINDING_TIMEOUT_SECS, EXPORTER_LABEL,
     EXPORTER_SECRET_LEN,
 };
-use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::error::{ForwardError, ListenerError};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded security limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -1026,9 +1036,23 @@ async fn dispatch_frame(
                             let _ = emit_stub_502(dc).await;
                         }
                     }
+                    Err(ForwardError::HeadParse(reason)) => {
+                        tracing::warn!(
+                            reason,
+                            "openhostd: request head parse failed; tearing down"
+                        );
+                        let _ = send_error_frame(dc, reason).await;
+                        return FrameOutcome::Teardown;
+                    }
+                    Err(ForwardError::HeadTooLarge { .. }) => {
+                        tracing::warn!("openhostd: request head too large; tearing down");
+                        let _ = send_error_frame(dc, "request head too large").await;
+                        return FrameOutcome::Teardown;
+                    }
                     Err(err) => {
                         tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
                         let _ = emit_stub_502(dc).await;
+                        return FrameOutcome::Continue;
                     }
                 },
                 None => {

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,74 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    use openhost_daemon::forward::MAX_HEAD_BYTES;
+
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a HEAD frame that exceeds the 32KB limit.
+    let big_head = vec![b'A'; MAX_HEAD_BYTES + 1];
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    assert!(String::from_utf8_lossy(&err_frame.payload).contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // RFC 7230 §3.2.4 violation.
+    let head = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+    let req_head = Frame::new(FrameType::RequestHead, head.to_vec()).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after malformed REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    assert!(String::from_utf8_lossy(&err_frame.payload).contains("whitespace"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement]

This PR adds defense-in-depth protections to the openhost daemon's HTTP-over-DataChannel forwarding logic.

#### 💡 What
1.  **Request Head Size Limit**: Implements a 32KB security limit for the request head (request line + headers). This is enforced immediately when a `REQUEST_HEAD` frame is received by the listener, and again as a secondary check before parsing in the forwarder.
2.  **RFC 7230 §3.2.4 Compliance**:
    *   Rejects any request containing whitespace between a header field-name and the colon (e.g., `Host : example.com`). This is a critical hardening measure against HTTP Request Smuggling.
    *   Correctly trims both leading and trailing optional whitespace (OWS) from header values, as mandated by the spec.
3.  **Error Handling**: Ensures that header-related security violations result in an explicit `ERROR` frame being sent to the client and the immediate teardown of the data channel.

#### 🎯 Why
- **Resource Exhaustion**: Without a limit on the head size, a malicious client could send an extremely large `REQUEST_HEAD` frame to consume excessive memory or cause a DoS during parsing.
- **Protocol Smuggling**: Inconsistent handling of whitespace in headers is a common vector for smuggling attacks where different parsers in a proxy chain disagree on where a header ends or what its name is.

#### ✅ Verification
- **Unit Tests**: Added tests in `forward.rs` for whitespace-before-colon rejection and head-size limit enforcement.
- **Integration Tests**: Added end-to-end tests in `tests/forward.rs` that simulate a real daemon connection and verify that oversized or malformed headers trigger `ERROR` frames and teardown.
- **Full Suite**: Ran `cargo test -p openhost-daemon` (all 99 unit tests + integration tests passed).
- **Linting**: Verified with `cargo fmt` and `cargo clippy`.

---
*PR created automatically by Jules for task [4687942106724703780](https://jules.google.com/task/4687942106724703780) started by @vamzi*