### PR TITLE
🛡️ Sentinel: Sanitize `True-Client-IP` and `CF-Connecting-IP`

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -591,6 +593,14 @@ mod tests {
         h.insert(
             HeaderName::from_static("x-forwarded-proto"),
             HeaderValue::from_static("https"),
+        );
+        h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.10.11.12"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("13.14.15.16"),
         );
         h.insert(
             HeaderName::from_static("x-custom"),

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -317,6 +317,8 @@ async fn forwarder_strips_hop_by_hop_and_provenance_before_upstream() -> DaemonR
                  Transfer-Encoding: chunked\r\n\
                  X-Forwarded-For: 10.0.0.1\r\n\
                  X-Real-IP: 10.0.0.2\r\n\
+                 True-Client-IP: 10.0.0.3\r\n\
+                 CF-Connecting-IP: 10.0.0.4\r\n\
                  Forwarded: by=attacker\r\n\
                  X-Custom: retained\r\n\
                  \r\n";
@@ -340,6 +342,8 @@ async fn forwarder_strips_hop_by_hop_and_provenance_before_upstream() -> DaemonR
         "x-forwarded-proto",
         "forwarded",
         "x-real-ip",
+        "true-client-ip",
+        "cf-connecting-ip",
     ];
     for bad in banned {
         assert!(


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 Vulnerability: The localhost forwarder was missing some common provenance headers used by edge proxies (Cloudflare, Akamai) in its sanitization list.
🎯 Impact: Malicious clients could potentially spoof their IP addresses to bypass upstream security controls.
🔧 Fix: Added `True-Client-IP` and `CF-Connecting-IP` to the list of headers stripped before forwarding to upstream.
✅ Verification: Added these headers to the unit test `fresh_headers` and the integration test `forwarder_strips_hop_by_hop_and_provenance_before_upstream`. All tests passed.

---
*PR created automatically by Jules for task [4773385464227564838](https://jules.google.com/task/4773385464227564838) started by @vamzi*