### PR TITLE
🛡️ Sentinel: Fix Unix file-creation permission race conditions (TOCTOU)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Secure Unix File Creation
+**Vulnerability:** Unix file-creation permission race conditions (TOCTOU). When creating sensitive files (such as Ed25519 seeds, DTLS certs, and client allowlists), writing the file first and then setting permissions using `chmod` / `PermissionsExt::set_permissions` leaves a brief timing window where the file is created with default permissions (like 0644 or 0666) and can be read by other local users before permissions are narrowed.
+**Learning:** Setting the permissions on the `OpenOptions` before calling `open` / `create` sets the file creation mode atomically on Unix, closing this timing window.
+**Prevention:** Always use `std::fs::OpenOptions` or `tokio::fs::OpenOptions` with `.mode(0o600)` on Unix when creating highly sensitive files to prevent access-control race conditions.

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,22 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut file = options.open(&tmp).await?;
+    use tokio::io::AsyncWriteExt;
+    file.write_all(pem.as_bytes()).await?;
+    file.flush().await?;
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,14 +106,21 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut file = options.open(&tmp).await?;
+    use tokio::io::AsyncWriteExt;
+    file.write_all(bytes).await?;
+    file.flush().await?;
 
     tokio::fs::rename(&tmp, path).await
 }

--- a/crates/openhost-daemon/src/pair_watcher.rs
+++ b/crates/openhost-daemon/src/pair_watcher.rs
@@ -287,7 +287,9 @@ mod tests {
 
         let mut watcher =
             PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
-        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Drain any immediate startup/noisy events (e.g. from the initial write of allow.toml)
+        while tokio::time::timeout(Duration::from_millis(100), watcher.recv()).await.is_ok() {}
 
         fs::write(&sibling, b"unrelated").unwrap();
 

--- a/crates/openhost-daemon/src/pair_watcher.rs
+++ b/crates/openhost-daemon/src/pair_watcher.rs
@@ -289,7 +289,10 @@ mod tests {
             PairWatcher::spawn(&path, Duration::from_millis(50)).expect("watcher spawns");
 
         // Drain any immediate startup/noisy events (e.g. from the initial write of allow.toml)
-        while tokio::time::timeout(Duration::from_millis(100), watcher.recv()).await.is_ok() {}
+        while tokio::time::timeout(Duration::from_millis(100), watcher.recv())
+            .await
+            .is_ok()
+        {}
 
         fs::write(&sibling, b"unrelated").unwrap();
 

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,14 +168,21 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut file = options.open(&tmp)?;
+    use std::io::Write;
+    file.write_all(body.as_bytes())?;
+    file.flush()?;
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
🛡️ Sentinel Security Improvement PR

🚨 Severity: HIGH
💡 Vulnerability: Unix file-creation permission race conditions (TOCTOU). Writing sensitive files with default permissions and then subsequently narrowing them with chmod/set_permissions leaves a brief timing window where local processes can read the files.
🎯 Impact: Local attackers could potentially read Ed25519 seeds, DTLS certificate keys, or the client pairing database during creation/rotation.
🔧 Fix: Set `OpenOptions` mode to `0o600` on Unix systems at creation time so files are atomically initialized with the correct secure permissions.
✅ Verification: Built and ran the full suite of cargo workspace unit and integration tests successfully, confirming permissions are correctly verified as 0600.

---
*PR created automatically by Jules for task [4452256237962617350](https://jules.google.com/task/4452256237962617350) started by @vamzi*