### PR TITLE
🛡️ Sentinel: Enforce RFC 7230 compliance in request head parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-15 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling hazard due to non-compliant header parsing (allowing whitespace before header colons and not trimming optional whitespace (OWS) from header values).
+**Learning:** In `crates/openhost-daemon/src/forward.rs`, `parse_request_head` previously accepted trailing whitespace before the colon by trimming the key, and only trimmed leading whitespace from the value. Since `http::HeaderValue::from_str` does not automatically strip trailing whitespace, the downstream server and forwarder could disagree on parsed header values, leading to request smuggling.
+**Prevention:** Strictly validate that the header field name does not contain space or tab characters, rejecting any whitespace before the colon, and use `.trim_matches([' ', '\t'])` to strip OWS at both ends of the header value.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,14 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.contains([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace in header name or before colon is forbidden",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` around the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +787,20 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example \t \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: HTTP Request Smuggling hazard due to non-compliant header parsing (allowing whitespace before header colons and not trimming trailing optional whitespace from header values).

🎯 Impact: Malicious requests containing whitespace before colons (e.g. `Host : evil.com`) could bypass proxy routing filters or lead to parsing discrepancies between the forwarder and the upstream, creating a Request Smuggling or SSRF vulnerability. Additionally, untrimmed trailing whitespace in header values would lead to parsing mismatches.

🔧 Fix:
- Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to reject headers with space or horizontal tab characters in the header field name or before the colon.
- Used `.trim_matches([' ', '\t'])` to strip both leading and trailing optional whitespace (OWS) from the header value.

✅ Verification:
- Added `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` unit tests.
- Ran all workspace checks and tests successfully (`cargo fmt --all --check && cargo clippy --workspace -- -D warnings && cargo test --workspace`).

---
*PR created automatically by Jules for task [9044139384583055403](https://jules.google.com/task/9044139384583055403) started by @vamzi*