### PR TITLE
🛡️ Sentinel: [security improvement] Enforce 32KB request head limit and tighten HTTP parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Enforce Request Head Limits and Strict Parsing
+**Vulnerability:** Potential memory exhaustion (DoS) from unbounded HTTP request headers and potential HTTP Request Smuggling due to lenient header parsing (whitespace before colon, header folding).
+**Learning:** Even if the underlying transport is secure (WebRTC/DTLS), the application-layer protocol (HTTP) must still be hardened. Lenient parsers can be exploited to bypass security controls or crash the process.
+**Prevention:** Always enforce a reasonable limit on the request "head" (line + headers) and use a strict parser that rejects RFC-violating constructs like `obs-fold` or malformed header names.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the 32 KiB security limit.
+    #[error("request head exceeded {limit} byte limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted request head size (request line + headers +
+/// `\r\n\r\n`). 32 KiB is comfortably above every browser default and
+/// bounds a hostile client from inflating daemon memory.
+pub const MAX_HEAD_BYTES: usize = 32768;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -64,6 +69,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -183,6 +190,15 @@ impl Forwarder {
         head_payload: &[u8],
         body: Bytes,
     ) -> Result<ForwardOutcome, ForwardError> {
+        // Defense in depth: the listener already checked this, but
+        // enforcing it here ensures the forwarder itself is never
+        // tricked into parsing an oversized head.
+        if head_payload.len() > MAX_HEAD_BYTES {
+            return Err(ForwardError::HeadTooLarge {
+                limit: MAX_HEAD_BYTES,
+            });
+        }
+
         if body.len() > self.max_body_bytes {
             return Err(ForwardError::BodyTooLarge {
                 cap: self.max_body_bytes,
@@ -380,10 +396,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "header line starts with whitespace (obs-fold unsupported)",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse("header name ends with whitespace"));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +806,36 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m == "header name ends with whitespace")
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Folded-Value\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(m) if m.contains("obs-fold")));
+    }
+
+    #[tokio::test]
+    async fn forwarder_rejects_oversized_head() {
+        let cfg = ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        };
+        let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
+        let big_head = vec![b'A'; MAX_HEAD_BYTES + 1];
+        let result = fwd.forward(&big_head, Bytes::new()).await;
+        assert!(matches!(result, Err(ForwardError::HeadTooLarge { .. })));
     }
 
     // --- Response head encoder --------------------------------------

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -20,8 +20,10 @@ use crate::channel_binding::{
     ChannelBinder, ChannelBindingError, AUTH_NONCE_LEN, BINDING_TIMEOUT_SECS, EXPORTER_LABEL,
     EXPORTER_SECRET_LEN,
 };
-use crate::error::ListenerError;
-use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
+use crate::error::{ForwardError, ListenerError};
+use crate::forward::{
+    ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade, MAX_HEAD_BYTES,
+};
 use crate::publish::SharedState;
 use bytes::{Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -970,6 +972,14 @@ async fn dispatch_frame(
 
     match frame.frame_type {
         FrameType::RequestHead => {
+            if frame.payload.len() > MAX_HEAD_BYTES {
+                tracing::warn!(
+                    limit = MAX_HEAD_BYTES,
+                    "openhostd: request head exceeded limit; tearing down"
+                );
+                let _ = send_error_frame(dc, "request head too large").await;
+                return FrameOutcome::Teardown;
+            }
             let mut req = request.lock().await;
             req.head_payload = Some(frame.payload.clone());
             req.body.clear();
@@ -1025,6 +1035,24 @@ async fn dispatch_frame(
                             );
                             let _ = emit_stub_502(dc).await;
                         }
+                    }
+                    Err(ForwardError::HeadTooLarge { limit }) => {
+                        tracing::warn!(
+                            limit,
+                            "openhostd: request head exceeded limit; tearing down"
+                        );
+                        let _ = send_error_frame(dc, "request head too large").await;
+                        return FrameOutcome::Teardown;
+                    }
+                    Err(ForwardError::HeadParse(reason)) => {
+                        tracing::warn!(
+                            reason,
+                            "openhostd: request head parse failed; tearing down"
+                        );
+                        let _ =
+                            send_error_frame(dc, &format!("request head parse failed: {reason}"))
+                                .await;
+                        return FrameOutcome::Teardown;
                     }
                     Err(err) => {
                         tracing::warn!(?err, "openhostd: forwarder failed; replying 502");

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,44 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    use openhost_daemon::forward::MAX_HEAD_BYTES;
+
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a head that exceeds the 32 KiB security limit.
+    let mut big_head = b"GET / HTTP/1.1\r\n".to_vec();
+    big_head.extend(vec![b'X'; MAX_HEAD_BYTES]);
+    big_head.extend_from_slice(b"\r\n\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame. The channel will be torn down.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    assert!(String::from_utf8_lossy(&err_frame.payload).contains("head"));
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential memory exhaustion (DoS) via oversized HTTP request heads and potential HTTP Request Smuggling due to lenient header parsing (RFC 7230 §3.2.4 violation).
🎯 Impact: An attacker could crash the daemon by sending extremely large headers or bypass security controls/inject requests into upstream services via smuggling.
🔧 Fix:
- Introduced a 32 KiB security limit on HTTP request heads (`MAX_HEAD_BYTES`).
- Tightened the HTTP parser to reject whitespace before the header colon and obsolete line folding (`obs-fold`).
- Expanded blocked provenance headers to include `true-client-ip` and `cf-connecting-ip`.
- Ensured malformed or oversized heads trigger an explicit `ERROR` frame and session teardown.
✅ Verification:
- Added unit tests for strict parsing and oversized head rejection in `forward.rs`.
- Added an integration test `forwarder_request_head_exceeds_cap_rejects_and_tears_down` in `forward.rs` (tests).
- Verified all tests pass with `cargo test -p openhost-daemon`.
- Verified `cargo clippy` and `cargo fmt` compliance.

---
*PR created automatically by Jules for task [13673888793842312302](https://jules.google.com/task/13673888793842312302) started by @vamzi*