### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 header parsing violations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-06 - Strict RFC 7230 Header Parsing
+**Vulnerability:** Trimming whitespace from HTTP header names before validation in hand-rolled parsers violates RFC 7230 §3.2.4 and can mask request smuggling vulnerabilities.
+**Learning:** Hand-rolled HTTP parsers must be extremely strict with OWS (Optional WhiteSpace). In this codebase, \`.trim()\` on header names was hiding illegal whitespace that \`HeaderName::from_bytes\` would have otherwise caught.
+**Prevention:** Rely on established parser libraries when possible, or ensure hand-rolled parsers exactly match RFC specifications. For header values, RFC 7230 allows OWS but requires it be trimmed before processing.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` allowed at both ends of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +782,28 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "expected error for whitespace before colon, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: OWS (Optional WhiteSpace) allowed at both
+        // ends of the value.
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com  \r\nX-Custom:  value \t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
+        assert_eq!(headers.get("x-custom").unwrap(), "value");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Permissive HTTP header parsing (whitespace before colon allowed, trailing whitespace in values not trimmed).
🎯 Impact: Potential HTTP Request Smuggling if an upstream proxy or server interprets the malformed headers differently than the daemon's forwarder.
🔧 Fix: Removed \`.trim()\` on header names to allow strict validation by \`http::HeaderName\`, and used \`.trim_matches([' ', '\t'])\` on header values.
✅ Verification: Added tests \`parse_request_head_rejects_whitespace_before_colon\` and \`parse_request_head_trims_trailing_whitespace_from_values\` in \`crates/openhost-daemon/src/forward.rs\`. All tests passed.

---
*PR created automatically by Jules for task [4547208254125264801](https://jules.google.com/task/4547208254125264801) started by @vamzi*