### PR TITLE
🛡️ Sentinel: secure atomic file creation permissions on Unix

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel's Security Journal
+
+## 2026-07-28 - HTTP Request Smuggling Prevention (RFC 7230 §3.2.4)
+**Vulnerability:** HTTP Request Smuggling could occur if whitespace (space or tab) surrounding a header name was not rejected.
+**Learning:** Strict compliance with RFC 7230 §3.2.4 is required to prevent parsing deviations between the openhost daemon forwarder and upstream servers.
+**Prevention:** Explicitly reject any request header containing leading or trailing whitespace around its name in `parse_request_head` and trim OWS from values.
+
+## 2026-07-28 - Unix File Creation Permission Race Condition
+**Vulnerability:** Creating sensitive files (e.g., Ed25519 seeds, DTLS certs, allowlists) with default permissions and subsequently changing their mode using `set_permissions` opens a TOCTOU (Time of Check, Time of Use) timing window. During this window, other unprivileged local users could read the sensitive data.
+**Learning:** File permissions must be set atomically at the exact moment of file creation rather than as a post-creation adjustment.
+**Prevention:** Use `OpenOptions` (either `std::fs` or `tokio::fs`) with `OpenOptionsExt::mode(0o600)` on Unix platforms to ensure atomic 0o600 permissions at creation time.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -228,18 +228,22 @@ pub async fn run(file: PathBuf) -> Result<()> {
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
     use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut f = options
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
     f.write_all(seed).await?;
     f.flush().await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,23 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut f = options.open(&tmp).await?;
+        f.write_all(pem.as_bytes()).await?;
+        f.flush().await?;
+    }
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,13 +106,21 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
 
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut file = options.open(&tmp).await?;
+        file.write_all(bytes).await?;
+        file.flush().await?;
     }
 
     tokio::fs::rename(&tmp, path).await

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,13 +168,21 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
 
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    {
+        use std::io::Write;
+        let mut f = options.open(&tmp)?;
+        f.write_all(body.as_bytes())?;
+        f.flush()?;
     }
 
     std::fs::rename(&tmp, path)?;


### PR DESCRIPTION
### Description
This security improvement addresses a potential Time-of-Check to Time-of-Use (TOCTOU) file permission race condition on Unix platforms. Previously, sensitive files (including Ed25519 seeds, DTLS certs, and allowlist pairing databases) were created using default permissions (typically subject to umask) and then restricted to `0o600` via a subsequent `set_permissions` call. This left a brief window during which an unprivileged local user could potentially open and read the file.

The fix introduces atomic `0o600` file creation permissions on Unix platforms by configuring `OpenOptionsExt::mode(0o600)` at creation time, while maintaining cross-platform compatibility for non-Unix platforms (e.g., Windows).

### Fix
- Replaced the write-then-chmod flow with atomic `OpenOptions` configuration.
- Configured `.mode(0o600)` at creation time on Unix for:
  - Private identity seeds in `crates/openhost-daemon/src/identity_store.rs`
  - Ephemeral sender seeds in `crates/openhost-cli/src/send.rs`
  - Private DTLS certificates in `crates/openhost-daemon/src/dtls_cert.rs`
  - The pairing allowlist database in `crates/openhost-daemon/src/pairing.rs`
- Isolated the Unix-only extension calls within clean conditional blocks (`#[cfg(unix)]`) to ensure full platform compatibility.

### Verification
- Format and clippy checked successfully via `cargo fmt --all --check` and `cargo clippy --workspace --all-targets`.
- Verified that all workspace tests pass successfully using `cargo test --workspace`.

---
*PR created automatically by Jules for task [1323244945308074548](https://jules.google.com/task/1323244945308074548) started by @vamzi*