### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling and enhance provenance sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Request Smuggling via Header Name Whitespace
+**Vulnerability:** The HTTP parser allowed whitespace between the header name and the colon (e.g., `Host : example.com`), which violates RFC 7230 §3.2.4 and can lead to request smuggling or cache poisoning if upstream/downstream parsers handle it differently.
+**Learning:** Using `.trim()` on the extracted header name is a common but dangerous pattern that can hide invalid protocol framing.
+**Prevention:** Enforce strict RFC 7230 §3.2.4 compliance by ensuring no whitespace exists between the field name and the colon.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,9 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
+    "x-forwarded-port",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -383,7 +386,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +596,18 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("9.10.11.12"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("13.14.15.16"),
+        );
+        h.insert(
+            HeaderName::from_static("x-forwarded-port"),
+            HeaderValue::from_static("443"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +776,18 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name
+        // and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(m) if m.contains("invalid header name")),
+            "expected 'invalid header name', got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. HTTP Request Smuggling: The `parse_request_head` function allowed whitespace between header names and the colon, violating RFC 7230 §3.2.4.
2. Incomplete Provenance Sanitization: Several sensitive headers (`true-client-ip`, `cf-connecting-ip`, `x-forwarded-port`) were not included in the sanitization allowlist.

🎯 Impact:
1. Request smuggling could allow an attacker to bypass security controls or poison caches by desynchronizing the daemon's parser from upstream/downstream proxies.
2. Missing provenance headers could allow a client to spoof its origin IP or protocol to the upstream service.

🛠️ Fix:
1. Removed `.trim()` from header name extraction in `parse_request_head` to enforce strict RFC compliance.
2. Added `true-client-ip`, `cf-connecting-ip`, and `x-forwarded-port` to `PROVENANCE_HEADERS`.

✅ Verification:
1. Added `parse_request_head_rejects_whitespace_before_colon` test case.
2. Updated `fresh_headers` test helper and verified that `sanitize_strips_all_provenance_headers` now covers the new headers.
3. All tests passed via `cargo test -p openhost-daemon --lib forward::tests`.

---
*PR created automatically by Jules for task [1231990327563139015](https://jules.google.com/task/1231990327563139015) started by @vamzi*