### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 header parsing compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-09 - Strict RFC 7230 header parsing to prevent request smuggling
+**Vulnerability:** The hand-rolled HTTP parser was trimming whitespace from header names and only trimming leading whitespace from values.
+**Learning:** RFC 7230 §3.2.4 strictly forbids whitespace between the header name and the colon. Trimming it masks invalid requests that could be used in request smuggling attacks if the upstream is more strict. Additionally, OWS (Optional WhiteSpace) in header values includes both leading and trailing whitespace.
+**Prevention:** Always validate header names without trimming. Use `HeaderName::from_bytes` on the raw name part. Trim both leading and trailing SP/HTAB from header values using `.trim_matches([' ', '\t'])`.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name = &line[..colon];
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +782,29 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "A server MUST reject any received request message that
+        // contains whitespace between a header field-name and its colon"
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "should have rejected whitespace before colon"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(
+            headers.get("host").unwrap().to_str().unwrap(),
+            "example",
+            "trailing whitespace should be trimmed"
+        );
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Non-compliant HTTP header parsing. The daemon's hand-rolled parser allowed whitespace between header names and colons (violating RFC 7230 §3.2.4) and failed to trim trailing OWS from header values.
🎯 Impact: Potential for HTTP Request Smuggling (HRS) if an upstream server handles these malformed headers differently than the openhost daemon.
🔧 Fix: Removed `.trim()` from header names before passing to `HeaderName::from_bytes` (which enforces strict token validation) and updated value parsing to trim both leading and trailing SP/HTAB characters.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` in `crates/openhost-daemon/src/forward.rs`. Verified all workspace tests pass.

---
*PR created automatically by Jules for task [8465662085997578172](https://jules.google.com/task/8465662085997578172) started by @vamzi*