### PR TITLE
🛡️ Sentinel: [security improvement] strip more provenance headers

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -591,6 +593,14 @@ mod tests {
         h.insert(
             HeaderName::from_static("x-forwarded-proto"),
             HeaderValue::from_static("https"),
+        );
+        h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("1.1.1.1"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("2.2.2.2"),
         );
         h.insert(
             HeaderName::from_static("x-custom"),


### PR DESCRIPTION
💡 What: Added `true-client-ip` and `cf-connecting-ip` to the `PROVENANCE_HEADERS` list in the daemon's HTTP forwarder.

🎯 Why: These headers are used by CDNs to convey the original client IP. By explicitly stripping them, we prevent clients from injecting these headers to spoof their IP address or bypass IP-based controls when the daemon is deployed behind a proxy/CDN.

📊 Impact: Improved defense-in-depth against header-based identity spoofing and SSRF.

🔬 Measurement: Updated `fresh_headers` test helper to include these headers and verified that `sanitize_strips_all_provenance_headers` passes. Full suite ran via `cargo test -p openhost-daemon`.

---
*PR created automatically by Jules for task [11950267969917190525](https://jules.google.com/task/11950267969917190525) started by @vamzi*