### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Unix File Creation Permission Race Condition
+**Vulnerability:** When highly sensitive files (such as Ed25519 seeds, DTLS certs, allowlists) are created using default file-creation functions and then have their permissions updated using `set_permissions` afterwards, a small Time-of-Check to Time-of-Use (TOCTOU) timing window is introduced where other local users can read the sensitive file before the permissions are tightened.
+**Learning:** Standard file-creation operations on POSIX respect the current process `umask`, which often permits other local users to read created files. Tightening the permissions with `chmod` or `set_permissions` immediately after creation does not close the window between creation and permission modification.
+**Prevention:** Always create highly sensitive files atomically with `0o600` permissions (read/write by owner only) using `OpenOptions::new().mode(0o600)` at creation time, eliminating any race condition window.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.starts_with(' ')
+            || name.starts_with('\t')
+            || name.ends_with(' ')
+            || name.ends_with('\t')
+        {
+            return Err(ForwardError::HeadParse(
+                "invalid whitespace around header name",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value, and at the end of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +770,29 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+
+        let raw3 = b"GET / HTTP/1.1\r\n Host: example\r\n\r\n";
+        let err3 = parse_request_head(raw3).unwrap_err();
+        assert!(matches!(err3, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example \r\nCustom: value\t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
+        assert_eq!(headers.get("custom").unwrap(), "value");
     }
 
     #[test]


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** Under RFC 7230 §3.2.4, HTTP request headers must not contain whitespace between the header name and the colon separator, and trailing whitespace from header values must be handled properly. Lax parsing can lead to HTTP Request Smuggling, where an attacker smuggles a hidden second request inside the body of the first.

🎯 **Impact:** If exploited, request smuggling can bypass security controls, hijack user sessions, or poison web caches.

🔧 **Fix:**
- Updated `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to explicitly reject any header name that starts or ends with whitespace (spaces or tabs).
- Replaced the leading-whitespace-only trim with `trim_matches([' ', '\t'])` to safely trim both leading and trailing whitespace from header values.

✅ **Verification:**
- Added robust unit tests verifying both that whitespace-surrounded header names are rejected and that trailing whitespace in header values is correctly trimmed.
- Run `cargo test -p openhost-daemon` and confirmed all tests pass successfully.

---
*PR created automatically by Jules for task [1254031427300756373](https://jules.google.com/task/1254031427300756373) started by @vamzi*