### PR TITLE
⚡ Bolt: optimize answer fragment reassembly

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Optimized Pkarr Answer Fragment Reassembly]
+**Learning:** Initializing large arrays of non-`Copy` types (e.g., `[Option<Vec<u8>>; 256]`) in this Rust 1.85 environment requires nested inline `const` blocks: `const { [const { None }; 256] }`. Additionally, reconstructing Pkarr fragments from DNS TXT records should use `iter_raw()` to concatenate character-strings into a `Vec<u8>` to avoid intermediate UTF-8 validation and multiple allocations.
+**Action:** Use nested `const` blocks for array initialization and pre-calculate final buffer capacity when reassembling fragmented data.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,53 +1098,89 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // BOLT: replace $O(T \times N)$ multi-pass with $O(N)$ single-pass bucket sort.
+    // Impact: reduces reassembly cost from $O(\text{fragments} \times \text{records})$ to $O(\text{records})$.
+    let label_prefix = format!("{base}-");
+    let mut buckets: [Option<Vec<u8>>; 256] = const { [const { None }; 256] };
+    let mut total_expected: Option<u8> = None;
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
-        return Ok(None);
+    for rr in packet.all_resource_records() {
+        // DNS labels in pkarr are usually single-label names relative to the
+        // origin. BOLT: match the first label bytes directly to avoid String allocation.
+        let Some(label) = rr.name.get_labels().first() else {
+            continue;
+        };
+        let label_bytes = label.as_ref();
+        if !label_bytes.starts_with(label_prefix.as_bytes()) {
+            continue;
+        }
+
+        let suffix_bytes = &label_bytes[label_prefix.len()..];
+        let Ok(suffix_str) = core::str::from_utf8(suffix_bytes) else {
+            continue;
+        };
+        let Ok(idx) = suffix_str.parse::<u8>() else {
+            continue;
+        };
+
+        if let RData::TXT(txt) = &rr.rdata {
+            if buckets[idx as usize].is_some() {
+                return Err(PkarrError::MultipleOpenhostRecords);
+            }
+
+            // BOLT: Reconstruct the fragment by concatenating all character-strings.
+            // Using a byte vector avoids intermediate String UTF-8 validation overhead.
+            let mut fragment_bytes = Vec::new();
+            for (key, value) in txt.iter_raw() {
+                fragment_bytes.extend_from_slice(key);
+                if let Some(v) = value {
+                    fragment_bytes.push(b'=');
+                    fragment_bytes.extend_from_slice(v);
+                }
+            }
+
+            let bytes = URL_SAFE_NO_PAD.decode(&fragment_bytes)?;
+            let frag = decode_fragment(&bytes)?;
+
+            if let Some(t) = total_expected {
+                if t != frag.total {
+                    return Err(PkarrError::MalformedCanonical(
+                        "answer fragments disagree on chunk_total",
+                    ));
+                }
+            } else {
+                total_expected = Some(frag.total);
+            }
+
+            if frag.idx != idx {
+                return Err(PkarrError::MalformedCanonical(
+                    "answer fragment idx disagrees with its DNS label suffix",
+                ));
+            }
+
+            buckets[idx as usize] = Some(frag.payload);
+        }
+    }
+
+    // Missing zero-fragment ⇒ no answer for us.
+    let total = match (buckets[0].as_ref(), total_expected) {
+        (Some(_), Some(t)) => t,
+        _ => return Ok(None),
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
-        return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
-        ));
-    }
-    let total = first.total;
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
-    fragments.push(first);
-    for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
-        if frag.total != total {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragments disagree on chunk_total",
-            ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
-            ));
-        }
-        fragments.push(frag);
-    }
+    // BOLT: Pre-calculate capacity to ensure $O(1)$ reallocations for the final buffer.
+    let total_len: usize = (0..total)
+        .map(|i| buckets[i as usize].as_ref().map_or(0, |p| p.len()))
+        .sum();
+    let mut sealed = Vec::with_capacity(total_len);
 
-    let mut sealed = Vec::with_capacity(fragments.iter().map(|f| f.payload.len()).sum());
-    for frag in fragments {
-        sealed.extend_from_slice(&frag.payload);
+    for i in 0..total {
+        let payload = buckets[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
+        sealed.extend_from_slice(&payload);
     }
 
     // Use the packet timestamp as a sensible default for `created_at` —


### PR DESCRIPTION
💡 What: Refactored the Pkarr answer fragment reassembly logic in `crates/openhost-pkarr/src/offer.rs` to use a single-pass $O(N)$ bucket sort.
🎯 Why: The original implementation used a multi-pass approach, walking the packet's resource records $T$ times (where $T$ is the number of fragments). This was $O(T \times N)$, which is inefficient for a large number of fragments.
📊 Impact: Reduces algorithmic complexity from $O(T \times N)$ to $O(N)$. Pre-calculates buffer capacity to ensure $O(1)$ reallocations for the final reassembled payload.
🔬 Measurement: Verified using `cargo test -p openhost-pkarr --lib offer::tests`, specifically `multi_fragment_answer_reassembles` and `small_answer_fragments_and_reassembles`.

---
*PR created automatically by Jules for task [16805251834255491352](https://jules.google.com/task/16805251834255491352) started by @vamzi*