### PR TITLE
🛡️ Sentinel: [MEDIUM] Hardened HTTP header parsing and enforced head size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Header Parsing Hardening
+**Vulnerability:** Potential memory exhaustion (DoS) via oversized request heads and protocol-level vulnerabilities like Request Smuggling due to non-strict header parsing.
+**Learning:** Even if the underlying HTTP library (hyper) might handle these, the daemon's own framing and parsing layer must enforce security limits and spec compliance before forwarding. RFC 7230 §3.2.4 explicitly prohibits whitespace between the header name and colon to prevent smuggling.
+**Prevention:** Always enforce standard security limits (e.g., 32KiB for headers) and implement strict, spec-compliant parsing for protocol-level inputs.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound `REQUEST_HEAD` payload exceeded the 32 KiB security limit.
+    #[error("request head exceeded {limit} byte security limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,10 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum allowed size for the `REQUEST_HEAD` payload (32 KiB).
+/// Enforced as a defense-in-depth security limit per spec §7.12.
+pub const MAX_HEAD_BYTES: usize = 32768;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +187,12 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,7 +393,13 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name_raw = &line[..colon];
+        if name_raw.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace between header name and colon is prohibited (RFC 7230 §3.2.4)",
+            ));
+        }
+        let name = name_raw.trim();
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -761,6 +777,49 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        let reason = match err {
+            ForwardError::HeadParse(r) => r,
+            _ => panic!("expected HeadParse error"),
+        };
+        assert!(reason.contains("whitespace between header name and colon"));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        // Add enough headers to exceed 32 KiB.
+        for i in 0..2000 {
+            raw.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+        }
+        raw.extend_from_slice(b"\r\n");
+
+        // parse_request_head itself doesn't check MAX_HEAD_BYTES,
+        // but Forwarder::forward does.
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let res = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .enable_io()
+            .build()
+            .unwrap()
+            .block_on(fwd.forward(&raw, Bytes::new()));
+
+        match res {
+            Err(ForwardError::HeadTooLarge { limit }) => assert_eq!(limit, MAX_HEAD_BYTES),
+            Err(e) => panic!("expected HeadTooLarge, got error: {:?}", e),
+            Ok(_) => panic!("expected HeadTooLarge, got Ok"),
+        }
     }
 
     #[test]

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,15 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    len = frame.payload.len(),
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,45 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Build a > 32 KiB head.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    for i in 0..2000 {
+        big_head.extend_from_slice(format!("X-Header-{:04}: value\r\n", i).as_bytes());
+    }
+    big_head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("head too large"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Hardened HTTP header parsing and enforced head size limits

### 🚨 Severity: MEDIUM

### 💡 Vulnerability:
1. **Unbounded Request Heads:** The daemon previously lacked a hard limit on the size of the `REQUEST_HEAD` frame payload, which could lead to memory exhaustion (DoS) if a malicious client sent an extremely large header.
2. **Lax Header Parsing:** The header parser was trimming whitespace between the header name and the colon. RFC 7230 §3.2.4 strictly prohibits this whitespace. Inconsistent handling of such whitespace between proxies is a classic source of HTTP Request Smuggling/Splitting vulnerabilities.

### 🎯 Impact:
- **Resource Exhaustion:** Memory exhaustion on the daemon host.
- **Protocol Smuggling:** Potential to bypass security filters or smuggle requests if the daemon is used in front of certain upstreams that interpret non-compliant headers differently.

### 🔧 Fix:
- Defined `MAX_HEAD_BYTES = 32768` (32 KiB) as a security limit.
- Updated the data-channel listener to reject `REQUEST_HEAD` frames exceeding this limit immediately with an `ERROR` frame and channel teardown.
- Added a secondary defense-in-depth check in `Forwarder::forward`.
- Updated `parse_request_head` to strictly reject any whitespace (SP/HTAB) between the header name and the colon.

### ✅ Verification:
- Added unit tests in `crates/openhost-daemon/src/forward.rs` for strict parsing and size limits.
- Added an integration test in `crates/openhost-daemon/tests/forward.rs` (`forwarder_request_head_exceeds_cap_rejects_and_tears_down`) verifying the E2E enforcement via the data channel.
- Ran the full `openhost-daemon` test suite (`cargo test -p openhost-daemon`).
- Verified with `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [3024764649208543208](https://jules.google.com/task/3024764649208543208) started by @vamzi*