### PR TITLE
🛡️ Sentinel: Harden HTTP request head parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - HTTP Header Name Smuggling in Hand-Rolled Parser
+**Vulnerability:** Hand-rolled HTTP parser trimmed whitespace from header names before validation, allowing `Host :` to be accepted as `Host`.
+**Learning:** RFC 7230 §3.2.4 strictly forbids whitespace before the colon. Trimming names before passing them to a validator (like `http::HeaderName::from_bytes`) masks this violation.
+**Prevention:** Never trim header names in HTTP parsers; let the validator handle the raw bytes to ensure strict compliance.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +782,31 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg == "invalid header name"),
+            "Expected 'invalid header name' error for whitespace before colon, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230: Header values (field-content) are bounded by OWS.
+        let raw = b"GET / HTTP/1.1\r\nHost: example \t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(
+            headers.get("host").unwrap().as_bytes(),
+            b"example",
+            "Trailing SP/HTAB must be trimmed from header values"
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
### 🛡️ Sentinel: Harden HTTP request head parsing

**🚨 Severity:** MEDIUM (Defense in Depth)

**💡 Vulnerability:**
The hand-rolled HTTP/1.1 request head parser was using `.trim()` on header names before validation. This violated RFC 7230 §3.2.4 ("No whitespace is allowed between the header field-name and colon") and could mask request smuggling attempts where a malformed header like `Host :` was accepted as `Host`.

**🎯 Impact:**
While `http::HeaderName::from_bytes` is strict, trimming the input before passing it to the validator allowed illegal whitespace to bypass the check. Correctly rejecting such requests is a standard SSRF and request-smuggling defense for proxies and daemons.

**🔧 Fix:**
- Removed `.trim()` from header names in `parse_request_head`. The raw slice is now passed to `HeaderName::from_bytes`, which correctly rejects any embedded or surrounding whitespace.
- Updated header value parsing to use `.trim_matches([' ', '\t'])` to remove both leading and trailing optional whitespace (OWS), ensuring consistent interpretation of header values.

**✅ Verification:**
- Added `parse_request_head_rejects_whitespace_before_colon` unit test.
- Added `parse_request_head_trims_trailing_whitespace_from_values` unit test.
- Ran the full workspace test suite: `cargo test --workspace` (all passed).
- Verified that `http::HeaderName::from_bytes` correctly rejects whitespace when not pre-trimmed.

---
*PR created automatically by Jules for task [2919870027225922599](https://jules.google.com/task/2919870027225922599) started by @vamzi*