### PR TITLE
🛡️ Sentinel: Harden HTTP header parsing and provenance sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - HTTP Request Smuggling via Header Whitespace
+**Vulnerability:** potential HTTP Request Smuggling (HRS) due to permissive header parsing that allowed whitespace between the field name and the colon.
+**Learning:** RFC 7230 §3.2.4 explicitly forbids whitespace before the colon in a header field. Allowing it can lead to interpretation differences between the openhost proxy and its upstream servers, which is a classic HRS vector.
+**Prevention:** Header names must be extracted exactly as they appear in the request head without trimming; rely on `http::HeaderName::from_bytes` to enforce RFC compliance on the raw name.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -783,7 +783,10 @@ mod tests {
         // RFC 7230 §3.2.4: no whitespace between field-name and colon.
         let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
-        assert!(matches!(err, ForwardError::HeadParse("invalid header name")));
+        assert!(matches!(
+            err,
+            ForwardError::HeadParse("invalid header name")
+        ));
     }
 
     #[test]

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,9 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
+    "x-forwarded-port",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -383,7 +386,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +596,18 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("1.2.3.4"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("5.6.7.8"),
+        );
+        h.insert(
+            HeaderName::from_static("x-forwarded-port"),
+            HeaderValue::from_static("443"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +776,14 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: no whitespace between field-name and colon.
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse("invalid header name")));
     }
 
     #[test]


### PR DESCRIPTION
This PR hardens the daemon's HTTP forwarder against potential Request Smuggling and IP spoofing.

### 🛡️ Hardening Measures

1.  **RFC 7230 Compliance:** The `parse_request_head` function was previously calling `.trim()` on header names. RFC 7230 §3.2.4 explicitly forbids whitespace before the colon. Allowing it can lead to HTTP Request Smuggling (HRS) if the upstream server interprets such headers differently. I've removed the `.trim()` call, ensuring `http::HeaderName::from_bytes` correctly rejects non-compliant formatting.
2.  **Expanded Provenance Sanitization:** Added `true-client-ip`, `cf-connecting-ip`, and `x-forwarded-port` to the `PROVENANCE_HEADERS` list. These are common headers used by CDNs (Akamai, Cloudflare) and load balancers to convey client information. Stripping them on the way in prevents clients from spoofing these values to the home server's upstream services.

### ✅ Verification
- `cargo test -p openhost-daemon` passes with 98 tests (including the new RFC compliance case).
- `cargo test --workspace` passes.
- Verified that `PROVENANCE_HEADERS` are correctly stripped in `forwarder_strips_hop_by_hop_and_provenance_before_upstream`.

---
*PR created automatically by Jules for task [809964479902274933](https://jules.google.com/task/809964479902274933) started by @vamzi*