### PR TITLE
⚡ Bolt: use BytesMut for O(1) buffer consumption

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-15 - O(1) Buffer Consumption with BytesMut
+**Learning:** Using `Vec<u8>` with `drain(..consumed)` for inbound network buffers introduces an O(N) penalty on every frame decode, as remaining bytes must be shifted to the front of the allocation. While negligible for tiny pings, this becomes a bottleneck for large HTTP bodies or high-throughput streams.
+**Action:** Use `BytesMut` from the `bytes` crate for all stream-based inbound buffers. Use `.put_slice()` for appending and `.advance()` for O(1) consumption.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +182,7 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                buf.lock().await.put_slice(&msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +199,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -837,11 +837,11 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -12,7 +12,7 @@
 #![allow(dead_code)] // different test files use different helpers
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use ed25519_dalek::Signer as _;
 use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -118,7 +118,7 @@ impl Resolve for ScriptedResolve {
 pub struct ClientSession {
     pub client_pc: Arc<RTCPeerConnection>,
     pub dc: Arc<RTCDataChannel>,
-    pub received: Arc<Mutex<Vec<u8>>>,
+    pub received: Arc<Mutex<BytesMut>>,
     pub client_sk: SigningKey,
     pub client_pk: PublicKey,
     pub host_pk: PublicKey,
@@ -251,7 +251,7 @@ pub async fn establish_connection_opts(
         }));
     }
 
-    let received: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let received: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let (dc_open_tx, mut dc_open_rx) = mpsc::channel::<()>(1);
 
     let dc = client_pc
@@ -273,7 +273,7 @@ pub async fn establish_connection_opts(
         let received = Arc::clone(&received_for_dc);
         Box::pin(async move {
             let mut buf = received.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
         })
     }));
 
@@ -434,10 +434,10 @@ async fn wait_and_drain_auth_host(session: &ClientSession) {
     }
 }
 
-async fn drain_prefix(received: &Mutex<Vec<u8>>, n: usize) {
+async fn drain_prefix(received: &Mutex<BytesMut>, n: usize) {
     let mut buf = received.lock().await;
     let take = n.min(buf.len());
-    buf.drain(..take);
+    buf.advance(take);
 }
 
 async fn sign_auth_client(


### PR DESCRIPTION
💡 What: Replaced \`Vec<u8>\` with \`BytesMut\` for the inbound network buffers in both the daemon and the client.

🎯 Why: Using \`Vec::drain(..n)\` on a buffer is an \$O(N)\$ operation because it requires shifting all subsequent bytes. \`BytesMut::advance(n)\` is an \$O(1)\$ operation that simply moves an internal pointer.

📊 Impact: Eliminates the memory-shifting overhead on every frame reception. This improves throughput and reduces CPU usage for high-bandwidth HTTP transactions.

🔬 Measurement: Verified with existing integration tests and unit tests. Performance improvement is algorithmic (\$O(N) \to O(1)\$).

---
*PR created automatically by Jules for task [163405372116727591](https://jules.google.com/task/163405372116727591) started by @vamzi*