### PR TITLE
🛡️ Sentinel: Harden HTTP forwarder header parsing and sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - RFC 7230 §3.2.4 Violation in HTTP Header Parsing
+**Vulnerability:** The HTTP/1.1 request head parser in `openhost-daemon` was using `.trim()` on header names, which allowed whitespace between the header field name and the colon (e.g., `Host : example`).
+**Learning:** Over-aggressive trimming during manual HTTP parsing can inadvertently accept malformed headers that are prohibited by RFC 7230 §3.2.4. This creates a risk of HTTP request smuggling if an upstream server interprets the same headers differently.
+**Prevention:** Avoid `.trim()` on header names. Let the underlying header library (like `http::header::HeaderName`) validate the raw bytes from the colon-split to ensure no illegal whitespace is present.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -64,6 +64,9 @@ const PROVENANCE_HEADERS: &[&str] = &[
     "x-forwarded-proto",
     "forwarded",
     "x-real-ip",
+    "true-client-ip",
+    "cf-connecting-ip",
+    "x-forwarded-port",
 ];
 
 type HyperClient = LegacyClient<HttpConnector, Full<Bytes>>;
@@ -383,7 +386,10 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon." We do NOT .trim() the name here;
+        // HeaderName::from_bytes will reject it if it contains spaces.
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -593,6 +599,18 @@ mod tests {
             HeaderValue::from_static("https"),
         );
         h.insert(
+            HeaderName::from_static("true-client-ip"),
+            HeaderValue::from_static("1.1.1.1"),
+        );
+        h.insert(
+            HeaderName::from_static("cf-connecting-ip"),
+            HeaderValue::from_static("2.2.2.2"),
+        );
+        h.insert(
+            HeaderName::from_static("x-forwarded-port"),
+            HeaderValue::from_static("443"),
+        );
+        h.insert(
             HeaderName::from_static("x-custom"),
             HeaderValue::from_static("keep-me"),
         );
@@ -782,6 +800,15 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let res = parse_request_head(raw);
+        assert!(res.is_err(), "Must reject whitespace before colon");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Harden HTTP forwarder header parsing and sanitization

🚨 **Severity:** HIGH
💡 **Vulnerability:** The HTTP/1.1 request head parser incorrectly allowed whitespace between header field names and colons, violating RFC 7230 §3.2.4. Additionally, several common provenance headers used by reverse proxies were not being stripped.
🎯 **Impact:** Potential for HTTP request smuggling (due to parser differential with upstream) and IP spoofing (by injecting provenance headers that might be trusted by the upstream service).
🔧 **Fix:**
- Removed `.trim()` from header name parsing in `parse_request_head` to ensure strict RFC compliance.
- Added `true-client-ip`, `cf-connecting-ip`, and `x-forwarded-port` to the `PROVENANCE_HEADERS` blocklist.
✅ **Verification:**
- Added a reproduction test case `parse_request_head_rejects_whitespace_before_colon` that now correctly fails on malformed input.
- Updated `fresh_headers` and verified that `sanitize_strips_all_provenance_headers` correctly removes the new headers.
- All workspace tests passed.

---
*PR created automatically by Jules for task [16155805183820351424](https://jules.google.com/task/16155805183820351424) started by @vamzi*