### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - [HTTP Request Smuggling Vulnerability via Lenient Header Parsing]
+**Vulnerability:** HTTP Request Smuggling due to lenient parsing of header names containing whitespace (space or tab) preceding or surrounding the colon separator, in violation of RFC 7230 §3.2.4.
+**Learning:** Leniently trimming whitespace before/around header names allows proxy/server differences in parsing, which enables attackers to smuggle requests through intermediate HTTP hops. Strictly rejecting requests with whitespace surrounding the header name prevents parsing discrepancies.
+**Prevention:** Always validate that there is no whitespace before the colon separator on any HTTP header line, and strictly reject any malformed lines immediately.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.starts_with(' ')
+            || name.starts_with('\t')
+            || name.ends_with(' ')
+            || name.ends_with('\t')
+        {
+            return Err(ForwardError::HeadParse(
+                "invalid whitespace around header name",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value, and at the end of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +770,29 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+
+        let raw3 = b"GET / HTTP/1.1\r\n Host: example\r\n\r\n";
+        let err3 = parse_request_head(raw3).unwrap_err();
+        assert!(matches!(err3, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_trailing_whitespace_from_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example \r\nCustom: value\t\r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example");
+        assert_eq!(headers.get("custom").unwrap(), "value");
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: HTTP Request Smuggling via lenient header name parsing.
🎯 Impact: Attackers could inject smuggled HTTP headers/requests to bypass access controls or poison the cache.
🔧 Fix: Reject any header lines containing whitespace surrounding the header name before the colon separator, and trim all leading and trailing OWS from header values.
✅ Verification: Ran cargo test --workspace and verified all new and existing HTTP parser unit tests pass.

---
*PR created automatically by Jules for task [16205453920467779938](https://jules.google.com/task/16205453920467779938) started by @vamzi*