### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling and provenance spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-15 - [HTTP Header Hardening]
+**Vulnerability:** HTTP Request Smuggling and Spoofing via provenance headers.
+**Learning:** Legacy HTTP parsers often allow whitespace before colons or obsolete line folding, which can be exploited for smuggling. Additionally, many upstream services trust non-standard provenance headers like 'true-client-ip'.
+**Prevention:** Strictly adhere to RFC 7230 §3.2.4 by rejecting malformed headers early and maintain a comprehensive blocklist of provenance headers.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -380,10 +382,22 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (RFC 7230 §3.2.4) is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name (RFC 7230 §3.2.4) is not supported",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +607,14 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("1.1.1.1"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("2.2.2.2"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +783,26 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : localhost\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        match err {
+            ForwardError::HeadParse(m) => assert!(m.contains("whitespace before colon")),
+            _ => panic!("expected HeadParse error"),
+        }
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obsolete_line_folding() {
+        let raw = b"GET / HTTP/1.1\r\nHost: localhost\r\n folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        match err {
+            ForwardError::HeadParse(m) => assert!(m.contains("obsolete line folding")),
+            _ => panic!("expected HeadParse error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The HTTP header parser was vulnerable to request smuggling/splitting by accepting obsolete line folding and whitespace before colons (violating RFC 7230). Additionally, missing provenance headers allowed for potential IP spoofing if upstream services trusted 'true-client-ip' or 'cf-connecting-ip'.
🎯 Impact: Attackers could bypass security controls, poison caches, or spoof their identity to upstream services.
🔧 Fix: Hardened `parse_request_head` to strictly reject RFC 7230 violations and expanded `PROVENANCE_HEADERS` blocklist.
✅ Verification: Added new unit tests in `forward.rs` covering these cases and verified that all workspace tests pass.

---
*PR created automatically by Jules for task [2621061920109482580](https://jules.google.com/task/2621061920109482580) started by @vamzi*