### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2026-07-25 - Unix File Creation Permission Race Condition Prevention
+**Vulnerability:** A TOCTOU (Time-of-Check to Time-of-Use) race condition existed when highly sensitive files (such as Ed25519 seed files, DTLS certificates, and pairing allowlists) were created with default permissions and subsequently restricted using `chmod` or equivalent functions, temporarily exposing secrets to other local users.
+**Learning:** File permissions must be established atomically at the exact moment of creation rather than modified afterwards. On Unix-like systems, this is securely achieved using `OpenOptionsExt::mode(0o600)` during file creation.
+**Prevention:** Use `tokio::fs::OpenOptions` or `std::fs::OpenOptions` with `.mode(0o600)` on Unix platforms when initializing sensitive local stores.
+
+## 2026-07-28 - HTTP Header Whitespace Parsing Vulnerability
+**Vulnerability:** The HTTP request parser permissively trimmed whitespace (spaces/tabs) surrounding header field names (e.g. `Host : value` or ` Host: value`) before colon separation. This violates RFC 7230 §3.2.4 and can lead to HTTP Request Smuggling or header spoofing when requests are processed by intermediate proxies.
+**Learning:** Hand-rolled HTTP parsers must strictly enforce the HTTP specification. Permissive parsing allows malformed messages to pass downstream, where different proxy parsers may interpret them differently.
+**Prevention:** Explicitly check for and reject any leading or trailing whitespace around header field names before parsing. Trim OWS from both ends of the header value.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.starts_with(' ')
+            || name.starts_with('\t')
+            || name.ends_with(' ')
+            || name.ends_with('\t')
+        {
+            return Err(ForwardError::HeadParse(
+                "invalid whitespace around header name",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value, and at the end of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +770,29 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+
+        let raw3 = b"GET / HTTP/1.1\r\n Host: example\r\n\r\n";
+        let err3 = parse_request_head(raw3).unwrap_err();
+        assert!(matches!(err3, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example \r\nCustom: value\t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
+        assert_eq!(headers.get("custom").unwrap(), "value");
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: The HTTP request head parser in `openhost-daemon` was previously lenient with whitespace around header field names (permissively trimming spaces/tabs from the field name before colon separation). This violates RFC 7230 §3.2.4.

🎯 Impact: Permissive header parsing can lead to HTTP Request Smuggling or header spoofing when requests are processed by intermediate proxies that follow different parsing rules.

🔧 Fix: Replaced name trimming in `parse_request_head` with an explicit check that rejects header names with leading or trailing spaces or tabs, returning a `HeadParse` error. Updated header value parsing to use `.trim_matches([' ', '\t'])` to strip OWS from both sides of the header value.

✅ Verification: Added unit tests `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_trailing_whitespace_from_values` in `crates/openhost-daemon/src/forward.rs` and verified that they compile and pass cleanly via `cargo test`.

---
*PR created automatically by Jules for task [176398006939551037](https://jules.google.com/task/176398006939551037) started by @vamzi*