### PR TITLE
⚡ Bolt: optimize HTTP response head encoding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-06-26 - [Optimizing HTTP Response Head Encoding]
+**Learning:** The `format!` macro and `usize::to_string()` are convenient but cause unnecessary `String` allocations. In high-frequency paths like HTTP response head encoding, these allocations add up. `http::HeaderValue` provides an optimized `From<u64>` implementation that avoids intermediate strings.
+**Action:** Prefer manual `extend_from_slice` with pre-existing byte slices (like `status.as_str().as_bytes()`) and optimized type conversions over `format!` for hot-path buffer construction.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -462,7 +462,12 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT: Avoid format! macro for status line construction.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.extend_from_slice(b" ");
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -519,12 +524,18 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        // BOLT: Use HeaderValue::from(u64) to avoid intermediate String allocation.
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT: Avoid format! macro for status line construction.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.extend_from_slice(b" ");
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What: Optimized the HTTP response head encoding in `crates/openhost-daemon/src/forward.rs` by eliminating unnecessary `String` allocations.

🎯 Why: The previous implementation used `format!` and `to_string()`, which allocate on every response. This is a high-frequency path for the daemon.

📊 Impact: Reduces allocations per response. `HeaderValue::from(u64)` writes directly to an internal buffer, and `extend_from_slice` with pre-existing byte slices avoids the formatting engine overhead.

🔬 Measurement: Verified with `cargo test -p openhost-daemon` to ensure no regression in HTTP response framing.

---
*PR created automatically by Jules for task [15303665394716801210](https://jules.google.com/task/15303665394716801210) started by @vamzi*