### PR TITLE
🛡️ Sentinel: [HIGH] Strict RFC 7230 header parsing to prevent request smuggling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-08 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling via lenient header parsing.
+**Learning:** Hand-rolled HTTP parsers must strictly follow RFC 7230 §3.2.4. Leniently trimming whitespace from header names can allow an attacker to bypass security filters that expect exact header names. Additionally, only trimming leading whitespace from values (OWS) can leave trailing whitespace that different proxies may interpret inconsistently (e.g., in Content-Length).
+**Prevention:** Remove any `.trim()` calls on header names before validation. Use `.trim_matches([' ', '\t'])` on header values to ensure both leading and trailing Optional WhiteSpace is removed.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -745,6 +745,31 @@ mod tests {
     }
 
     // --- Request head parser ----------------------------------------
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "Should reject whitespace before colon, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: OWS (Optional WhiteSpace) can appear after the
+        // value. Our forwarder must trim it before passing to hyper.
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(
+            headers.get("host").unwrap(),
+            "example.com",
+            "Trailing whitespace in header value was not trimmed"
+        );
+    }
 
     #[test]
     fn parse_request_head_happy_path() {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Lenient HTTP header parsing in the hand-rolled \`parse_request_head\` function allowed whitespace before colons and trailing whitespace in header values.
🎯 Impact: This can lead to HTTP Request Smuggling or Header Injection if a downstream proxy and the openhost daemon interpret these malformed headers differently.
🔧 Fix: Removed the \`.trim()\` call on header names to let \`HeaderName::from_bytes\` catch invalid whitespace, and used \`.trim_matches\` on values to correctly strip all OWS.
✅ Verification: Added unit tests \`parse_request_head_rejects_whitespace_before_colon\` and \`parse_request_head_trims_trailing_whitespace_from_values\`. Ran full workspace test suite.

---
*PR created automatically by Jules for task [16605803565636588450](https://jules.google.com/task/16605803565636588450) started by @vamzi*