### PR TITLE
🛡️ Sentinel: Fix RFC 7230 §3.2.4 header parsing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-01 - [RFC 7230 §3.2.4 Header Parsing Vulnerability]
+**Vulnerability:** The HTTP/1.1 request head parser incorrectly allowed whitespace between the header field name and the colon by calling `.trim()` on the name.
+**Learning:** RFC 7230 §3.2.4 strictly forbids such whitespace because inconsistent handling by different proxies/servers can lead to request smuggling or response splitting.
+**Prevention:** Always use strict parsing for HTTP headers. Avoid blanket `.trim()` on header components; instead, follow the RFC's specific whitespace rules (e.g., OWS allowed between colon and value, but none before the colon).

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,7 +383,17 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon. [...] A server MUST reject any received
+        // request message that contains whitespace between a header
+        // field-name and colon with a response code of 400 (Bad Request)."
+        //
+        // By NOT calling .trim() here, HeaderName::from_bytes will fail
+        // if trailing whitespace exists, correctly triggering a 400-level
+        // error in the caller.
+        let name = &line[..colon];
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
         let value = line[colon + 1..].trim_start_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
@@ -782,6 +792,16 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let res = parse_request_head(raw);
+        assert!(
+            res.is_err(),
+            "RFC 7230 §3.2.4: request with whitespace before colon MUST be rejected"
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The HTTP/1.1 request head parser incorrectly allowed whitespace between the header field name and the colon by calling `.trim()` on the name.
🎯 Impact: This violation of RFC 7230 §3.2.4 can lead to HTTP Request Smuggling and Response Splitting vulnerabilities when the daemon is used in conjunction with other HTTP-processing intermediaries.
🔧 Fix: Removed the `.trim()` call on header names in `parse_request_head`. This ensures that trailing whitespace before the colon causes `HeaderName::from_bytes` to fail, correctly rejecting the malformed request.
✅ Verification: Added a unit test `parse_request_head_rejects_whitespace_before_colon` in `crates/openhost-daemon/src/forward.rs` which confirms that such requests are now rejected. All existing workspace tests pass.

---
*PR created automatically by Jules for task [1048299790601613548](https://jules.google.com/task/1048299790601613548) started by @vamzi*