### PR TITLE
⚡ Bolt: optimize DNS packet processing via O(N) single-pass bucket sort

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-28 - DNS Packet Single-Pass Fragment Reassembly with O(N) Bucket Sort
+**Learning:** Sequential DNS packet record queries using `packet.resource_records(name)` scale quadratically O(N^2) in the number of fragments because each query scans all packet records, performing repetitive string formatting and allocations. By using `packet.all_resource_records()` and `get_labels().first()` with a fixed-size `Vec<Option<DecodedFragment>>` array of size 256, we can reassemble fragments in a single O(N) pass with zero string formatting/allocations on mismatching labels.
+**Action:** Always prefer single-pass linear scans over sequential multiple-probing queries for packet-level or collection-level reassembly tasks in pkarr/DNS parsing.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1097,48 +1097,106 @@ pub fn decode_answer_fragments_from_packet(
         "{ANSWER_TXT_PREFIX}{}",
         zbase32::encode_full_bytes(&client_hash)
     );
+    let prefix = format!("{base}-");
+    let prefix_bytes = prefix.as_bytes();
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
+    // Optimize DNS packet processing using O(N) single-pass bucket sort.
+    // Instead of querying packet.resource_records() total times (O(N^2) complexity
+    // and multiple formatted string allocations per loop iteration), we iterate
+    // through all resource records exactly once and sort fragments by index.
+    // Using a stack-allocated array of size 256 avoids any heap allocation/initialization overhead.
+    let mut buckets: [Option<DecodedFragment>; 256] = {
+        const NONE: Option<DecodedFragment> = None;
+        [NONE; 256]
+    };
+    let mut fragment_total: Option<u8> = None;
+    let mut found_any = false;
 
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
+    for rr in packet.all_resource_records() {
+        let labels = rr.name.get_labels();
+        if let Some(first_label) = labels.first() {
+            let label_bytes = first_label.as_ref();
+            if label_bytes.starts_with(prefix_bytes) {
+                if let RData::TXT(txt) = &rr.rdata {
+                    let index_bytes = &label_bytes[prefix_bytes.len()..];
+                    let index_str = core::str::from_utf8(index_bytes).map_err(|_| {
+                        PkarrError::MalformedCanonical("invalid utf-8 in index suffix")
+                    })?;
+                    let idx: u8 = index_str.parse().map_err(|_| {
+                        PkarrError::MalformedCanonical("failed to parse index suffix as u8")
+                    })?;
+
+                    let idx_usize = idx as usize;
+
+                    if buckets[idx_usize].is_some() {
+                        return Err(PkarrError::MultipleOpenhostRecords);
+                    }
+
+                    // Extract and decode TXT contents
+                    let mut text = String::new();
+                    for (key, value) in txt.iter_raw() {
+                        text.push_str(
+                            core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?,
+                        );
+                        if let Some(v) = value {
+                            text.push('=');
+                            text.push_str(
+                                core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?,
+                            );
+                        }
+                    }
+
+                    let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
+                    let frag = decode_fragment(&bytes)?;
+
+                    if frag.idx != idx {
+                        return Err(PkarrError::MalformedCanonical(
+                            "answer fragment idx disagrees with its DNS label suffix",
+                        ));
+                    }
+
+                    if let Some(total) = fragment_total {
+                        if frag.total != total {
+                            return Err(PkarrError::MalformedCanonical(
+                                "answer fragments disagree on chunk_total",
+                            ));
+                        }
+                    } else {
+                        fragment_total = Some(frag.total);
+                    }
+
+                    buckets[idx_usize] = Some(frag);
+                    found_any = true;
+                }
+            }
+        }
+    }
+
+    if !found_any {
+        return Ok(None);
+    }
+
+    // Ensure we have fragment 0. If fragment 0 is absent, return Ok(None) to maintain backward compatibility.
+    let Some(first) = buckets[0].take() else {
         return Ok(None);
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
+
+    let total = first.total;
+    if total == 0 {
         return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
+            "fragment set has zero total",
         ));
     }
-    let total = first.total;
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
+    let mut fragments = Vec::with_capacity(total as usize);
     fragments.push(first);
+
     for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
-        if frag.total != total {
+        let Some(frag) = buckets[i as usize].take() else {
             return Err(PkarrError::MalformedCanonical(
-                "answer fragments disagree on chunk_total",
+                "answer fragment set is missing an idx",
             ));
-        }
-        if frag.idx != i {
-            return Err(PkarrError::MalformedCanonical(
-                "answer fragment idx disagrees with its DNS label suffix",
-            ));
-        }
+        };
         fragments.push(frag);
     }
 


### PR DESCRIPTION
💡 What: Optimized `decode_answer_fragments_from_packet` in `crates/openhost-pkarr/src/offer.rs` using a single-pass O(N) bucket-sort algorithm. Also completely eliminated heap allocations for bucket initialization by utilizing a stack-allocated `[Option<DecodedFragment>; 256]` array.

🎯 Why: Sequential DNS packet record queries using `packet.resource_records(name)` scale quadratically O(N^2) in the number of fragments because each query scans all packet records, performing repetitive string formatting and allocations.

📊 Impact: Reduces processing complexity from O(N^2) to O(N) while completely eliminating heap allocation and initialization overhead for the bucket-sort tracking.

🔬 Measurement: Run the test suite via `cargo test -p openhost-pkarr` to verify functional correctness.

---
*PR created automatically by Jules for task [17835322782711109516](https://jules.google.com/task/17835322782711109516) started by @vamzi*