### PR TITLE
⚡ Bolt: optimize DNS fragment reassembly and TXT encoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - DNS Fragment Reassembly Optimization
+**Learning:** Reassembling fragmented DNS records via repeated `SignedPacket::resource_records(name)` probes is O(N*M) where N is fragments and M is total records. Switching to `SignedPacket::all_resource_records()` enables O(M) reassembly but requires careful label matching because it returns absolute names (e.g., `_answer-<hash>-<idx>.<origin>`).
+**Action:** Use a single pass over `all_resource_records()` for multi-record processing. Match relative names by checking the first label's bytes and verifying it has exactly one parent label (the origin zone).

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1027,22 +1027,13 @@ fn build_multi_string_txt(value: &str) -> Result<TXT<'static>> {
         value.is_ascii(),
         "build_multi_string_txt expects ASCII; multi-byte UTF-8 would be split mid-code-point"
     );
-    // `simple_dns::TXT::with_string` borrows the input string for the
-    // lifetime of the returned TXT. To hand back a `TXT<'static>` we
-    // collect every chunk into an owned `Vec<String>` that outlives
-    // the loop's borrows, then call `into_owned()` at the end to
-    // internalise those borrows.
-    let chunks: Vec<String> = value
-        .as_bytes()
-        .chunks(DNS_CHARACTER_STRING_MAX)
-        .map(|c| {
-            core::str::from_utf8(c)
-                .expect("caller guaranteed ASCII")
-                .to_string()
-        })
-        .collect();
+    // BOLT OPTIMIZATION: Build the TXT record directly from chunks of the
+    // input string and use `into_owned()` to internalize the borrows. This
+    // avoids allocating an intermediate `Vec<String>` and performing
+    // multiple `to_string()` calls.
     let mut txt = TXT::new();
-    for s in &chunks {
+    for chunk in value.as_bytes().chunks(DNS_CHARACTER_STRING_MAX) {
+        let s = core::str::from_utf8(chunk).expect("caller guaranteed ASCII");
         txt = txt
             .with_string(s)
             .map_err(|e| PkarrError::TxtBuildFailed(e.to_string()))?;
@@ -1098,48 +1089,77 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // BOLT OPTIMIZATION: single pass over all records, O(M + N log N).
+    // Replaces the previous O(N*M) repeated probes.
+    let mut fragments: Vec<DecodedFragment> = Vec::new();
+    let base_with_dash = format!("{base}-");
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            // BOLT OPTIMIZATION: Robust fragment matching. We check if the
+            // record name has exactly one label following the fragment label
+            // (the origin), and if the first label matches our expected
+            // `_answer-<hash>-<idx>` shape.
+            let mut labels = rr.name.iter();
+            if let Some(first_label) = labels.next() {
+                // Ensure there is exactly one more label (the origin zone).
+                if labels.count() == 1 {
+                    let label_bytes = first_label.as_ref();
+                    if let Some(rest) = label_bytes.strip_prefix(base_with_dash.as_bytes()) {
+                        if let Ok(idx_str) = core::str::from_utf8(rest) {
+                            if let Ok(idx) = idx_str.parse::<u8>() {
+                                let text = collect_txt_data(txt)?;
+                                let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
+                                let frag = decode_fragment(&bytes)?;
+
+                                if frag.idx != idx {
+                                    return Err(PkarrError::MalformedCanonical(
+                                        "answer fragment idx disagrees with its DNS label suffix",
+                                    ));
+                                }
+                                fragments.push(frag);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if fragments.is_empty() {
         return Ok(None);
-    };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
+    }
+
+    // Sort by idx to ensure order-independence of DHT packets.
+    fragments.sort_by_key(|f| f.idx);
+
+    // Validate completeness.
+    let first = &fragments[0];
     if first.idx != 0 {
         return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
+            "answer fragment set is incomplete (missing fragment 0)",
         ));
     }
     let total = first.total;
+    if fragments.len() != total as usize {
+        return Err(PkarrError::MalformedCanonical(
+            "answer fragment set is incomplete (missing fragments)",
+        ));
+    }
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
-    fragments.push(first);
-    for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
+    for (i, frag) in fragments.iter().enumerate() {
         if frag.total != total {
             return Err(PkarrError::MalformedCanonical(
                 "answer fragments disagree on chunk_total",
             ));
         }
-        if frag.idx != i {
+        if frag.idx != i as u8 {
+            // This case should be covered by fragments.len() check + sorting,
+            // but we double-check for safety.
             return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
+                "answer fragment set is incomplete (missing fragments)",
             ));
         }
-        fragments.push(frag);
     }
 
     let mut sealed = Vec::with_capacity(fragments.iter().map(|f| f.payload.len()).sum());
@@ -1157,9 +1177,34 @@ pub fn decode_answer_fragments_from_packet(
     }))
 }
 
+/// BOLT OPTIMIZATION: Reassemble DNS TXT character-strings into a `String`
+/// with pre-calculated capacity to minimize reallocations.
+fn collect_txt_data(txt: &TXT<'_>) -> Result<String> {
+    // Each character-string in a TXT RR is capped at 255 bytes. For base64
+    // fragments we don't expect '=' splits, but the simple-dns iter_raw()
+    // still yields (key, Option<value>) by splitting at the first '='.
+    let mut total_len = 0;
+    for (k, v) in txt.iter_raw() {
+        total_len += k.len();
+        if let Some(val) = v {
+            total_len += 1 + val.len();
+        }
+    }
+
+    let mut out = String::with_capacity(total_len);
+    for (key, value) in txt.iter_raw() {
+        out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+        if let Some(v) = value {
+            out.push('=');
+            out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+        }
+    }
+    Ok(out)
+}
+
 fn collect_single_txt(packet: &SignedPacket, name: &str) -> Result<Option<String>> {
     let mut seen = 0usize;
-    let mut out = String::new();
+    let mut out = None;
     for rr in packet.resource_records(name) {
         if let RData::TXT(txt) = &rr.rdata {
             seen += 1;
@@ -1167,20 +1212,10 @@ fn collect_single_txt(packet: &SignedPacket, name: &str) -> Result<Option<String
                 // Multiple TXTs at the same name → malformed.
                 return Err(PkarrError::MultipleOpenhostRecords);
             }
-            for (key, value) in txt.iter_raw() {
-                out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
-                if let Some(v) = value {
-                    out.push('=');
-                    out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
-                }
-            }
+            out = Some(collect_txt_data(txt)?);
         }
     }
-    if seen == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(out))
-    }
+    Ok(out)
 }
 
 // ============================================================================


### PR DESCRIPTION
💡 What:
- Optimized `build_multi_string_txt` to avoid intermediate `Vec<String>` allocations by building the TXT record directly from input chunks.
- Implemented `collect_txt_data` helper to reassemble DNS TXT character-strings into a `String` with pre-calculated capacity, minimizing reallocations.
- Refactored `decode_answer_fragments_from_packet` to use a single pass over `packet.all_resource_records()` instead of repeated O(M) probes for each fragment index.

🎯 Why:
- The previous fragment reassembly logic was O(N*M) where N is the number of fragments and M is the total records in the packet. For large packets or many fragments, this was inefficient.
- DNS record building and parsing had unnecessary heap allocations that could be avoided with zero-allocation slicing and pre-allocation.

📊 Impact:
- Fragment reassembly is now O(M + N log N) (due to sorting collected fragments).
- Reduced memory pressure and CPU cycles during signalling packet processing.
- Robust label matching ensures correctness for absolute names yielded by `pkarr`.

🔬 Measurement:
- All existing tests in `openhost-pkarr` pass (`cargo test -p openhost-pkarr`).
- Robustness of the single-pass label matching was verified with a targeted test case.

---
*PR created automatically by Jules for task [38814712030980503](https://jules.google.com/task/38814712030980503) started by @vamzi*