### PR TITLE
⚡ Bolt: optimize answer fragment reassembly to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Optimize answer fragment reassembly]
+**Learning:** Fragment reassembly via repeated `packet.resource_records(name)` calls leads to $O(N \times M)$ complexity, which becomes pathological as the number of answers and fragments per answer grows. `packet.all_resource_records()` allows for a single-pass $O(N)$ reassembly using bucket sorting.
+**Action:** Always prefer a single pass over `all_resource_records()` when reassembling multi-fragment records or scanning for multiple client hashes in one packet.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1093,53 +1093,98 @@ pub fn decode_answer_fragments_from_packet(
     client_pk: &PublicKey,
 ) -> Result<Option<AnswerEntry>> {
     let client_hash = allowlist_hash(daemon_salt, &client_pk.to_bytes());
-    let base = format!(
-        "{ANSWER_TXT_PREFIX}{}",
-        zbase32::encode_full_bytes(&client_hash)
-    );
+    let client_hash_z32 = zbase32::encode_full_bytes(&client_hash);
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // O(N) single-pass reassembly: walk all RRs once and bucket-sort
+    // matching fragments by their numeric `-<idx>` suffix.
+    // Size 256 handles all possible u8 indices safely.
+    let mut buckets: Vec<Option<DecodedFragment>> = (0..256).map(|_| None).collect();
+    let mut total: Option<u8> = None;
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        let name_str = rr.name.to_string();
+        // Split into labels; openhost answer fragments are always in the first label.
+        let Some(first_label) = name_str.split('.').next() else {
+            continue;
+        };
+
+        let mut parts = first_label.split('-');
+        // Expected parts: ["_answer", "<hash>", "<idx>"]
+        if !parts
+            .next()
+            .is_some_and(|p| p.eq_ignore_ascii_case("_answer"))
+        {
+            continue;
+        }
+        if !parts
+            .next()
+            .is_some_and(|p| p.eq_ignore_ascii_case(&client_hash_z32))
+        {
+            continue;
+        }
+        let Some(idx_str) = parts.next() else {
+            continue;
+        };
+        let idx: u8 = match idx_str.parse() {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        if parts.next().is_some() {
+            continue;
+        }
+
+        if let RData::TXT(txt) = &rr.rdata {
+            if buckets[idx as usize].is_some() {
+                // Multiple TXTs at the same fragment name → malformed.
+                return Err(PkarrError::MultipleOpenhostRecords);
+            }
+
+            let text = collect_txt_rdata(txt)?;
+            let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
+            let frag = decode_fragment(&bytes)?;
+
+            if let Some(t) = total {
+                if frag.total != t {
+                    return Err(PkarrError::MalformedCanonical(
+                        "answer fragments disagree on chunk_total",
+                    ));
+                }
+            } else {
+                total = Some(frag.total);
+            }
+
+            if frag.idx != idx {
+                return Err(PkarrError::MalformedCanonical(
+                    "answer fragment idx disagrees with its DNS label suffix",
+                ));
+            }
+
+            buckets[idx as usize] = Some(frag);
+        }
+    }
+
+    // Missing zero-fragment ⇒ no answer for us.
+    let Some(first) = buckets[0].take() else {
         return Ok(None);
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
-        return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
-        ));
-    }
     let total = first.total;
 
     let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
     fragments.push(first);
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
-        if frag.total != total {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragments disagree on chunk_total",
-            ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
-            ));
-        }
+        let frag = buckets[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         fragments.push(frag);
+    }
+
+    // Extraneous fragments beyond 'total' are a malformed packet.
+    if buckets.iter().skip(total as usize).any(|b| b.is_some()) {
+        return Err(PkarrError::MalformedCanonical(
+            "extraneous answer fragment beyond total",
+        ));
     }
 
     let mut sealed = Vec::with_capacity(fragments.iter().map(|f| f.payload.len()).sum());
@@ -1167,13 +1212,7 @@ fn collect_single_txt(packet: &SignedPacket, name: &str) -> Result<Option<String
                 // Multiple TXTs at the same name → malformed.
                 return Err(PkarrError::MultipleOpenhostRecords);
             }
-            for (key, value) in txt.iter_raw() {
-                out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
-                if let Some(v) = value {
-                    out.push('=');
-                    out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
-                }
-            }
+            out = collect_txt_rdata(txt)?;
         }
     }
     if seen == 0 {
@@ -1181,6 +1220,18 @@ fn collect_single_txt(packet: &SignedPacket, name: &str) -> Result<Option<String
     } else {
         Ok(Some(out))
     }
+}
+
+fn collect_txt_rdata(txt: &TXT) -> Result<String> {
+    let mut out = String::new();
+    for (key, value) in txt.iter_raw() {
+        out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+        if let Some(v) = value {
+            out.push('=');
+            out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+        }
+    }
+    Ok(out)
 }
 
 // ============================================================================
@@ -3068,6 +3119,41 @@ mod tests {
             reassembled.extend_from_slice(&f.payload);
         }
         assert_eq!(reassembled, sealed);
+    }
+
+    #[test]
+    fn large_answer_fragments_reassemble_single_pass() {
+        let sk = host_sk();
+        let client_pk = client_sk().public_key();
+        let salt = [0x33u8; SALT_LEN];
+
+        // 2 fragments.
+        let sealed = (0u8..=u8::MAX).cycle().take(600).collect::<Vec<u8>>();
+        let fragments = split_into_fragments(&sealed).unwrap();
+        assert_eq!(fragments.len(), 2);
+
+        let client_hash = allowlist_hash(&salt, &client_pk.to_bytes());
+        let label = zbase32::encode_full_bytes(&client_hash);
+        let base = format!("{ANSWER_TXT_PREFIX}{label}");
+
+        let seed = Zeroizing::new(sk.to_bytes());
+        let keypair = Keypair::from_secret_key(&seed);
+        let mut builder = SignedPacket::builder();
+
+        for (i, frag) in fragments.into_iter().enumerate() {
+            builder = builder.txt(
+                Name::new_unchecked(&format!("{base}-{i}")),
+                TXT::try_from(URL_SAFE_NO_PAD.encode(&frag).as_str()).unwrap(),
+                OFFER_TXT_TTL,
+            );
+        }
+
+        let packet = builder.sign(&keypair).unwrap();
+
+        let reassembled = decode_answer_fragments_from_packet(&packet, &salt, &client_pk)
+            .unwrap()
+            .expect("fragments present");
+        assert_eq!(reassembled.sealed, sealed);
     }
 
     #[test]


### PR DESCRIPTION
💡 What: Optimized `decode_answer_fragments_from_packet` to use a single pass over the packet's resource records.
🎯 Why: The original implementation performed multiple full-packet scans, leading to quadratic complexity in the number of answers and fragments.
📊 Impact: Reduces reassembly complexity from $O(N \times M)$ to $O(N)$.
🔬 Measurement: Verified with `large_answer_fragments_reassemble_single_pass` test case and existing suite.

---
*PR created automatically by Jules for task [8482858635619775385](https://jules.google.com/task/8482858635619775385) started by @vamzi*