### PR TITLE
🛡️ Sentinel: Harden HTTP forwarder against smuggling and IP spoofing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Hardening Hand-rolled HTTP Parser against Smuggling
+**Vulnerability:** HTTP Request Smuggling (Desync) via malformed headers.
+**Learning:** Hand-rolled HTTP parsers often overlook RFC 7230 edge cases like whitespace before colons and obsolete line folding (obs-fold). Malicious clients can use these to desync a proxy from its upstream, potentially smuggling a second request.
+**Prevention:** Always enforce strict RFC 7230 compliance in manual parsers: reject any header line starting with whitespace and reject whitespace between the header name and the colon.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -380,10 +382,23 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding (obs-fold) is not supported",
+            ));
+        }
+
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name is not allowed",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +608,14 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.10.11.12"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("13.14.15.16"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -745,6 +768,20 @@ mod tests {
     }
 
     // --- Request head parser ----------------------------------------
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n Folded-Value\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
 
     #[test]
     fn parse_request_head_happy_path() {


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability:
1. **HTTP Request Smuggling (Desync) via malformed headers**: The manual HTTP/1.1 parser in the daemon's forwarder accepted whitespace before colons and obsolete line folding (obs-fold), which are forbidden by RFC 7230 and can be used for request smuggling attacks.
2. **IP Provenance Spoofing**: Several common CDN headers (`true-client-ip`, `cf-connecting-ip`) were not stripped from inbound requests, potentially allowing clients to spoof their source IP to upstream services.

🎯 Impact:
- Malicious clients could potentially desync the `openhost-daemon` from its upstream service, leading to request smuggling.
- Attackers could bypass IP-based controls if the upstream service trusts the un-stripped provenance headers.

🔧 Fix:
- Strictified `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to explicitly reject obs-fold and whitespace before colons.
- Added `true-client-ip` and `cf-connecting-ip` to the `PROVENANCE_HEADERS` list and the `fresh_headers` test utility.

✅ Verification:
- Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_rejects_obs_fold` to verify the new rejection criteria.
- Verified that all workspace tests pass via `cargo test --workspace`.
- Confirmed no regressions in existing header sanitization logic.

---
*PR created automatically by Jules for task [17336800257191568908](https://jules.google.com/task/17336800257191568908) started by @vamzi*