### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 §3.2.4 whitespace violation in HTTP parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - HTTP Header Smuggling via Whitespace Lenience
+**Vulnerability:** The HTTP/1.1 request head parser incorrectly accepted whitespace before the colon in header fields (e.g., `Host : example.com`).
+**Learning:** Using `.trim()` on header names before validation can bypass RFC-mandated strictness. In `openhost-daemon`, this was being done before passing the name to `http::HeaderName::from_bytes`.
+**Prevention:** Avoid manual trimming of protocol-critical identifiers. Delegate validation to established libraries (like the `http` crate) using the raw, untrimmed bytes from the wire.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,7 +383,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +782,19 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let result = parse_request_head(raw);
+        assert!(
+            result.is_err(),
+            "Parser incorrectly accepted whitespace before colon: {:?}",
+            result.ok().map(|(_, _, h)| h)
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The HTTP/1.1 request head parser incorrectly accepted whitespace before the colon in header fields (e.g., `Host : example.com`).
🎯 Impact: This violation of RFC 7230 §3.2.4 could lead to HTTP Request Smuggling or Response Splitting in certain proxy configurations.
🔧 Fix: Removed the `.trim()` call on the header name in `parse_request_head`, allowing the `http` crate's `HeaderName` type to correctly validate and reject names with whitespace.
✅ Verification: Added a unit test to `crates/openhost-daemon/src/forward.rs` that specifically checks for this condition and confirmed it fails without the fix and passes with it. Also ran all workspace tests to ensure no regressions.

---
*PR created automatically by Jules for task [7515099733017378963](https://jules.google.com/task/7515099733017378963) started by @vamzi*