### PR TITLE
🛡️ Sentinel: [HIGH] Fix file-creation permission race conditions on Unix

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-25 - Unix file creation permission race condition prevention
+**Vulnerability:** Unix file-creation permission race conditions where sensitive files (Ed25519 identity seeds, DTLS certs, and pairing allowlists) are initially created with default umask permissions before being restricted via `set_permissions`, leaving a brief Time-of-Check to Time-of-Use (TOCTOU) timing window during which other local users could read the sensitive keys or certificates.
+**Learning:** Using `set_permissions` after file creation is insecure on multi-user systems. Instead, `OpenOptions::new().mode(0o600)` must be used at creation time to ensure files are atomically created with restrictive permissions from the very first instruction.
+**Prevention:** Always use `OpenOptions` (either `std::fs` or `tokio::fs`) with `OpenOptionsExt::mode(0o600)` at creation time when writing highly sensitive files.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -227,19 +227,32 @@ pub async fn run(file: PathBuf) -> Result<()> {
 }
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
-    use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+    #[cfg(unix)]
+    let mut f = {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .await
+            .with_context(|| format!("create identity file: {}", path.display()))?
+    };
+
+    #[cfg(not(unix))]
+    let mut f = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
+
+    use tokio::io::AsyncWriteExt;
     f.write_all(seed).await?;
     f.flush().await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,33 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
-    }
+    let mut f = {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .await?
+    };
+
+    #[cfg(not(unix))]
+    let mut f = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp)
+        .await?;
+
+    use tokio::io::AsyncWriteExt;
+    f.write_all(pem.as_bytes()).await?;
+    f.flush().await?;
+    drop(f);
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,14 +106,32 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
 
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
-    }
+    let mut f = {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        tokio::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)
+            .await?
+    };
+
+    #[cfg(not(unix))]
+    let mut f = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp)
+        .await?;
+
+    use tokio::io::AsyncWriteExt;
+    f.write_all(bytes).await?;
+    f.flush().await?;
+    drop(f);
 
     tokio::fs::rename(&tmp, path).await
 }

--- a/crates/openhost-daemon/src/pair_watcher.rs
+++ b/crates/openhost-daemon/src/pair_watcher.rs
@@ -289,6 +289,12 @@ mod tests {
             PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
         tokio::time::sleep(Duration::from_millis(100)).await;
 
+        // Drain any filesystem events triggered by the initial setup
+        while tokio::time::timeout(Duration::from_millis(50), watcher.recv())
+            .await
+            .is_ok()
+        {}
+
         fs::write(&sibling, b"unrelated").unwrap();
 
         let res = tokio::time::timeout(Duration::from_millis(500), watcher.recv()).await;

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,14 +168,30 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
 
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
-    }
+    let mut f = {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp)?
+    };
+
+    #[cfg(not(unix))]
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp)?;
+
+    use std::io::Write;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
+    drop(f);
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: File-creation permission race conditions (TOCTOU) on Unix. Sensitive files (identity seeds, DTLS certs, and pairing allowlists) were created with default umask permissions before being restricted via `set_permissions`.

🎯 Impact: A brief timing window existed where local unauthorized users could read or write highly sensitive key material, certificates, or authorized pairing databases.

🔧 Fix: Configured `OpenOptions` (both sync `std::fs` and async `tokio::fs`) with `.mode(0o600)` at creation time on Unix, ensuring files are created atomically with restricted permissions.

✅ Verification: Verified using full workspace tests, cargo clippy, and manual inspection of standard and tokio `OpenOptionsExt` usage.

---
*PR created automatically by Jules for task [8311835675843380500](https://jules.google.com/task/8311835675843380500) started by @vamzi*