### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 header parsing compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2026-07-15 - Strict RFC 7230 Header Parsing
+**Vulnerability:** Request Smuggling
+**Learning:** `http::HeaderValue::from_str` and the manual `parse_request_head` parser were previously lenient with whitespace around the colon and within header values. Specifically, allowing whitespace between the field name and colon, and failing to trim trailing OWS from field values, can lead to request smuggling or splitting when the daemon is used in conjunction with other HTTP intermediaries.
+**Prevention:** Enforce RFC 7230 §3.2.4 strictly. Reject any header field name that ends with whitespace before the colon. Use `.trim_matches([' ', '\t'])` on header values to ensure all Optional WhiteSpace (OWS) is removed from both ends before parsing as a `HeaderValue`.
+
+## 2026-07-16 - Strict RFC 7230 Compliance Verification
+**Vulnerability:** Request Smuggling / RFC 7230 non-compliance
+**Learning:** Proactive verification of RFC compliance in manual parsers is essential. Unit tests should explicitly cover edge cases in the specification (like OWS and whitespace-before-colon) that libraries like `http` or `hyper` might handle differently if they are passed pre-split strings.
+**Prevention:** Always add negative tests for specification violations (e.g., rejecting whitespace before colons) and positive tests for required normalization (e.g., trimming trailing OWS) when implementing or maintaining manual protocol parsers.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,14 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.ends_with([' ', '\t']) {
+            // RFC 7230 §3.2.4: "No whitespace is allowed between the
+            // header field-name and colon."
+            return Err(ForwardError::HeadParse("whitespace before header colon"));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +787,24 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: Header values may be surrounded by OWS
+        // (optional whitespace: SP or HTAB).
+        let raw = b"GET / HTTP/1.1\r\nHost: example \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Non-compliant HTTP header parsing (RFC 7230 §3.2.4). The parser previously allowed whitespace before the colon and failed to trim trailing OWS from header values.
🎯 Impact: Potential for Request Smuggling or splitting if the daemon is used with certain HTTP intermediaries.
🔧 Fix: Updated `parse_request_head` to reject field names with trailing whitespace and used `.trim_matches([' ', '\t'])` on field values.
✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values`. Ran `cargo test -p openhost-daemon --lib forward::tests`.

---
*PR created automatically by Jules for task [6348717573942572737](https://jules.google.com/task/6348717573942572737) started by @vamzi*