### PR TITLE
⚡ Bolt: optimize network buffering and HTTP construction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Buffer Management and Header Construction]
+**Learning:** `Vec::drain(..n)` is an $O(N)$ operation because it requires shifting all remaining elements to the front of the vector. For inbound network buffers that accumulate data, this can lead to $O(N^2)$ complexity. `BytesMut::advance(n)` from the `bytes` crate provides $O(1)$ buffer consumption by adjusting an internal offset. Additionally, `HeaderValue::from(u64)` is more efficient than `u16_val.to_string().parse()` or `HeaderValue::from_str(&val.to_string())` as it avoids intermediate string allocations.
+**Action:** Use `BytesMut` for network buffers and `HeaderValue::from(u64)` for numeric headers like `Content-Length`.

--- a/crates/openhost-client/src/session.rs
+++ b/crates/openhost-client/src/session.rs
@@ -15,7 +15,7 @@
 //! one DC is not yet supported end-to-end).
 
 use crate::error::{ClientError, Result};
-use bytes::Bytes;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::wire::{Frame, FrameType, MAX_PAYLOAD_LEN};
 use std::sync::Arc;
 use std::time::Duration;
@@ -159,7 +159,7 @@ impl Drop for OpenhostSession {
 /// Inbound frame reader. Wraps the DC's `on_message` buffer + a
 /// `Notify` the reader awaits when it runs out of frames to decode.
 pub struct SessionInboundReader {
-    buffer: Arc<Mutex<Vec<u8>>>,
+    buffer: Arc<Mutex<BytesMut>>,
     notify: Arc<Notify>,
 }
 
@@ -174,7 +174,7 @@ impl SessionInboundReader {
     /// lost-wakeup for exactly that race window, and the binding
     /// handshake's first frame is the common case where it fires.
     pub(crate) fn install(dc: &Arc<RTCDataChannel>) -> Self {
-        let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
         let notify: Arc<Notify> = Arc::new(Notify::new());
         let buf_for_msg = Arc::clone(&buffer);
         let notify_for_msg = Arc::clone(&notify);
@@ -182,7 +182,8 @@ impl SessionInboundReader {
             let buf = Arc::clone(&buf_for_msg);
             let notify = Arc::clone(&notify_for_msg);
             Box::pin(async move {
-                buf.lock().await.extend_from_slice(&msg.data);
+                // BOLT: Use BytesMut for O(1) buffer consumption.
+                buf.lock().await.put_slice(&msg.data);
                 notify.notify_one();
             })
         }));
@@ -199,7 +200,7 @@ impl SessionInboundReader {
                 let mut buf = self.buffer.lock().await;
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         return Ok(frame);
                     }
                     Ok(None) => {

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -462,7 +462,13 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT: Manual status line construction to avoid format! overhead.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
+
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -517,14 +523,21 @@ fn encode_response_head(
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
     // frame-split the response stream.
+    // BOLT: HeaderValue::from(u64) avoids string allocations.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // BOLT: Manual status line construction to avoid format! overhead.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
+
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -23,7 +23,7 @@ use crate::channel_binding::{
 use crate::error::ListenerError;
 use crate::forward::{ForwardOutcome, ForwardResponse, Forwarder, WebSocketUpgrade};
 use crate::publish::SharedState;
-use bytes::{Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use openhost_core::identity::{PublicKey, SigningKey};
 use openhost_core::wire::{Frame, FrameType};
 use openhost_pkarr::{AnswerBlob, BindingMode, BlobCandidate, CandidateType, SetupRole};
@@ -747,7 +747,7 @@ async fn wire_frame_loop(
     binding_mode: BindingMode,
     local_dtls_fp: [u8; 32],
 ) {
-    let buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let buffer: Arc<Mutex<BytesMut>> = Arc::new(Mutex::new(BytesMut::new()));
     let request: Arc<Mutex<RequestInProgress>> = Arc::new(Mutex::new(RequestInProgress::default()));
     let binding: Arc<Mutex<BindingState>> = Arc::new(Mutex::new(BindingState::Pending));
     // `Some(tx)` during an active WebSocket tunnel; `None` otherwise.
@@ -837,11 +837,12 @@ async fn wire_frame_loop(
         let forwarder = forwarder.clone();
         Box::pin(async move {
             let mut buf = buffer.lock().await;
-            buf.extend_from_slice(&msg.data);
+            // BOLT: Use BytesMut for O(1) buffer consumption.
+            buf.put_slice(&msg.data);
             loop {
                 match Frame::try_decode(&buf) {
                     Ok(Some((frame, consumed))) => {
-                        buf.drain(..consumed);
+                        buf.advance(consumed);
                         let outcome = dispatch_frame(
                             &frame,
                             &dc,


### PR DESCRIPTION
💡 What:
- Migrated inbound network buffers from `Vec<u8>` with `.drain(..n)` to `BytesMut` with `.advance(n)` in `openhost-daemon` and `openhost-client`.
- Optimized HTTP response head encoding in `openhost-daemon` by replacing `format!` with manual byte slice extensions.
- Replaced `HeaderValue::from_str(&body_len.to_string())` with `HeaderValue::from(body_len as u64)`.

🎯 Why:
- `Vec::drain` is an $O(N)$ operation that can lead to $O(N^2)$ complexity when processing large streams in chunks. `BytesMut::advance` is $O(1)$.
- `format!` and `to_string()` incur runtime parsing and intermediate allocation overhead that is avoidable in performance-critical paths like HTTP header construction.

📊 Impact:
- Improves inbound frame processing efficiency, especially for large requests/responses.
- Reduces allocations and CPU cycles during HTTP response generation.

🧪 Measurement:
- Verified via `cargo test --workspace`.
- Code reviewed for correctness and adherence to the `bytes` crate's best practices.

---
*PR created automatically by Jules for task [450989022097978382](https://jules.google.com/task/450989022097978382) started by @vamzi*