### PR TITLE
🛡️ Sentinel: [HIGH] Secure Unix File Permissions at Creation Time & Config Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel Security Journal
+
+## 2026-07-15 - Strict RFC 7230 Header Parsing
+**Vulnerability:** HTTP Request Smuggling via whitespace injection in headers.
+**Learning:** Legacy parsers that allowed leading/trailing whitespace or whitespace before the colon in header fields could be exploited for request smuggling. Trim and reject rules must strictly conform to RFC 7230 §3.2.4.
+**Prevention:** Reject headers containing whitespace before the colon and explicitly trim OWS from header values.
+
+## 2026-07-25 - File Creation Permission Race Condition
+**Vulnerability:** Local information disclosure of sensitive private keys and certificates.
+**Learning:** Creating sensitive files using default write/create functions, followed by a secondary `chmod` or `set_permissions` call, creates a timing window where the file is readable by other local users.
+**Prevention:** Always use `OpenOptions` with Unix-specific `mode(0o600)` at file creation time to ensure permissions are locked down before any bytes are written.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -227,18 +227,28 @@ pub async fn run(file: PathBuf) -> Result<()> {
 }
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
-        .await
-        .with_context(|| format!("create identity file: {}", path.display()))?;
-    f.write_all(seed).await?;
-    f.flush().await?;
-
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true).mode(0o600);
+        let mut file = options
+            .open(path)
+            .await
+            .with_context(|| format!("create identity file: {}", path.display()))?;
+        use tokio::io::AsyncWriteExt;
+        file.write_all(seed).await?;
+        file.flush().await?;
+    }
+    #[cfg(not(unix))]
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut f = tokio::fs::File::create(path)
+            .await
+            .with_context(|| format!("create identity file: {}", path.display()))?;
+        f.write_all(seed).await?;
+        f.flush().await?;
     }
     Ok(())
 }

--- a/crates/openhost-daemon/src/config.rs
+++ b/crates/openhost-daemon/src/config.rs
@@ -426,6 +426,24 @@ impl Config {
                     )
                     .into());
                 }
+                if let Ok(parsed_uri) = target.parse::<http::Uri>() {
+                    if parsed_uri.authority().is_none() {
+                        return Err(ConfigError::Invalid(
+                            "forward.target URI must have an authority (e.g. http://127.0.0.1:8080)",
+                        )
+                        .into());
+                    }
+                } else {
+                    return Err(ConfigError::Invalid("forward.target is not a valid URI").into());
+                }
+            }
+            if let Some(host_override) = &forward.host_override {
+                if http::header::HeaderValue::from_str(host_override).is_err() {
+                    return Err(ConfigError::Invalid(
+                        "forward.host_override must be a valid HTTP header value",
+                    )
+                    .into());
+                }
             }
             if forward.max_body_bytes == 0 {
                 return Err(ConfigError::Invalid("forward.max_body_bytes must be > 0").into());
@@ -582,6 +600,54 @@ mod tests {
         cfg.dtls.rotate_secs = 0;
         let err = cfg.validate().unwrap_err();
         assert!(format!("{err}").contains("rotate_secs"));
+    }
+
+    #[test]
+    fn rejects_invalid_forward_target_and_host_override() {
+        let mut cfg = seed_config(Path::new("/tmp"));
+
+        // Invalid target scheme (https)
+        cfg.forward = Some(ForwardConfig {
+            target: Some("https://127.0.0.1:8080".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(format!("{err}").contains("forward.target must be an http:// URL"));
+
+        // Target with missing authority is parsed as invalid URI or missing authority
+        cfg.forward = Some(ForwardConfig {
+            target: Some("http://".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(
+            format!("{err}").contains("must have an authority")
+                || format!("{err}").contains("is not a valid URI")
+        );
+
+        // Target with unparseable URI
+        cfg.forward = Some(ForwardConfig {
+            target: Some("http://[::1".into()),
+            host_override: None,
+            max_body_bytes: 1024,
+            websockets: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(format!("{err}").contains("is not a valid URI"));
+
+        // Invalid host override (contains CRLF)
+        cfg.forward = Some(ForwardConfig {
+            target: Some("http://127.0.0.1:8080".into()),
+            host_override: Some("localhost\r\nHeader: value".into()),
+            max_body_bytes: 1024,
+            websockets: None,
+        });
+        let err = cfg.validate().unwrap_err();
+        assert!(format!("{err}").contains("must be a valid HTTP header value"));
     }
 
     #[test]

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,23 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true).mode(0o600);
+        let mut file = options.open(&tmp).await?;
+        use tokio::io::AsyncWriteExt;
+        file.write_all(pem.as_bytes()).await?;
+        file.flush().await?;
     }
+    #[cfg(not(unix))]
+    {
+        tokio::fs::write(&tmp, pem).await?;
+    }
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,13 +106,21 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = tokio::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true).mode(0o600);
+        let mut file = options.open(&tmp).await?;
+        use tokio::io::AsyncWriteExt;
+        file.write_all(bytes).await?;
+        file.flush().await?;
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::fs::write(&tmp, bytes).await?;
     }
 
     tokio::fs::rename(&tmp, path).await

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,13 +168,20 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true).mode(0o600);
+        let mut file = options.open(&tmp)?;
+        use std::io::Write;
+        file.write_all(body.as_bytes())?;
+        file.flush()?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp, body.as_bytes())?;
     }
 
     std::fs::rename(&tmp, path)?;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A timing-window permission race condition existed where sensitive files (such as host Ed25519 identity keys, self-signed DTLS certificates with private keys, and client allowlists) were created with default system permissions (subject to umask, e.g. 0644 or 0666) before being restricted to 0600 with `chmod` / `set_permissions`. Additionally, `Config::validate` lacked validation for HTTP forward targets and host overrides, potentially allowing malformed configurations or request smuggling.
🎯 Impact: On a multi-user system, other local users could briefly read the newly-created private keys, identities, or paired clients during the race window, leading to sensitive credential leakage.
🔧 Fix:
1. Replaced separate file creation + `set_permissions` with `OpenOptions` / `OpenOptionsExt::mode(0o600)` at creation time on Unix, ensuring sensitive files are created with safe permissions from the very first instruction.
2. Added strict verification to `Config::validate` to ensure `forward.target` is a valid HTTP URI with an authority component, and `forward.host_override` is a valid HTTP header value.
✅ Verification: Ran `cargo clippy --workspace -- -D warnings` and `cargo test --workspace` confirming all tests pass. Explicitly added `rejects_invalid_forward_target_and_host_override` unit tests verifying the validation rules.

---
*PR created automatically by Jules for task [9774328320413222192](https://jules.google.com/task/9774328320413222192) started by @vamzi*