### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP Smuggling and IP Spoofing Risks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Strict HTTP Forwarding Sanatization
+**Vulnerability:** Potential HTTP Request Smuggling and IP Spoofing in the localhost forwarder.
+**Learning:** The initial `parse_request_head` implementation was too permissive, allowing whitespace before colons and obsolete line folding (`obs-fold`), both of which are exploited in smuggling attacks. Additionally, common CDN provenance headers like `true-client-ip` and `cf-connecting-ip` were not being stripped, allowing clients to potentially spoof their origin IP to upstream services.
+**Prevention:** Always use strict RFC 7230 parsing for manual HTTP reconstruction. In Rust, ensure `HeaderMap` insertions from untrusted sources are preceded by explicit validation against `obs-fold` and whitespace-prefixed/suffixed header names.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -380,12 +382,22 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 
     let mut headers = HeaderMap::new();
     for line in lines {
+        if line.starts_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "obsolete line folding is not supported",
+            ));
+        }
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name is prohibited",
+            ));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -593,6 +605,14 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.10.11.12"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("13.14.15.16"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +781,29 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("whitespace before colon"))
+        );
+    }
+
+    #[test]
+    fn parse_request_head_rejects_obs_fold() {
+        // RFC 7230 §3.2.4: "A sender MUST NOT generate ob-fold ... A
+        // recipient SHOULD treat such a request as invalid". We choose
+        // to reject it.
+        let raw = b"GET / HTTP/1.1\r\nHost: example\r\n  Folded-Header: yes\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("obsolete line folding"))
+        );
     }
 
     #[test]

--- a/crates/openhost-daemon/tests/real_pkarr.rs
+++ b/crates/openhost-daemon/tests/real_pkarr.rs
@@ -15,7 +15,7 @@
 #![cfg(feature = "real-network")]
 
 use openhost_daemon::config::{
-    Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
+    BindingModeConfig, Config, DtlsConfig, IdentityConfig, IdentityStore, LogConfig, PkarrConfig,
 };
 use openhost_daemon::App;
 use openhost_pkarr::{PkarrResolve, Resolver};
@@ -38,6 +38,7 @@ fn real_config(dir: &TempDir) -> Config {
         dtls: DtlsConfig {
             cert_path: dir.path().join("dtls.pem"),
             rotate_secs: 3600,
+            allowed_binding_modes: vec![BindingModeConfig::Exporter, BindingModeConfig::CertFp],
         },
         forward: None,
         log: LogConfig::default(),


### PR DESCRIPTION
This PR addresses potential HTTP request smuggling and IP spoofing vulnerabilities in the `openhost-daemon`'s localhost forwarder.

### 🚨 Severity: HIGH (Defense in Depth)

### 💡 Vulnerability:
1. **HTTP Request Smuggling:** The `parse_request_head` function was previously too permissive, allowing whitespace before the colon in header lines and not explicitly rejecting obsolete line folding (`obs-fold`). Attackers can exploit these behaviors to hide headers or desynchronize proxies.
2. **Provenance Spoofing:** While some headers like `X-Forwarded-For` were stripped, common CDN-specific IP headers (`true-client-ip` and `cf-connecting-ip`) were preserved, allowing a malicious openhost client to spoof their IP address to the upstream local service.

### 🎯 Impact:
A malicious client could potentially bypass IP-based rate limits or ACLs on the upstream service, or mount request smuggling attacks if the upstream is an older or more permissive HTTP implementation.

### 🔧 Fix:
- Updated `PROVENANCE_HEADERS` to include `true-client-ip` and `cf-connecting-ip`.
- Refined `parse_request_head` to strictly enforce RFC 7230 §3.2.4 by rejecting whitespace between the field-name and colon.
- Explicitly rejected obsolete line folding.
- Switched to `trim_matches` for header values to ensure all optional whitespace (SP and HTAB) is removed.

### ✅ Verification:
- Added `parse_request_head_rejects_whitespace_before_colon` unit test.
- Added `parse_request_head_rejects_obs_fold` unit test.
- Updated `fresh_headers` and `sanitize_strips_all_provenance_headers` to cover the new IP headers.
- Ran `cargo test -p openhost-daemon` and `cargo test --workspace` to ensure no regressions.

---
*PR created automatically by Jules for task [1029861744849311450](https://jules.google.com/task/1029861744849311450) started by @vamzi*