### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-06 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling via whitespace before the colon in header fields.
+**Learning:** Hand-rolled HTTP parsers that `trim()` header names before validation can be tricked by proxies that pass through `Host : example` while the server sees it as `Host: example`, leading to request desynchronization.
+**Prevention:** Always use strict byte-for-byte validation for header names and ensure optional whitespace (OWS) is only trimmed from header values.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +782,22 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the
+        // header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The hand-rolled HTTP/1.1 request head parser in the daemon's forwarder was overly permissive with whitespace. Specifically, it trimmed header names before validation, which allowed whitespace between the field name and the colon (e.g., `Host : example`). Per RFC 7230 §3.2.4, no whitespace is allowed there. Additionally, it failed to trim trailing whitespace from header values.
🎯 Impact: This inconsistency can lead to HTTP Request Smuggling if an upstream proxy and the openhost daemon disagree on how to interpret malformed headers, potentially allowing an attacker to "smuggle" a second request inside the first.
🔧 Fix: Removed the `.trim()` call on header names to ensure strict validation by `HeaderName::from_bytes`. Updated header value parsing to use `.trim_matches([' ', '\t'])` to correctly handle optional whitespace (OWS) on both ends of the value.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` in `crates/openhost-daemon/src/forward.rs`. Verified that malformed headers are now rejected and values are correctly trimmed. All 313 workspace tests passed.

---
*PR created automatically by Jules for task [11838478404313780485](https://jules.google.com/task/11838478404313780485) started by @vamzi*