### PR TITLE
🛡️ Sentinel: [security improvement] Strict HTTP head limits and validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-11 - Strict HTTP Header Validation
+**Vulnerability:** HTTP Request Smuggling / Ambiguity via illegal whitespace in header names.
+**Learning:** RFC 7230 §3.2.4 explicitly forbids whitespace between the header name and the colon. Parsers that are too lenient (e.g., by trimming the name) can be exploited if an upstream proxy has a different interpretation of the malformed header.
+**Prevention:** Always validate that the substring before the colon in an HTTP header line does not end with whitespace before performing any trimming or further processing.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the security cap.
+    #[error("request head exceeded {limit} byte cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,10 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum size of a `REQUEST_HEAD` frame (32 KiB). Prevents a hostile
+/// client from inflating memory with an unbounded set of headers.
+pub const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +187,15 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense in depth: the listener already enforces MAX_HEAD_BYTES
+        // but we double-check here to ensure the security limit is
+        // never bypassed by a different caller.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,8 +396,16 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
+        // It also mandates that no whitespace be present between the
+        // header name and the colon.
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is forbidden (RFC 7230 §3.2.4)",
+            ));
+        }
+        let name = name.trim();
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
@@ -782,6 +803,26 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_between_name_and_colon() {
+        // RFC 7230 §3.2.4
+        let head = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(head).unwrap_err();
+        assert!(format!("{err}").contains("whitespace between header name and colon"));
+    }
+
+    #[tokio::test]
+    async fn forward_rejects_oversized_head() {
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            ..Default::default()
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let big_head = vec![b'A'; MAX_HEAD_BYTES + 1];
+        let res = fwd.forward(&big_head, Bytes::new()).await;
+        assert!(matches!(res, Err(ForwardError::HeadTooLarge { .. })));
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded security cap; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD exceeds 32KB security limit").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,62 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    use openhost_daemon::forward::MAX_HEAD_BYTES;
+
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a head frame that exceeds the 32KB security limit.
+    let oversized_head = vec![b'A'; MAX_HEAD_BYTES + 1];
+    let req_head = Frame::new(FrameType::RequestHead, oversized_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("limit"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn forwarder_rejects_whitespace_between_header_name_and_colon() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let mut session = establish_connection(&app).await;
+
+    let head = b"GET / HTTP/1.1\r\nHost : 127.0.0.1\r\n\r\n";
+    let (resp_head, _body) = round_trip(&mut session, head, b"").await;
+
+    let head_text = std::str::from_utf8(&resp_head.payload).unwrap();
+    // The forwarder maps ForwardError::HeadParse to a 502 Bad Gateway
+    // when a request fails to parse.
+    assert!(head_text.starts_with("HTTP/1.1 502 "));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential DoS via memory exhaustion (unbounded request heads) and potential Request Smuggling via lenient header name parsing.
🎯 Impact: A malicious client could exhaust daemon memory with oversized REQUEST_HEAD frames or bypass security filters by exploiting discrepancies in header parsing between the daemon and its upstream.
🔧 Fix:
- Introduced a 32 KiB \`MAX_HEAD_BYTES\` limit for \`REQUEST_HEAD\` frames.
- Enforced the limit in both the protocol listener and the forwarder (defense-in-depth).
- Hardened the HTTP parser to strictly reject whitespace between header names and colons per RFC 7230 §3.2.4.
- Added a new \`ForwardError::HeadTooLarge\` variant for precise error reporting.
✅ Verification: Added unit and integration tests in \`crates/openhost-daemon/src/forward.rs\` and \`crates/openhost-daemon/tests/forward.rs\` verifying that oversized heads are rejected and malformed headers trigger expected errors.

---
*PR created automatically by Jules for task [4751155002566940044](https://jules.google.com/task/4751155002566940044) started by @vamzi*