### PR TITLE
⚡ Bolt: HTTP/WebSocket forwarding path string & Uri allocation optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal
+
+## 2026-07-28 - Forwarding URL & string optimization
+**Learning:** Reconstructing the request Uri on every forwarded HTTP/WebSocket request can be optimized by using `http::Uri::builder()` with a zero-allocation path/query construct (`std::borrow::Cow` to avoid slash prepends). Also, passing the parsed request path around as a borrowed `&str` instead of a heap-allocated `String` avoids a per-request heap allocation.
+**Action:** Always prefer `Uri::builder` over whole-string formatting/parsing and use lifetimes/borrowing to avoid intermediate string allocations.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -197,7 +197,7 @@ impl Forwarder {
         // path below.
         if is_websocket_upgrade(&headers) {
             match self.websockets.as_ref() {
-                Some(cfg) if cfg.is_allowed(&path) => {
+                Some(cfg) if cfg.is_allowed(path) => {
                     return self
                         .forward_websocket(method, path, headers, body)
                         .await
@@ -212,7 +212,7 @@ impl Forwarder {
         // Build the outbound URI by combining the target origin with the
         // request path. The path comes from the client verbatim; no
         // rewriting this PR.
-        let target_uri = combine_target_and_path(&self.target, &path)?;
+        let target_uri = combine_target_and_path(&self.target, path)?;
 
         let mut req_builder = Request::builder().method(method).uri(target_uri);
         // Replace the HeaderMap wholesale — simpler than iterating and
@@ -279,12 +279,12 @@ impl Forwarder {
     async fn forward_websocket(
         &self,
         method: Method,
-        path: String,
+        path: &str,
         mut headers: HeaderMap,
         body: Bytes,
     ) -> Result<WebSocketUpgrade, ForwardError> {
         sanitize_websocket_request_headers(&mut headers, &self.host_override)?;
-        let target_uri = combine_target_and_path(&self.target, &path)?;
+        let target_uri = combine_target_and_path(&self.target, path)?;
         let mut req_builder = Request::builder().method(method).uri(target_uri);
         if let Some(req_headers) = req_builder.headers_mut() {
             *req_headers = headers;
@@ -340,7 +340,7 @@ fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
 ///
 /// Rejects HTTP/0.9, HTTP/1.0, HTTP/2+, missing blank line, and any
 /// obvious line-ending confusion (bare `\n` inside headers).
-fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), ForwardError> {
+fn parse_request_head(bytes: &[u8]) -> Result<(Method, &str, HeaderMap), ForwardError> {
     let text = std::str::from_utf8(bytes)
         .map_err(|_| ForwardError::HeadParse("request head is not valid UTF-8"))?;
 
@@ -361,8 +361,7 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         .ok_or(ForwardError::HeadParse("request line missing method"))?;
     let path = parts
         .next()
-        .ok_or(ForwardError::HeadParse("request line missing path"))?
-        .to_string();
+        .ok_or(ForwardError::HeadParse("request line missing path"))?;
     let version = parts
         .next()
         .ok_or(ForwardError::HeadParse("request line missing HTTP version"))?;
@@ -492,14 +491,16 @@ fn combine_target_and_path(target: &Uri, path: &str) -> Result<Uri, ForwardError
     };
 
     let path_and_query = if path_str.is_empty() || !path_str.starts_with('/') {
-        format!("/{path_str}")
+        std::borrow::Cow::Owned(format!("/{path_str}"))
     } else {
-        path_str.to_string()
+        std::borrow::Cow::Borrowed(path_str)
     };
 
-    let uri_str = format!("http://{authority}{path_and_query}");
-    uri_str
-        .parse()
+    Uri::builder()
+        .scheme("http")
+        .authority(authority.as_str())
+        .path_and_query(path_and_query.as_ref())
+        .build()
         .map_err(|_| ForwardError::HeadParse("could not combine target + path into a URI"))
 }
 


### PR DESCRIPTION
### 💡 What: The optimization implemented
- Avoided copying and allocating request `path` as a `String` inside `parse_request_head` and `forward_websocket` by passing and borrowing it as a `&str`.
- Optimized `combine_target_and_path` to use `std::borrow::Cow` to bypass string formatting allocations when the path already starts with `/`.
- Replaced expensive string formatting and parsing (`format!("http://{authority}{path_and_query}").parse()`) with `http::Uri::builder()`, constructing the `Uri` from pre-parsed components directly and avoiding any whole-string scanning.

### 🎯 Why: The performance problem it solves
The HTTP localhost forwarder reconstructs and dispatches requests on every inbound framed message. Previously, multiple intermediate `String` allocations occurred on every request:
1. Converting request path from bytes slice to `String` in `parse_request_head`.
2. Formatting and allocating target + path to query string.
3. Parsing target + path from a single continuous string back into components.

### 📊 Impact: Expected performance improvement
- Redundant heap allocations are reduced by up to 3 per forwarded request (fully zero-allocation request-path extraction and efficient builder-based target URI assembly).
- Reduces CPU instruction overhead and lock contention associated with memory allocations on the hot data-channel forwarding path.

### 🔬 Measurement: How to verify the improvement
- Built successfully and verified with workspace-wide unit and integration tests (`cargo test --workspace`).
- Verified with strict Clippy checks (`cargo clippy --workspace --all-targets -- -D warnings`).

---
*PR created automatically by Jules for task [1010621121177680781](https://jules.google.com/task/1010621121177680781) started by @vamzi*