### PR TITLE
⚡ Bolt: O(1) inbound buffer management via BytesMut

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+# Bolt's Journal - Critical Learnings Only
+
+## 2025-05-15 - Initializing Journal
+**Learning:** Initialized journal for the openhost project.
+**Action:** Keep hunting for performance bottlenecks.
+
+## 2025-05-15 - O(1) Inbound Buffer Management
+**Learning:** Inbound network buffers using `Vec<u8>::drain(..n)` perform in $O(N)$ due to memory shifting, which becomes a bottleneck in high-throughput data channels. Replacing them with `bytes::BytesMut` and using `.advance(n)` provides $O(1)$ consumption.
+**Action:** Always prefer `BytesMut` for protocol decoders and stream-processing buffers in performance-critical paths.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -158,8 +158,11 @@ impl Drop for OpenhostSession {
 
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
+///
+/// Uses `BytesMut` for O(1) buffer consumption via `.advance(n)`,
+/// matching the daemon's performance-critical network logic.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +177,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +185,7 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                buf.lock().await.put_slice(&msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +202,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,9 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    // Inbound network buffer. Uses `BytesMut` for O(1) consumption via
+    // `.advance(n)`, avoiding the O(N) memory-shifting cost of `Vec::drain`.
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -837,11 +839,11 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,

--- a/crates/openhost-daemon/tests/support/mod.rs
+++ b/crates/openhost-daemon/tests/support/mod.rs
@@ -12,7 +12,7 @@
 #![allow(dead_code)] // different test files use different helpers
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use ed25519_dalek::Signer as _;
 use openhost_core::crypto::auth_bytes_bound;
 use openhost_core::identity::{PublicKey, SigningKey};
@@ -118,7 +118,7 @@ impl Resolve for ScriptedResolve {
 pub struct ClientSession {
     pub client_pc: Arc<RTCPeerConnection>,
     pub dc: Arc<RTCDataChannel>,
-    pub received: Arc<Mutex<Vec<u8>>>,
+    pub received: Arc<Mutex<BytesMut>>,
     pub client_sk: SigningKey,
     pub client_pk: PublicKey,
     pub host_pk: PublicKey,
@@ -251,7 +251,7 @@ pub async fn establish_connection_opts(
         }));
     }
 
-    let received: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let received: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let (dc_open_tx, mut dc_open_rx) = mpsc::channel::<()>(1);
 
     let dc = client_pc
@@ -273,7 +273,7 @@ pub async fn establish_connection_opts(
         let received = Arc::clone(&received_for_dc);
         Box::pin(async move {
             let mut buf = received.lock().await;
-            buf.extend_from_slice(&msg.data);
+            buf.put_slice(&msg.data);
         })
     }));
 
@@ -434,10 +434,10 @@ async fn wait_and_drain_auth_host(session: &ClientSession) {
     }
 }
 
-async fn drain_prefix(received: &Mutex<Vec<u8>>, n: usize) {
+async fn drain_prefix(received: &Mutex<BytesMut>, n: usize) {
     let mut buf = received.lock().await;
     let take = n.min(buf.len());
-    buf.drain(..take);
+    buf.advance(take);
 }
 
 async fn sign_auth_client(


### PR DESCRIPTION
💡 What: Migrated inbound network buffers in both the daemon and client from `Vec<u8>` to `bytes::BytesMut`.

🎯 Why: `Vec::drain(..n)` is an $O(N)$ operation because it requires shifting all subsequent bytes in memory. For high-throughput or large-payload data channels, this overhead accumulates and can become a bottleneck.

📊 Impact: Achieves $O(1)$ buffer consumption via `BytesMut::advance(n)`, which simply adjusts an internal pointer/offset instead of copying memory.

🔬 Measurement: Verified that all workspace tests and key integration tests (`end_to_end`, `forward`, `listener`) pass, ensuring functional correctness with improved efficiency.

---
*PR created automatically by Jules for task [14028518413270053032](https://jules.google.com/task/14028518413270053032) started by @vamzi*