### PR TITLE
🛡️ Sentinel: [HIGH] Strict RFC 7230 header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-08 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling risk via loose header parsing.
+**Learning:** Trimming whitespace from header names and only trimming leading whitespace from values allows malformed headers that can be exploited for request smuggling. RFC 7230 §3.2.4 strictly forbids whitespace before the colon and requires OWS (SP/HTAB) trimming for values.
+**Prevention:** Always use strict parsers that follow RFC specifications for HTTP. For hand-rolled parsers, ensure they explicitly reject forbidden whitespace and correctly handle optional whitespace according to the spec.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` before and after the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -754,6 +754,25 @@ mod tests {
         assert_eq!(path, "/foo/bar?x=1");
         assert_eq!(headers.get("host").unwrap(), "example");
         assert_eq!(headers.get("x-custom").unwrap(), "yes");
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            format!("{err}").contains("invalid header name"),
+            "Expected 'invalid header name' error for whitespace before colon, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: "Optional whitespace (OWS) is allowed before and after the field-value."
+        let raw = b"GET / HTTP/1.1\r\nHost: example  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: HTTP Request Smuggling risk via loose header parsing.
🎯 Impact: Attackers could potentially smuggle requests through the daemon's forwarder if an upstream is also susceptible to whitespace ambiguities in header parsing.
🔧 Fix: Enhanced `parse_request_head` to strictly follow RFC 7230 §3.2.4 by rejecting whitespace before the colon in header fields and correctly trimming OWS (SP/HTAB) from values.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` to `crates/openhost-daemon/src/forward.rs`. All workspace tests pass.

---
*PR created automatically by Jules for task [10075338433542183652](https://jules.google.com/task/10075338433542183652) started by @vamzi*