### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix HTTP header parsing and add size limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Strict HTTP Header Parsing and Head Size Limits
+**Vulnerability:** HTTP Request Smuggling via whitespace before colon in headers, and Potential DoS via unbounded header accumulation.
+**Learning:** Hand-rolled HTTP parsers often miss subtle RFC requirements like RFC 7230 §3.2.4 which forbids whitespace between header name and colon. Additionally, protocol security limits (like 32KB for headers) must be enforced at the entry point (listener) and ideally again at the processing layer (forwarder) for defense in depth.
+**Prevention:** Always validate header formatting against RFC 7230 strictly. Enforce explicit size limits on all inbound buffers and protocol-level objects.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -189,6 +189,13 @@ pub enum ForwardError {
         cap: usize,
     },
 
+    /// Inbound `REQUEST_HEAD` exceeded the 32 KiB security limit.
+    #[error("request head exceeded {limit} byte security limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Request asserts `Upgrade: websocket` but no `[forward.websockets]`
     /// allowlist is configured, or the target path is not on it. Operators
     /// who want to allow WebSocket upgrades per spec §4.2 must add the

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted size for the HTTP request head (request line +
+/// headers + terminator). Heads larger than this are rejected as a
+/// security measure to prevent DoS via unbounded header accumulation.
+pub const MAX_HEAD_BYTES: usize = 32768;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -183,6 +188,14 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense in depth: the listener is expected to reject
+        // oversized heads early, but we enforce the security limit
+        // here too.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -383,7 +396,17 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name",
+            ));
+        }
+        let name = name.trim();
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -780,6 +803,15 @@ mod tests {
     #[test]
     fn parse_request_head_rejects_header_without_colon() {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
     }

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -21,7 +21,9 @@ use crate::channel_binding::{
     EXPORTER_SECRET_LEN,
 };
 use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: REQUEST_HEAD exceeded security limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "REQUEST_HEAD too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -424,6 +424,51 @@ async fn forwarder_upstream_unreachable_returns_502() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    // Heads larger than MAX_HEAD_BYTES (32 KiB) are rejected by the
+    // listener early as a DoS mitigation.
+    use openhost_daemon::forward::MAX_HEAD_BYTES;
+
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Build a head that's just over the limit.
+    let mut large_head = b"GET / HTTP/1.1\r\n".to_vec();
+    while large_head.len() <= MAX_HEAD_BYTES {
+        large_head.extend_from_slice(b"X-Filler: 1234567890abcdef\r\n");
+    }
+    large_head.extend_from_slice(b"\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, large_head).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(diagnostic.contains("HEAD"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_request_body_exceeding_cap_triggers_error_frame_and_teardown() -> DaemonResult<()>
 {
     // Configure a tiny 256-byte cap so the test doesn't have to allocate


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Non-compliant HTTP header parsing (accepted whitespace before colon) and lack of request head size limits.
🎯 Impact: Potential HTTP request smuggling and Denial of Service (DoS) via memory exhaustion.
🔧 Fix: Enforced RFC 7230 §3.2.4 for header parsing and implemented a 32 KiB security limit for request heads in both the listener and forwarder.
✅ Verification: Added unit tests for strict header validation and an integration test for the 32 KiB head limit. Verified with `cargo test --all`.

---
*PR created automatically by Jules for task [2197334810590083972](https://jules.google.com/task/2197334810590083972) started by @vamzi*