### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unix file-creation permission race conditions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Unix File Creation Permission Race Condition
+**Vulnerability:** When highly sensitive files (such as Ed25519 seeds, DTLS certs, allowlists) are created using default file-creation functions and then have their permissions updated using `set_permissions` afterwards, a small Time-of-Check to Time-of-Use (TOCTOU) timing window is introduced where other local users can read the sensitive file before the permissions are tightened.
+**Learning:** Standard file-creation operations on POSIX respect the current process `umask`, which often permits other local users to read created files. Tightening the permissions with `chmod` or `set_permissions` immediately after creation does not close the window between creation and permission modification.
+**Prevention:** Always create highly sensitive files atomically with `0o600` permissions (read/write by owner only) using `OpenOptions::new().mode(0o600)` at creation time, eliminating any race condition window.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -228,18 +228,20 @@ pub async fn run(file: PathBuf) -> Result<()> {
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
     use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut f = options
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
     f.write_all(seed).await?;
     f.flush().await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,20 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    use tokio::io::AsyncWriteExt as _;
+    let mut f = options.open(&tmp).await?;
+    f.write_all(pem.as_bytes()).await?;
+    f.flush().await?;
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,14 +106,19 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
 
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    use tokio::io::AsyncWriteExt as _;
+    let mut f = options.open(&tmp).await?;
+    f.write_all(bytes).await?;
+    f.flush().await?;
 
     tokio::fs::rename(&tmp, path).await
 }

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,14 +168,19 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
 
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    use std::io::Write as _;
+    let mut f = options.open(&tmp)?;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
### 🚨 Severity
HIGH

### 💡 Vulnerability
Unix file-creation permission race condition (TOCTOU). When creating highly sensitive files (such as Ed25519 identity keys, DTLS certificates, and pairing/allowlist files) with default creation options and then calling `set_permissions` immediately after, a temporary window is introduced during which other local users could potentially read the file's contents before the permissions are tightened.

### 🎯 Impact
Other local users on a shared Unix system could read highly sensitive credentials, including Ed25519 seeds (which would compromise host identity and authorize potential attackers) and DTLS certificates.

### 🔧 Fix
Replaced the standard file-creation operations with `OpenOptions` that specify `.mode(0o600)` on Unix platforms at creation time, ensuring that files are created atomically with private permissions and eliminating the race condition entirely.

### ✅ Verification
Compiled with `cargo clippy --all-targets` and verified that the entire test suite (`cargo test`) passes. Checked that the files continue to be written correctly with `0o600` permissions on Unix.

---
*PR created automatically by Jules for task [14706688534339928052](https://jules.google.com/task/14706688534339928052) started by @vamzi*