### PR TITLE
⚡ Bolt: Optimize PKARR answer fragment reassembly to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-08 - [Optimized PKARR fragment reassembly]
+**Learning:** (N^2)$ reassembly in PKARR answer decoding was caused by repeated linear probes for each fragment index. Using a single pass with bucket sorting reduces this to (N)$.
+**Action:** Always look for "TODO(perf)" markers in hand-rolled reassembly or parsing logic; they often highlight (N^2)$ bottlenecks that can be solved with single-pass bucket sorting or hash lookups.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1097,53 +1097,95 @@ pub fn decode_answer_fragments_from_packet(
         "{ANSWER_TXT_PREFIX}{}",
         zbase32::encode_full_bytes(&client_hash)
     );
+    let prefix_with_hyphen = format!("{base}-");
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Single pass over all RRs to bucket-sort fragments by their numeric
+    // suffix. Reduces complexity from O(total * N) to O(N).
+    let mut buckets: Vec<Option<DecodedFragment>> = Vec::new();
+    let mut total_expected: Option<u8> = None;
+    let mut fragments_found = 0;
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
-        return Ok(None);
+    for rr in packet.all_resource_records() {
+        let name_str = rr.name.to_string();
+        let Some(suffix) = name_str.strip_prefix(&prefix_with_hyphen) else {
+            continue;
+        };
+        // suffix is e.g. "0" or "0.abcd..." if fully qualified.
+        let label_idx_str = suffix.split('.').next().unwrap();
+        let Ok(label_idx) = label_idx_str.parse::<u8>() else {
+            continue;
+        };
+
+        if let RData::TXT(txt) = &rr.rdata {
+            // Reassemble character-strings (logic from collect_single_txt).
+            let mut text = String::new();
+            for (key, value) in txt.iter_raw() {
+                text.push_str(core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?);
+                if let Some(v) = value {
+                    text.push('=');
+                    text.push_str(core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?);
+                }
+            }
+
+            let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
+            let frag = decode_fragment(&bytes)?;
+
+            // Integrity: envelope idx MUST match label idx.
+            if frag.idx != label_idx {
+                return Err(PkarrError::MalformedCanonical(
+                    "answer fragment idx disagrees with its DNS label suffix",
+                ));
+            }
+
+            let idx = frag.idx as usize;
+            let total = frag.total;
+
+            // Integrity: total must be consistent across all fragments.
+            if let Some(t) = total_expected {
+                if total != t {
+                    return Err(PkarrError::MalformedCanonical(
+                        "answer fragments disagree on chunk_total",
+                    ));
+                }
+            } else {
+                total_expected = Some(total);
+                buckets.resize_with(total as usize, || None);
+            }
+
+            // Integrity: bounds check idx against total to avoid panic.
+            if idx >= buckets.len() {
+                return Err(PkarrError::MalformedCanonical(
+                    "answer fragment idx >= total",
+                ));
+            }
+
+            // Integrity: no duplicate indices.
+            if buckets[idx].is_some() {
+                return Err(PkarrError::MultipleOpenhostRecords);
+            }
+
+            buckets[idx] = Some(frag);
+            fragments_found += 1;
+        }
+    }
+
+    // Reassembly requires at least the 0th fragment.
+    let total = match (total_expected, buckets.get(0).and_then(|f| f.as_ref())) {
+        (Some(t), Some(_)) => t,
+        _ => return Ok(None),
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
+
+    if fragments_found as u8 != total {
         return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
+            "answer fragment set is missing an idx",
         ));
     }
-    let total = first.total;
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
-    fragments.push(first);
-    for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
-        if frag.total != total {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragments disagree on chunk_total",
-            ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
-            ));
-        }
-        fragments.push(frag);
-    }
-
-    let mut sealed = Vec::with_capacity(fragments.iter().map(|f| f.payload.len()).sum());
-    for frag in fragments {
+    let mut sealed =
+        Vec::with_capacity(buckets.iter().map(|f| f.as_ref().unwrap().payload.len()).sum());
+    for frag_opt in buckets {
+        // Safe to unwrap because we verified fragments_found == total.
+        let frag = frag_opt.unwrap();
         sealed.extend_from_slice(&frag.payload);
     }
 

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1170,7 +1170,7 @@ pub fn decode_answer_fragments_from_packet(
     }
 
     // Reassembly requires at least the 0th fragment.
-    let total = match (total_expected, buckets.get(0).and_then(|f| f.as_ref())) {
+    let total = match (total_expected, buckets.first().and_then(|f| f.as_ref())) {
         (Some(t), Some(_)) => t,
         _ => return Ok(None),
     };
@@ -1181,8 +1181,12 @@ pub fn decode_answer_fragments_from_packet(
         ));
     }
 
-    let mut sealed =
-        Vec::with_capacity(buckets.iter().map(|f| f.as_ref().unwrap().payload.len()).sum());
+    let mut sealed = Vec::with_capacity(
+        buckets
+            .iter()
+            .map(|f| f.as_ref().unwrap().payload.len())
+            .sum(),
+    );
     for frag_opt in buckets {
         // Safe to unwrap because we verified fragments_found == total.
         let frag = frag_opt.unwrap();


### PR DESCRIPTION
💡 **What**: Optimized the PKARR answer fragment reassembly logic to use a single-pass bucket sort.
🎯 **Why**: The previous implementation performed a linear probe for each fragment index, leading to $O(T \times N)$ complexity (where T is the number of fragments and N is the number of records in the packet).
📊 **Impact**: Reduces reassembly time from quadratic to linear, which is critical for handling packets with many fragments (up to 255 supported by the protocol).
🔬 **Measurement**: Verified using existing unit tests in `openhost-pkarr` (`offer::tests`), specifically `small_answer_fragments_and_reassembles` and `multi_fragment_answer_reassembles`, along with new integrity checks for malformed packets.

---
*PR created automatically by Jules for task [9005122490135382919](https://jules.google.com/task/9005122490135382919) started by @vamzi*