### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP Request Smuggling via RFC 7230 §3.2.4 strict header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Security Journal
+
+## 2026-07-28 - Strict Compliance with RFC 7230 §3.2.4 to Prevent HTTP Request Smuggling
+**Vulnerability:** HTTP Request Smuggling due to lenient parsing of header names containing surrounding whitespace.
+**Learning:** Standard parser tolerance was trimming surrounding whitespace of header names (e.g., space or tab before the colon), allowing malformed requests that could bypass security gateways or cause downstream desynchronization.
+**Prevention:** Explicitly reject any HTTP request containing spaces or tabs leading, trailing, or before the colon in a header name, enforcing strict token validation before processing.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,14 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.starts_with([' ', '\t']) || name.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "header name has surrounding whitespace",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` at both ends of header value
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +787,36 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_around_header_name() {
+        // Space before colon
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        // Tab before colon
+        let raw = b"GET / HTTP/1.1\r\nHost\t: example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        // Leading space
+        let raw = b"GET / HTTP/1.1\r\n Host: example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        // Leading tab
+        let raw = b"GET / HTTP/1.1\r\n\tHost: example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_optional_whitespace_in_values() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example.com  \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: HTTP Request Smuggling / Lenient header parsing allowing whitespace before/around the colon.
🎯 Impact: Attackers could inject headers or smuggle HTTP requests through parsing desynchronization with downstream servers.
🔧 Fix: Implemented strict check in `parse_request_head` rejecting header names with leading/trailing spaces or tabs, or whitespace before the colon. Trim optional whitespace (OWS) on both ends of the header value.
✅ Verification: Covered with comprehensive unit tests (`parse_request_head_rejects_whitespace_around_header_name`, `parse_request_head_trims_optional_whitespace_in_values`). All workspace tests compile and pass cleanly.

---
*PR created automatically by Jules for task [7840646120835984294](https://jules.google.com/task/7840646120835984294) started by @vamzi*