### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 §3.2.4 header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-09 - Strict RFC 7230 Header Parsing
+**Vulnerability:** Hand-rolled HTTP/1.1 parser in `forward.rs` was trimming whitespace from header names before validation and failing to trim trailing whitespace from values.
+**Learning:** Trimming header names can mask request smuggling vulnerabilities where intermediaries (like proxies) have different parsing tolerances. RFC 7230 §3.2.4 explicitly forbids whitespace between the field name and the colon.
+**Prevention:** Rely on strict validation libraries (like the `http` crate's `HeaderName::from_bytes`) without pre-processing the input strings. Always trim both leading and trailing Optional WhiteSpace (OWS) from header values using `.trim_matches([' ', '\t'])` to align with the spec.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +782,24 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: "The field-value ... is preceded by optional
+        // whitespace (OWS) and followed by optional whitespace (OWS)."
+        let raw = b"GET / HTTP/1.1\r\nHost: example  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The HTTP request head parser was incorrectly trimming whitespace from header names and failing to trim trailing whitespace from header values.
🎯 Impact: Whitespace before the colon in header fields could lead to HTTP request smuggling or split-response attacks depending on the upstream proxy's parsing behavior.
🔧 Fix: Removed `.trim()` from header names to allow \`HeaderName::from_bytes\` to reject invalid whitespace. Updated value trimming to use \`.trim_matches([' ', '\t'])\` for full RFC 7230 OWS compliance.
✅ Verification: Added unit tests \`parse_request_head_rejects_whitespace_before_colon\` and \`parse_request_head_trims_trailing_whitespace_from_values\`. All 99 daemon unit tests and integration tests pass.

---
*PR created automatically by Jules for task [2415429438042829881](https://jules.google.com/task/2415429438042829881) started by @vamzi*