### PR TITLE
🛡️ Sentinel: Harden HTTP forwarder and expand IP-spoofing protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - HTTP Header Parsing Strictness (RFC 7230)
+**Vulnerability:** HTTP Request Smuggling / IP Spoofing
+**Learning:** Proxies must strictly enforce RFC 7230 §3.2.4 by rejecting whitespace before colons and obsolete line folding (obs-fold) to prevent desynchronization with upstreams. Additionally, provenance headers like `true-client-ip` and `cf-connecting-ip` must be explicitly stripped to prevent IP spoofing when behind CDNs.
+**Prevention:** Implement strict header validation in the initial parsing stage and maintain a comprehensive allowlist/denylist for provenance headers.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -380,10 +382,21 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: OBS fold is deprecated and MUST be rejected.
+            return Err(ForwardError::HeadParse("obsolete line folding is rejected"));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: No whitespace allowed before colon.
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is rejected",
+            ));
+        }
+        let name = name.trim();
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +606,14 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.10.11.12"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("13.14.15.16"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +782,28 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        if let ForwardError::HeadParse(reason) = err {
+            assert_eq!(reason, "whitespace before colon is rejected");
+        } else {
+            panic!("expected HeadParse error");
+        }
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n  continuation\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        if let ForwardError::HeadParse(reason) = err {
+            assert_eq!(reason, "obsolete line folding is rejected");
+        } else {
+            panic!("expected HeadParse error");
+        }
     }
 
     #[test]

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -317,6 +317,8 @@ async fn forwarder_strips_hop_by_hop_and_provenance_before_upstream() -> DaemonR
                  Transfer-Encoding: chunked\r\n\
                  X-Forwarded-For: 10.0.0.1\r\n\
                  X-Real-IP: 10.0.0.2\r\n\
+                 True-Client-IP: 10.0.0.3\r\n\
+                 CF-Connecting-IP: 10.0.0.4\r\n\
                  Forwarded: by=attacker\r\n\
                  X-Custom: retained\r\n\
                  \r\n";
@@ -340,6 +342,8 @@ async fn forwarder_strips_hop_by_hop_and_provenance_before_upstream() -> DaemonR
         "x-forwarded-proto",
         "forwarded",
         "x-real-ip",
+        "true-client-ip",
+        "cf-connecting-ip",
     ];
     for bad in banned {
         assert!(


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential HTTP Request Smuggling and IP Spoofing.
🎯 Impact: Attackers could potentially smuggle requests to upstreams or spoof their source IP address (bypassing IP-based ACLs) by exploiting lax header parsing or common CDN provenance headers.
🔧 Fix:
- Updated `parse_request_head` to strictly enforce RFC 7230 §3.2.4 (reject whitespace before colons and obs-fold).
- Added Akamai (`true-client-ip`) and Cloudflare (`cf-connecting-ip`) to the stripped `PROVENANCE_HEADERS`.
✅ Verification:
- New unit tests in `forward.rs` cover the strict parsing rules.
- Updated integration test `forwarder_strips_hop_by_hop_and_provenance_before_upstream` verifies the new headers are stripped.
- All workspace tests passed.

---
*PR created automatically by Jules for task [17728861122049443674](https://jules.google.com/task/17728861122049443674) started by @vamzi*