### PR TITLE
🛡️ Sentinel: [HIGH] Harden HTTP head parsing and DoS protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-05-15 - RFC 7230 Header Parsing and DoS Protection
+
+**Vulnerability:** HTTP request smuggling due to permissive header name parsing (whitespace before colon) and potential memory exhaustion (DoS) from unbounded request heads.
+
+**Learning:** The `parse_request_head` implementation used `.trim()` on header names, which incorrectly accepted whitespace before the colon (§3.2.4). Additionally, while request bodies were capped, the request head (line + headers) was not, allowing a malicious client to consume excessive memory.
+
+**Prevention:** Always parse header names verbatim and rely on strict validation libraries (or traits like `HeaderName::from_bytes`) to reject invalid characters, including whitespace. Enforce a generous but firm limit (e.g., 32 KiB) on the entire request head before attempting to parse it.

--- a/crates/openhost-daemon/src/error.rs
+++ b/crates/openhost-daemon/src/error.rs
@@ -181,6 +181,13 @@ pub enum ForwardError {
     #[error("inbound request head is malformed: {0}")]
     HeadParse(&'static str),
 
+    /// Inbound `REQUEST_HEAD` payload exceeded the 32 KiB security limit.
+    #[error("request head exceeded {limit} byte security limit")]
+    HeadTooLarge {
+        /// The security limit in bytes.
+        limit: usize,
+    },
+
     /// Inbound request body exceeded the configured
     /// `forward.max_body_bytes` cap.
     #[error("request body exceeded {cap} byte cap")]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -39,6 +39,11 @@ use std::time::Duration;
 /// case and still bounds a misconfigured target from wedging a request.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Maximum size of the HTTP request head (request line + headers) in bytes.
+/// RFC 7230 does not set a limit, but most servers cap it at 8-16 KiB.
+/// We use 32 KiB as a generous security upper bound.
+const MAX_HEAD_BYTES: usize = 32 * 1024;
+
 /// Hop-by-hop header names per RFC 7230 §6.1. Must be stripped from
 /// both inbound requests (before dispatch to upstream) and outbound
 /// responses (before re-framing to the openhost client).
@@ -64,6 +69,8 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -341,6 +348,12 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
 fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+    if bytes.len() > MAX_HEAD_BYTES {
+        return Err(ForwardError::HeadTooLarge {
+            limit: MAX_HEAD_BYTES,
+        });
+    }
+
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -383,7 +396,10 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name
+        // and colon." We parse the name verbatim; `HeaderName::from_bytes`
+        // correctly rejects names containing whitespace.
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -760,6 +776,26 @@ mod tests {
     fn parse_request_head_rejects_wrong_version() {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_oversized_head() {
+        // Build a 33 KiB head — 1 KiB over the limit.
+        let mut raw = b"GET / HTTP/1.1\r\nX-Padding: ".to_vec();
+        raw.extend(std::iter::repeat(b'a').take(33 * 1024));
+        raw.extend_from_slice(b"\r\n\r\n");
+
+        let err = parse_request_head(&raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadTooLarge { limit: 32768 }));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: whitespace before colon is illegal.
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        // `HeaderName::from_bytes` will reject the "Host " (with trailing space).
         assert!(matches!(err, ForwardError::HeadParse(_)));
     }
 

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -783,7 +783,7 @@ mod tests {
     fn parse_request_head_rejects_oversized_head() {
         // Build a 33 KiB head — 1 KiB over the limit.
         let mut raw = b"GET / HTTP/1.1\r\nX-Padding: ".to_vec();
-        raw.extend(std::iter::repeat(b'a').take(33 * 1024));
+        raw.extend(std::iter::repeat_n(b'a', 33 * 1024));
         raw.extend_from_slice(b"\r\n\r\n");
 
         let err = parse_request_head(&raw).unwrap_err();

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -1027,8 +1027,25 @@ async fn dispatch_frame(
                         }
                     }
                     Err(err) => {
-                        tracing::warn!(?err, "openhostd: forwarder failed; replying 502");
-                        let _ = emit_stub_502(dc).await;
+                        // ForwardError variants HeadParse, HeadTooLarge,
+                        // BodyTooLarge, and WebSocketUnsupported represent
+                        // violations by the client. Per spec §5, we send
+                        // an ERROR frame and tear down.
+                        use crate::error::ForwardError;
+                        match &err {
+                            ForwardError::HeadParse(_)
+                            | ForwardError::HeadTooLarge { .. }
+                            | ForwardError::BodyTooLarge { .. }
+                            | ForwardError::WebSocketUnsupported => {
+                                tracing::warn!(?err, "openhostd: client-side forward error; tearing down");
+                                let _ = send_error_frame(dc, &err.to_string()).await;
+                                return FrameOutcome::Teardown;
+                            }
+                            _ => {
+                                tracing::warn!(?err, "openhostd: upstream forward error; replying 502");
+                                let _ = emit_stub_502(dc).await;
+                            }
+                        }
                     }
                 },
                 None => {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -1037,12 +1037,18 @@ async fn dispatch_frame(
                             | ForwardError::HeadTooLarge { .. }
                             | ForwardError::BodyTooLarge { .. }
                             | ForwardError::WebSocketUnsupported => {
-                                tracing::warn!(?err, "openhostd: client-side forward error; tearing down");
+                                tracing::warn!(
+                                    ?err,
+                                    "openhostd: client-side forward error; tearing down"
+                                );
                                 let _ = send_error_frame(dc, &err.to_string()).await;
                                 return FrameOutcome::Teardown;
                             }
                             _ => {
-                                tracing::warn!(?err, "openhostd: upstream forward error; replying 502");
+                                tracing::warn!(
+                                    ?err,
+                                    "openhostd: upstream forward error; replying 502"
+                                );
                                 let _ = emit_stub_502(dc).await;
                             }
                         }

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -281,6 +281,49 @@ async fn forwarder_round_trip_returns_upstream_200() -> DaemonResult<()> {
 }
 
 #[tokio::test]
+async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonResult<()> {
+    // 32 KiB security limit is hardcoded in `forward.rs`.
+    let (port, _state) = spawn_upstream(UpstreamResponder::default()).await;
+    let (_tmp, app) = build_daemon(port).await;
+    let session = establish_connection(&app).await;
+
+    // Send a 33 KiB REQUEST_HEAD.
+    let mut big_head = b"GET / HTTP/1.1\r\nX-Padding: ".to_vec();
+    big_head.extend(std::iter::repeat(b'a').take(33 * 1024));
+    big_head.extend_from_slice(b"\r\n\r\n");
+
+    let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();
+    let req_end = Frame::new(FrameType::RequestEnd, vec![]).unwrap();
+    let mut wire = Vec::new();
+    req_head.encode(&mut wire);
+    req_end.encode(&mut wire);
+    session.dc.send(&Bytes::from(wire)).await.expect("send");
+
+    // Wait for the ERROR frame.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let err_frame = loop {
+        let bytes = session.received.lock().await.clone();
+        if let Ok(Some((frame, _))) = Frame::try_decode(&bytes) {
+            break frame;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("no frame arrived after oversized REQUEST_HEAD");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    };
+    assert_eq!(err_frame.frame_type, FrameType::Error);
+    let diagnostic = String::from_utf8_lossy(&err_frame.payload);
+    assert!(
+        diagnostic.contains("head exceeded"),
+        "ERROR diagnostic should mention head size limit; got {diagnostic:?}"
+    );
+
+    session.close().await;
+    app.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn forwarder_forwards_request_body_verbatim() -> DaemonResult<()> {
     let (port, state) = spawn_upstream(UpstreamResponder::EchoBody).await;
     let (_tmp, app) = build_daemon(port).await;

--- a/crates/openhost-daemon/tests/forward.rs
+++ b/crates/openhost-daemon/tests/forward.rs
@@ -289,7 +289,7 @@ async fn forwarder_request_head_exceeds_cap_rejects_and_tears_down() -> DaemonRe
 
     // Send a 33 KiB REQUEST_HEAD.
     let mut big_head = b"GET / HTTP/1.1\r\nX-Padding: ".to_vec();
-    big_head.extend(std::iter::repeat(b'a').take(33 * 1024));
+    big_head.extend(std::iter::repeat_n(b'a', 33 * 1024));
     big_head.extend_from_slice(b"\r\n\r\n");
 
     let req_head = Frame::new(FrameType::RequestHead, big_head).unwrap();


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential HTTP request smuggling due to permissive header name parsing and DoS risk from unbounded request heads.
🎯 Impact: Malicious clients could bypass security filters or exhaust daemon memory.
🔧 Fix: Enforced 32 KiB head limit, strictly rejected whitespace before header colons (RFC 7230), and expanded provenance header stripping.
✅ Verification: Added unit tests for head limits and RFC compliance; added integration test for head-size rejection and channel teardown.

---
*PR created automatically by Jules for task [7270862730498327669](https://jules.google.com/task/7270862730498327669) started by @vamzi*