### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential request smuggling in header parser

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -380,9 +380,19 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (RFC 7230 §3.2.4) is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
+        if line[..colon].ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header (RFC 7230 §3.2.4) is not allowed",
+            ));
+        }
         let name = line[..colon].trim();
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
@@ -782,6 +792,22 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("whitespace before colon"))
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n X-Custom: folded\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(msg) if msg.contains("line folding")));
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The HTTP header parser was too lenient, allowing whitespace before colons and obsolete line folding (header lines starting with whitespace).
🎯 Impact: Malicious clients could use these to bypass security filters, potentially leading to request smuggling, cache poisoning, or credential hijacking when communicating with upstreams that interpret these malformed headers differently.
🔧 Fix: Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to strictly reject these patterns as per RFC 7230 §3.2.4.
✅ Verification: Added unit tests in `crates/openhost-daemon/src/forward.rs` to ensure these cases are rejected. Ran all daemon tests.

---
*PR created automatically by Jules for task [18065144581952032283](https://jules.google.com/task/18065144581952032283) started by @vamzi*