### PR TITLE
⚡ Bolt: optimize answer fragment reassembly

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-24 - [Optimize answer fragment reassembly]
+**Learning:** Reassembling fragmented DNS TXT records by repeatedly probing for specific names using `packet.resource_records(name)` leads to (N \cdot M)$ complexity, where $ is the number of records and $ is the number of fragments.
+**Action:** Use a single pass over all resource records with `packet.all_resource_records()` and a bucket sort to achieve (N)$ complexity for reassembly.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,45 +1098,68 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Single pass over the packet's resource records to collect all
+    // fragments belonging to this client.
+    let mut bucket: [Option<DecodedFragment>; 256] = const { [const { None }; 256] };
+    let base_with_dash = format!("{base}-");
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        let Some(label) = rr.name.get_labels().first() else {
+            continue;
+        };
+        let label_bytes = label.as_ref();
+
+        if label_bytes.starts_with(base_with_dash.as_bytes()) {
+            let idx_bytes = &label_bytes[base_with_dash.len()..];
+            let Ok(idx_str) = core::str::from_utf8(idx_bytes) else {
+                continue;
+            };
+            let Ok(idx) = idx_str.parse::<u8>() else {
+                continue;
+            };
+
+            if let RData::TXT(txt) = &rr.rdata {
+                if bucket[idx as usize].is_some() {
+                    return Err(PkarrError::MultipleOpenhostRecords);
+                }
+                let mut out = String::new();
+                for (key, value) in txt.iter_raw() {
+                    out.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+                    if let Some(v) = value {
+                        out.push('=');
+                        out.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+                    }
+                }
+                let bytes = URL_SAFE_NO_PAD.decode(out.as_bytes())?;
+                let frag = decode_fragment(&bytes)?;
+
+                if frag.idx != idx {
+                    return Err(PkarrError::MalformedCanonical(
+                        "answer fragment idx disagrees with its DNS label suffix",
+                    ));
+                }
+
+                bucket[idx as usize] = Some(frag);
+            }
+        }
+    }
+
+    let Some(first) = bucket[0].take() else {
         return Ok(None);
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
-        return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
-        ));
-    }
     let total = first.total;
 
     let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
     fragments.push(first);
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
+        let frag = bucket[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         if frag.total != total {
             return Err(PkarrError::MalformedCanonical(
                 "answer fragments disagree on chunk_total",
-            ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
             ));
         }
         fragments.push(frag);


### PR DESCRIPTION
💡 What: Replaced the O(N*M) fragment reassembly with a single-pass O(N) bucket sort using `packet.all_resource_records()`.
🎯 Why: Reassembling fragments by repeatedly probing the packet for each index was inefficient, especially as the number of fragments grew.
📊 Impact: Reduces reassembly complexity from O(N*M) to O(N).
🔬 Measurement: Verified with existing tests in `crates/openhost-pkarr`.

---
*PR created automatically by Jules for task [1374468649672814282](https://jules.google.com/task/1374468649672814282) started by @vamzi*