### PR TITLE
🛡️ Sentinel: Enforce strict RFC 7230 header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-15 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP request smuggling or response splitting.
+**Learning:** `http::HeaderValue::from_str` does not automatically trim whitespace from the provided string. Additionally, many hand-rolled parsers (including the one in this daemon's forwarder) may be overly permissive with whitespace before the colon in header lines. RFC 7230 §3.2.4 explicitly prohibits whitespace between the header name and the colon and requires trimming OWS from the value.
+**Prevention:** Explicitly reject header names ending in whitespace before the colon and use `.trim_matches([' ', '\t'])` to handle OWS at both ends of the header value in all custom HTTP parsers.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,15 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: No whitespace allowed between header name and colon.
+        if name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace before header colon is prohibited (RFC 7230 §3.2.4)",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` at both ends of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +788,23 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        let ForwardError::HeadParse(reason) = err else {
+            panic!("expected HeadParse error, got {err:?}");
+        };
+        assert!(reason.contains("RFC 7230 §3.2.4"));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nX-Custom:  value  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("x-custom").unwrap(), "value");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: HTTP request smuggling or response splitting.
🎯 Impact: Permissive HTTP parsing can allow attackers to smuggle requests or split responses by injecting whitespace that is inconsistently handled by different proxies or upstreams.
🔧 Fix:
- Modified `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to explicitly reject headers with whitespace between the field name and the colon, complying with RFC 7230 §3.2.4.
- Updated header value parsing to use `.trim_matches([' ', '\t'])` to remove both leading and trailing Optional WhiteSpace (OWS), ensuring consistent interpretation.
✅ Verification:
- Added `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` unit tests in `crates/openhost-daemon/src/forward.rs`.
- Ran `cargo test -p openhost-daemon --lib forward::tests`.
- Ran full workspace tests and linter via `cargo test --workspace` and `cargo clippy --workspace`.

---
*PR created automatically by Jules for task [17557142292688729102](https://jules.google.com/task/17557142292688729102) started by @vamzi*