### PR TITLE
⚡ Bolt: optimize HTTP forwarder hot path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-10 - Optimizing HTTP forwarder hot path
+**Learning:** In high-frequency proxy logic, intermediate `String` allocations for HTTP headers (like `Content-Length`) and status lines are a significant source of overhead. Using `HeaderValue::from(u64)` and the `write!` macro directly on a `Vec<u8>` buffer eliminates these allocations. Pre-parsing configuration values like `host_override` into their final `HeaderValue` form also saves per-request validation and allocation.
+**Action:** Always look for opportunities to build binary response buffers using `write!` and pre-parsed `HeaderValue` types in performance-critical paths.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -106,7 +106,7 @@ pub struct Forwarder {
     /// Upstream origin; scheme is guaranteed `http`.
     target: Uri,
     /// Value the outbound `Host` header is pinned to.
-    host_override: String,
+    host_override: HeaderValue,
     /// Shared hyper client. Cloneable; we never hold it across requests
     /// so the internal connection pool is the only piece of state that
     /// lives between calls.
@@ -141,10 +141,10 @@ impl Forwarder {
             .ok_or_else(|| ForwardError::TargetParse("target is missing an authority".into()))?
             .to_string();
 
-        let host_override = cfg
-            .host_override
-            .clone()
-            .unwrap_or_else(|| authority.clone());
+        let host_override_str = cfg.host_override.as_deref().unwrap_or(&authority);
+        let host_override = HeaderValue::from_str(host_override_str).map_err(|_| {
+            ForwardError::TargetParse("host_override is not a valid header value".into())
+        })?;
 
         let mut connector = HttpConnector::new();
         connector.set_nodelay(true);
@@ -403,7 +403,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
 /// before this runs.
 fn sanitize_request_headers(
     headers: &mut HeaderMap,
-    host_override: &str,
+    host_override: &HeaderValue,
 ) -> Result<(), ForwardError> {
     for name in HOP_BY_HOP_HEADERS {
         headers.remove(*name);
@@ -412,10 +412,7 @@ fn sanitize_request_headers(
         headers.remove(*name);
     }
 
-    let host_value = HeaderValue::from_str(host_override).map_err(|_| {
-        ForwardError::HeadParse("configured host_override is not a valid header value")
-    })?;
-    headers.insert(http::header::HOST, host_value);
+    headers.insert(http::header::HOST, host_override.clone());
 
     Ok(())
 }
@@ -427,7 +424,7 @@ fn sanitize_request_headers(
 /// through unchanged (Key, Version, Protocol, Extensions).
 fn sanitize_websocket_request_headers(
     headers: &mut HeaderMap,
-    host_override: &str,
+    host_override: &HeaderValue,
 ) -> Result<(), ForwardError> {
     for name in HOP_BY_HOP_HEADERS {
         if *name == "connection" || *name == "upgrade" {
@@ -438,10 +435,7 @@ fn sanitize_websocket_request_headers(
     for name in PROVENANCE_HEADERS {
         headers.remove(*name);
     }
-    let host_value = HeaderValue::from_str(host_override).map_err(|_| {
-        ForwardError::HeadParse("configured host_override is not a valid header value")
-    })?;
-    headers.insert(http::header::HOST, host_value);
+    headers.insert(http::header::HOST, host_override.clone());
     Ok(())
 }
 
@@ -454,6 +448,8 @@ fn encode_websocket_response_head(
     status: StatusCode,
     mut headers: HeaderMap,
 ) -> Result<Vec<u8>, ForwardError> {
+    use std::io::Write;
+
     for name in HOP_BY_HOP_HEADERS {
         if *name == "connection" || *name == "upgrade" {
             continue;
@@ -462,7 +458,9 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(&mut out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec<u8> never fails");
+
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -510,6 +508,8 @@ fn encode_response_head(
     mut headers: HeaderMap,
     body_len: usize,
 ) -> Result<Vec<u8>, ForwardError> {
+    use std::io::Write;
+
     for name in HOP_BY_HOP_HEADERS {
         headers.remove(*name);
     }
@@ -519,12 +519,14 @@ fn encode_response_head(
     // frame-split the response stream.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    write!(&mut out, "HTTP/1.1 {} {}\r\n", status.as_u16(), reason)
+        .expect("writing to Vec<u8> never fails");
+
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -602,7 +604,8 @@ mod tests {
     #[test]
     fn sanitize_strips_all_hop_by_hop_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        let host = HeaderValue::from_static("127.0.0.1:8080");
+        sanitize_request_headers(&mut h, &host).unwrap();
         for name in HOP_BY_HOP_HEADERS {
             assert!(
                 !h.contains_key(*name),
@@ -614,7 +617,8 @@ mod tests {
     #[test]
     fn sanitize_strips_all_provenance_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        let host = HeaderValue::from_static("127.0.0.1:8080");
+        sanitize_request_headers(&mut h, &host).unwrap();
         for name in PROVENANCE_HEADERS {
             assert!(
                 !h.contains_key(*name),
@@ -626,7 +630,8 @@ mod tests {
     #[test]
     fn sanitize_preserves_benign_headers() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        let host = HeaderValue::from_static("127.0.0.1:8080");
+        sanitize_request_headers(&mut h, &host).unwrap();
         assert_eq!(
             h.get("x-custom").map(|v| v.to_str().unwrap()),
             Some("keep-me")
@@ -636,7 +641,8 @@ mod tests {
     #[test]
     fn sanitize_pins_host() {
         let mut h = fresh_headers();
-        sanitize_request_headers(&mut h, "127.0.0.1:8080").unwrap();
+        let host = HeaderValue::from_static("127.0.0.1:8080");
+        sanitize_request_headers(&mut h, &host).unwrap();
         assert_eq!(
             h.get(http::header::HOST).map(|v| v.to_str().unwrap()),
             Some("127.0.0.1:8080"),
@@ -655,7 +661,8 @@ mod tests {
         // RFC 7230 §6.1. The upstream never sees it.
         let mut h = HeaderMap::new();
         h.insert(http::header::UPGRADE, HeaderValue::from_static("websocket"));
-        sanitize_request_headers(&mut h, "x").unwrap();
+        let host = HeaderValue::from_static("x");
+        sanitize_request_headers(&mut h, &host).unwrap();
         assert!(!h.contains_key(http::header::UPGRADE));
     }
 
@@ -703,7 +710,8 @@ mod tests {
             HeaderName::from_static("sec-websocket-version"),
             HeaderValue::from_static("13"),
         );
-        sanitize_websocket_request_headers(&mut h, "upstream.local").unwrap();
+        let host = HeaderValue::from_static("upstream.local");
+        sanitize_websocket_request_headers(&mut h, &host).unwrap();
         assert!(h.contains_key(http::header::UPGRADE));
         assert!(h.contains_key(http::header::CONNECTION));
         assert!(h.contains_key("sec-websocket-key"));
@@ -727,7 +735,8 @@ mod tests {
             http::header::TRANSFER_ENCODING,
             HeaderValue::from_static("chunked"),
         );
-        sanitize_websocket_request_headers(&mut h, "x").unwrap();
+        let host = HeaderValue::from_static("x");
+        sanitize_websocket_request_headers(&mut h, &host).unwrap();
         assert!(!h.contains_key(http::header::TE));
         assert!(!h.contains_key(http::header::TRANSFER_ENCODING));
     }
@@ -740,7 +749,8 @@ mod tests {
         // just strip it as hop-by-hop so the upstream never sees it.
         let mut h = HeaderMap::new();
         h.insert(http::header::UPGRADE, HeaderValue::from_static("h2c"));
-        sanitize_request_headers(&mut h, "x").unwrap();
+        let host = HeaderValue::from_static("x");
+        sanitize_request_headers(&mut h, &host).unwrap();
         assert!(!h.contains_key(http::header::UPGRADE));
     }
 
@@ -857,7 +867,10 @@ mod tests {
             websockets: None,
         };
         let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
-        assert_eq!(fwd.host_override, "127.0.0.1:8080");
+        assert_eq!(
+            fwd.host_override,
+            HeaderValue::from_static("127.0.0.1:8080")
+        );
     }
 
     #[test]
@@ -869,7 +882,10 @@ mod tests {
             websockets: None,
         };
         let fwd = Forwarder::from_config(&cfg).unwrap().unwrap();
-        assert_eq!(fwd.host_override, "my-service.local");
+        assert_eq!(
+            fwd.host_override,
+            HeaderValue::from_static("my-service.local")
+        );
     }
 
     // --- combine_target_and_path ------------------------------------


### PR DESCRIPTION
💡 What:
- Changed `Forwarder.host_override` from `String` to `HeaderValue` to pre-validate and pre-allocate the host header.
- Replaced `HeaderValue::from_str(&body_len.to_string())` with `HeaderValue::from(body_len as u64)` in `encode_response_head`.
- Replaced `format!` with `write!` macro on pre-allocated `Vec<u8>` for HTTP status lines in `encode_response_head` and `encode_websocket_response_head`.
- Updated helper functions and unit tests to use `HeaderValue` references.

🎯 Why:
The localhost forwarder is a high-frequency hot path processing every request. Reducing intermediate `String` allocations and redundant header parsing significantly improves throughput and reduces memory churn in the daemon.

📊 Impact:
Eliminates multiple `String` allocations per forwarded request.

🔬 Measurement:
Run `cargo test -p openhost-daemon --lib forward::tests`. The optimizations are verified by the existing test suite which confirms identical wire-format output with more efficient construction.

---
*PR created automatically by Jules for task [9195127381714027421](https://jules.google.com/task/9195127381714027421) started by @vamzi*