### PR TITLE
⚡ Bolt: Optimize packet fragment reassembly via single-pass O(N) bucket sort

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,9 @@
+# Bolt's Journal
+
+## 2026-07-20 - O(N) single-pass bucket-sort fragment reassembly optimization
+**Learning:** Found that walking the packet's RR list chunk_total times is fine for 1-3 fragments but O(N^2) in pathological cases with MAX_FRAGMENT_TOTAL=255.
+**Action:** Decoded answer fragments from packets can be reassembled in a single O(N) pass.
+
+## 2026-07-28 - Forwarding URL and string optimization
+**Learning:** Avoided intermediate `String` allocations by using `http::Uri::builder()`, zero-allocation `&str` request-path borrowing, and `std::borrow::Cow` path normalization.
+**Action:** Use pre-parsed `HeaderValue` for host_override and write macro on a buffer directly.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,17 +1098,49 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Optimized: O(N) single-pass bucket sort of answer fragments.
+    let mut seen_txt_counts = [0usize; 256];
+    let mut txt_contents: Vec<Option<String>> = std::iter::repeat_with(|| None).take(256).collect();
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            let first_label = rr.name.get_labels().first();
+            if let Some(label) = first_label {
+                if let Ok(label_str) = std::str::from_utf8(label.as_ref()) {
+                    let label_str = label_str.strip_suffix('.').unwrap_or(label_str);
+                    if let Some(suffix) = label_str.strip_prefix(&base) {
+                        if let Some(idx_str) = suffix.strip_prefix('-') {
+                            if let Ok(idx) = idx_str.parse::<u8>() {
+                                let idx_usize = idx as usize;
+                                seen_txt_counts[idx_usize] += 1;
+                                if seen_txt_counts[idx_usize] > 1 {
+                                    return Err(PkarrError::MultipleOpenhostRecords);
+                                }
+
+                                let mut out = String::new();
+                                for (key, value) in txt.iter_raw() {
+                                    out.push_str(
+                                        core::str::from_utf8(key)
+                                            .map_err(|_| PkarrError::InvalidUtf8)?,
+                                    );
+                                    if let Some(v) = value {
+                                        out.push('=');
+                                        out.push_str(
+                                            core::str::from_utf8(v)
+                                                .map_err(|_| PkarrError::InvalidUtf8)?,
+                                        );
+                                    }
+                                }
+                                txt_contents[idx_usize] = Some(out);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let Some(first_text) = &txt_contents[0] else {
         return Ok(None);
     };
     let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
@@ -1123,10 +1155,12 @@ pub fn decode_answer_fragments_from_packet(
     let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
     fragments.push(first);
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
+        let i_usize = i as usize;
+        let text = txt_contents[i_usize]
+            .as_ref()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
         let frag = decode_fragment(&bytes)?;
         if frag.total != total {


### PR DESCRIPTION
### 💡 What
Optimized `decode_answer_fragments_from_packet` in `crates/openhost-pkarr/src/offer.rs` by scanning the packet's resource records in a single pass rather than sequentially probing for each index. The matching TXT records are bucket-sorted into a pre-allocated vector initialized safely using `std::iter::repeat_with`. Additionally, the first label is extracted from the resource record names using `.get_labels().first()` to robustly handle absolute domain names with zone suffixes.

### 🎯 Why
The original implementation searched the packet's resource records list `chunk_total` times, leading to an $O(N^2)$ lookup complexity. For packets with a large number of fragments (up to `MAX_FRAGMENT_TOTAL = 255`), this sequential probing walked the packet's resource records list excessively.

### 📊 Impact
Reduces packet reassembly time from $O(N^2)$ to $O(N)$ complexity. For standard 1-3 fragment packets, it saves redundant inner-loop scans, and for pathological large packets with many fragments, it eliminates up to 255 redundant full scans of the resource records.

### 🔬 Measurement
Validated via existing and full workspace test suites (`cargo test --workspace`), which pass with zero warnings or errors.

---
*PR created automatically by Jules for task [6197625212399905312](https://jules.google.com/task/6197625212399905312) started by @vamzi*