### PR TITLE
🛡️ Sentinel: [HIGH] Fix RFC 7230 header parsing violations

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-15 - Strict RFC 7230 Header Parsing
+**Vulnerability:** Hand-rolled HTTP request parsers that are lenient with whitespace surrounding header names (e.g., using `.trim()` on header names before validation) can accept requests containing whitespace before the colon (e.g., `Host : example.com`), which violates RFC 7230 §3.2.4 and can lead to request smuggling vulnerabilities in downstream/upstream forwarding proxies.
+**Learning:** Even though `HeaderName::from_bytes` validates header names, preprocessing them with `.trim()` masks illegal leading or trailing whitespace. RFC 7230 strictly prohibits any whitespace between the header name and the colon, while OWS is allowed (and must be trimmed) at both ends of header values.
+**Prevention:** Never use a generic `.trim()` on header names when parsing HTTP requests. Instead, explicitly check for and reject any whitespace before the colon, and only trim OWS (SP/HTAB) from the start and end of header values.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,14 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.ends_with(' ') || name.ends_with('\t') {
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon is forbidden by RFC 7230",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` allowed at both ends of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +766,28 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        // RFC 7230 §3.2.4: "No whitespace is allowed between the header
+        // field-name and colon."
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(
+            matches!(err, ForwardError::HeadParse(_)),
+            "expected error for whitespace before colon, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        // RFC 7230 §3.2.4: OWS (Optional WhiteSpace) allowed at both
+        // ends of the value.
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com  \r\nX-Custom:  value \t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
+        assert_eq!(headers.get("x-custom").unwrap(), "value");
     }
 
     #[test]


### PR DESCRIPTION
### Summary
This PR resolves an RFC 7230 parser compliance violation in the daemon's hand-rolled HTTP forwarder parser.

🚨 Severity: HIGH
💡 Vulnerability: The HTTP request parser generically called `.trim()` on the header name slice, masking spaces or horizontal tabs between the header field-name and the colon (e.g. `Host : example.com`). RFC 7230 §3.2.4 strictly prohibits whitespace before the colon. Additionally, trailing whitespace in header values was not fully trimmed before construction of `HeaderValue`, as `HeaderValue::from_str` does not trim whitespace on its own.
🎯 Impact: Accepting malformed requests with whitespace between field names and colons can lead to HTTP Request Smuggling or Request Splitting when communicating with upstream proxy servers, which may parse and interpret the headers differently.
🔧 Fix:
1. Replaced generic `.trim()` on header names in `parse_request_head` with strict RFC 7230 validation by explicitly rejecting spaces or tabs before the colon.
2. Trimmed OWS (SP/HTAB) from both ends of header values using `.trim_matches([' ', '\t'])` before constructing the `HeaderValue`.
3. Created a security learning journal entry in `.jules/sentinel.md`.
✅ Verification:
1. Added a unit test `parse_request_head_rejects_whitespace_before_colon` to confirm that any whitespace between field names and the colon is rejected with `ForwardError::HeadParse`.
2. Added `parse_request_head_trims_trailing_whitespace_from_values` to verify that optional whitespace (OWS) is properly stripped from both ends of header values.
3. Verified compilation and that all tests in the workspace pass successfully.

---
*PR created automatically by Jules for task [17101748947764155542](https://jules.google.com/task/17101748947764155542) started by @vamzi*