### PR TITLE
⚡ Bolt: optimize HTTP response head encoding

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -32,6 +32,7 @@ use hyper::upgrade::Upgraded;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client as LegacyClient;
 use hyper_util::rt::TokioExecutor;
+use std::io::Write;
 use std::time::Duration;
 
 /// Default connect timeout when reaching the upstream. Localhost should
@@ -462,7 +463,8 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to a Vec should not fail");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -519,12 +521,13 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to a Vec should not fail");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What: Optimized the HTTP response head encoding in `openhost-daemon`'s forwarder.
- Used `HeaderValue::from(u64)` for the `Content-Length` header to avoid string allocation and parsing.
- Replaced `format!` macro with `write!` directly on the output `Vec<u8>` for status line construction to eliminate intermediate `String` allocations.

🎯 Why: These functions are on the hot path for every forwarded request. Reducing per-request allocations improves throughput and reduces memory pressure.

📊 Impact: Eliminates at least two string allocations per forwarded response.

🔬 Measurement: Verified with `cargo test -p openhost-daemon --lib forward::tests` and integration tests in `crates/openhost-daemon/tests/forward.rs`.

---
*PR created automatically by Jules for task [3537621044105846149](https://jules.google.com/task/3537621044105846149) started by @vamzi*