### PR TITLE
🛡️ Sentinel: [HIGH] Fix Header Whitespace Parsing Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-29 - [Vulnerability] Header Whitespace Lenience in HTTP Parser
+**Vulnerability:** The HTTP/1.1 request head parser in `crates/openhost-daemon/src/forward.rs` used `.trim()` on header field names, allowing whitespace between the field name and the colon (e.g., `Host : example`).
+**Learning:** This violation of RFC 7230 §3.2.4 ("No whitespace is allowed between the header field-name and colon") is a classic precursor to HTTP Request Smuggling and Response Splitting. If a proxy and an upstream disagree on how to handle malformed headers, an attacker can "hide" a request or header.
+**Prevention:** Remove `.trim()` from header names before validation. Rely on strict parser primitives like `HeaderName::from_bytes` which correctly reject tokens containing whitespace.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,7 +383,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -780,6 +780,14 @@ mod tests {
     #[test]
     fn parse_request_head_rejects_header_without_colon() {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
     }


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Fix Header Whitespace Parsing Vulnerability

**🚨 Severity:** HIGH
**💡 Vulnerability:** The HTTP/1.1 request head parser was too lenient, allowing whitespace between a header field name and its colon (e.g., `Host : example`). This violates RFC 7230 §3.2.4.
**🎯 Impact:** Such lenience is a classic vector for HTTP Request Smuggling. If `openhost-daemon` and an upstream server disagree on how to parse these malformed headers, an attacker can potentially bypass security controls or poison caches.
**🔧 Fix:** Removed the `.trim()` call on the header name slice in `parse_request_head`. The `HeaderName::from_bytes` function now correctly rejects any input containing whitespace, as it is not a valid token character.
**✅ Verification:**
- Added a new unit test `parse_request_head_rejects_whitespace_before_colon` in `crates/openhost-daemon/src/forward.rs`.
- Verified that the test fails without the fix and passes with it.
- Ran `cargo test --workspace` to ensure no regressions.
- Recorded the security learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2167585974046353312](https://jules.google.com/task/2167585974046353312) started by @vamzi*