### PR TITLE
🛡️ Sentinel: [HIGH] Harden HTTP parsing and provenance stripping

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Strict HTTP Header Parsing and Provenance Sanitization
+**Vulnerability:** HTTP Request Smuggling and IP Spoofing.
+**Learning:** The HTTP/1.1 parser in `crates/openhost-daemon/src/forward.rs` was overly permissive, allowing whitespace before the colon in header fields (violating RFC 7230 §3.2.4). Additionally, several common proxy headers (`true-client-ip`, `cf-connecting-ip`, `x-forwarded-port`) were not being stripped, allowing clients to potentially spoof provenance information.
+**Prevention:** Enforce strict RFC compliance by rejecting any whitespace between the header field-name and the colon. Maintain a comprehensive list of known provenance headers for stripping in proxy/forwarding logic.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,9 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
+    "x-forwarded-port",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -383,7 +386,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +596,18 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("1.1.1.1"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("2.2.2.2"),
+        );
+        h.insert(
+            HeaderName::from_static("x-forwarded-port"),
+            HeaderValue::from_static("443"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -761,6 +776,18 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name
+        // and colon." Permissiveness here allows request smuggling.
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("invalid header name")),
+            "expected 'invalid header name' error for whitespace before colon, got {err:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The HTTP/1.1 request head parser was overly permissive, allowing whitespace before the colon in header fields (RFC 7230 §3.2.4 violation), which can lead to request smuggling. Additionally, several common proxy headers were not being stripped, allowing for potential IP spoofing.

🎯 Impact: An attacker could potentially perform HTTP request smuggling attacks or spoof their origin IP/port to bypass security controls in upstream services.

🔧 Fix:
- Modified `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to remove `.trim()` on the header name, ensuring that any whitespace before the colon causes `HeaderName::from_bytes` to fail.
- Expanded `PROVENANCE_HEADERS` in `crates/openhost-daemon/src/forward.rs` to include `true-client-ip`, `cf-connecting-ip`, and `x-forwarded-port`.
- Updated test helpers and added unit tests to verify these protections.

✅ Verification:
- New test `parse_request_head_rejects_whitespace_before_colon` verifies that malformed headers are rejected.
- Updated `sanitize_strips_all_provenance_headers` verifies that the new headers are correctly stripped.
- All workspace tests passed.

---
*PR created automatically by Jules for task [17699914066476536871](https://jules.google.com/task/17699914066476536871) started by @vamzi*