### PR TITLE
⚡ Bolt: optimize answer fragment reassembly

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-01-24 - [Optimizing DNS Fragment Reassembly]
+**Learning:** `pkarr::SignedPacket::all_resource_records()` is significantly more efficient than multiple `.resource_records(name)` probes for fragmented records. However, DNS names in the underlying `simple-dns` types are fully qualified and include the packet origin.
+**Action:** When scanning all resource records for specific prefixes/suffixes, always use `strip_prefix` and robustly parse components (e.g., using `.split('.').next()`) to handle the FQDN structure correctly.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,45 +1098,65 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Single pass over all resource records to bucket-sort answer fragments.
+    // Replaces the previous O(N^2) multi-probe approach.
+    let suffix_prefix = format!("{base}-");
+    let mut buckets: Vec<Option<DecodedFragment>> = (0..256).map(|_| None).collect();
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            let name_str = rr.name.to_string();
+            // simple-dns names might have a trailing dot, and they include the
+            // packet's root origin. We only care about matching our prefix.
+            if let Some(rest) = name_str.strip_prefix(&suffix_prefix) {
+                let idx_str = rest.split('.').next().unwrap_or("");
+                let idx: u8 = idx_str.parse().map_err(|_| {
+                    PkarrError::MalformedCanonical("answer fragment suffix is not a u8")
+                })?;
+
+                if buckets[idx as usize].is_some() {
+                    return Err(PkarrError::MultipleOpenhostRecords);
+                }
+
+                let mut out = String::new();
+                for (key, value) in txt.iter_raw() {
+                    out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+                    if let Some(v) = value {
+                        out.push('=');
+                        out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+                    }
+                }
+
+                let bytes = URL_SAFE_NO_PAD.decode(out.as_bytes())?;
+                let frag = decode_fragment(&bytes)?;
+
+                if frag.idx != idx {
+                    return Err(PkarrError::MalformedCanonical(
+                        "answer fragment idx disagrees with its DNS label suffix",
+                    ));
+                }
+                buckets[idx as usize] = Some(frag);
+            }
+        }
+    }
+
+    let Some(first) = buckets[0].take() else {
         return Ok(None);
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
-        return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
-        ));
-    }
-    let total = first.total;
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
+    let total = first.total;
+    let mut fragments = Vec::with_capacity(total as usize);
     fragments.push(first);
+
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
+        let frag = buckets[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         if frag.total != total {
             return Err(PkarrError::MalformedCanonical(
                 "answer fragments disagree on chunk_total",
-            ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
             ));
         }
         fragments.push(frag);


### PR DESCRIPTION
Optimized the `decode_answer_fragments_from_packet` function in `crates/openhost-pkarr/src/offer.rs` by replacing the previous $O(N^2)$ multi-probe approach with a single-pass loop. 

The new implementation:
1. Iterates over all resource records once using `packet.all_resource_records()`.
2. Bucket-sorts relevant `_answer-*` TXT records into a pre-allocated array based on their fragment index.
3. Robustly parses DNS names to handle fully-qualified labels provided by the underlying DNS library.
4. Maintains all existing security and consistency validations.

This change directly addresses a `TODO(perf)` and ensures that answer reassembly remains efficient even in pathological cases with many fragments.

---
*PR created automatically by Jules for task [7395101846440767282](https://jules.google.com/task/7395101846440767282) started by @vamzi*