### PR TITLE
⚡ Bolt: optimize inbound buffer consumption in daemon and client

### DIFF
--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,9 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    /// BOLT OPTIMIZATION: Use BytesMut for O(1) buffer consumption via advance()
+    /// instead of O(N) via Vec::drain().
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +176,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -199,7 +201,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // BOLT OPTIMIZATION: Use BytesMut for O(1) buffer consumption via advance()
+    // instead of O(N) via Vec::drain().
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -841,7 +843,7 @@ async fn wire_frame_loop(
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
💡 What: The optimization implemented
This PR optimizes the inbound data-channel frame buffering in both the `openhost-daemon` and `openhost-client` crates. It replaces the use of `Vec<u8>` with `BytesMut` and switches from `drain(..n)` to `advance(n)` for buffer consumption.

🎯 Why: The performance problem it solves
In the previous implementation, every time a frame was successfully decoded, `buf.drain(..consumed)` was called. For a `Vec<u8>`, this operation has $O(N)$ time complexity because it must shift all remaining bytes in the buffer to the front. In high-throughput scenarios (like streaming large response bodies or active WebSocket tunnels), this adds measurable overhead. By using `BytesMut::advance`, we achieve $O(1)$ consumption by simply moving a pointer.

📊 Impact: Expected performance improvement
Measurable reduction in CPU overhead for frame dispatch loops, especially as the buffer size or frame frequency increases. This improvement is most pronounced during large data transfers where the buffer might contain multiple frames or large partial frames.

🔬 Measurement: How to verify the improvement
The correctness is verified by the existing suite of integration tests (`cargo test -p openhost-daemon` and `cargo test -p openhost-client`), which cover frame round-trips and multi-frame assembly. Performance gains can be profiled using `cargo bench` or by observing CPU usage during high-bandwidth streaming tests.

---
*PR created automatically by Jules for task [12574379832867420831](https://jules.google.com/task/12574379832867420831) started by @vamzi*