### PR TITLE
🛡️ Sentinel: Fix HTTP Request Smuggling via strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-09 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling via permissive whitespace handling in header names and values.
+**Learning:** The daemon's hand-rolled HTTP parser was using `.trim()` on header names, which allowed whitespace between the field-name and the colon. This violates RFC 7230 §3.2.4 and is a known vector for request smuggling. Additionally, only leading whitespace was being trimmed from header values, leaving trailing OWS intact.
+**Prevention:** Explicitly check for and reject whitespace at the end of header names before the colon. Use `.trim_matches([' ', '\t'])` on header values to correctly strip both leading and trailing OWS as mandated by the spec.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name",
+            ));
+        }
+
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        // Also trim trailing OWS from the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
+
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -897,5 +906,29 @@ mod tests {
         let target: Uri = "http://127.0.0.1:8080".parse().unwrap();
         let uri = combine_target_and_path(&target, "http://evil.example/foo").unwrap();
         assert_eq!(uri.to_string(), "http://127.0.0.1:8080/foo");
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header field-name
+        // and colon. In the past, differences in the handling of such whitespace
+        // have led to request smuggling in proxies."
+        let raw = b"GET / HTTP/1.1\r\nHost : localhost\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(msg) if msg.contains("whitespace")),
+            "expected error with 'whitespace' message, got: {:?}",
+            err
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: "A field value might be preceded and/or followed by
+        // optional whitespace (OWS); a single SP / HTAB."
+        let raw = b"GET / HTTP/1.1\r\nHost: localhost \r\nX-Custom:  val \t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "localhost");
+        assert_eq!(headers.get("x-custom").unwrap(), "val");
     }
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: HTTP Request Smuggling via permissive whitespace handling in header names and values.
🎯 Impact: Attackers could potentially bypass SSRF protections or security filters by smuggling headers that are interpreted differently by the openhost daemon and the upstream service.
🔧 Fix: Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to explicitly reject whitespace before the colon in header names and use `.trim_matches([' ', '\t'])` on header values to ensure all optional whitespace is removed.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` to the `openhost-daemon` crate. Verified all tests pass with `cargo test -p openhost-daemon`.

---
*PR created automatically by Jules for task [4921417339247742454](https://jules.google.com/task/4921417339247742454) started by @vamzi*