### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden HTTP request head parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - HTTP Request Smuggling Prevention
+**Vulnerability:** HTTP Request Smuggling due to lax RFC 7230 compliance in hand-rolled parser.
+**Learning:** Hand-rolled HTTP parsers often miss security-critical edge cases like whitespace before colons or obsolete line folding (obs-fold) that standard libraries handle. These can be exploited for request smuggling.
+**Prevention:** Strictly implement RFC constraints in custom parsers and include negative tests for forbidden whitespace and line-folding patterns.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound request head exceeded the 32 KiB security limit.
+    #[error("request head exceeded {limit} byte cap")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum permitted request head size (line + headers + terminator)
+/// in bytes. 32 KiB is more than enough for any reasonable service
+/// while protecting against memory exhaustion from oversized headers.
+const MAX_HEAD_BYTES: usize = 32768;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -64,6 +69,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -341,6 +348,12 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadTooLarge {
+            limit: MAX_HEAD_BYTES,
+        });
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -380,10 +393,27 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        // RFC 7230 §3.2.4: Reject obsolete line folding (header lines
+        // beginning with whitespace).
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (obs-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        // RFC 7230 §3.2.4: No whitespace is allowed between the header
+        // field-name and colon.
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before header colon is not supported",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +623,14 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.9.9.9"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("10.10.10.10"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +799,37 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        let mut raw = b"GET / HTTP/1.1\r\n".to_vec();
+        raw.extend(vec![b'X'; MAX_HEAD_BYTES]);
+        raw.extend_from_slice(b": v\r\n\r\n");
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadTooLarge { limit } if limit == MAX_HEAD_BYTES));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("whitespace before header colon is not supported")
+        ));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Folded-Value\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("obsolete line folding (obs-fold) is not supported")
+        ));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Hand-rolled HTTP parser allowed RFC 7230 violations (whitespace before colon, line folding) and lacked a request-head size limit.
🎯 Impact: Could lead to HTTP Request Smuggling or memory exhaustion (DoS).
🔧 Fix: Implemented strict RFC 7230 validation and a 32 KiB head limit in `parse_request_head`.
✅ Verification: Added 3 new unit tests verifying rejection of oversized heads, malformed whitespace, and line folding.

---
*PR created automatically by Jules for task [7591012936160473930](https://jules.google.com/task/7591012936160473930) started by @vamzi*