### PR TITLE
🛡️ Sentinel: Fix HTTP Request Smuggling via RFC 7230 Compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - HTTP Request Smuggling RFC 7230 Compliance
+**Vulnerability:** HTTP Request Smuggling due to permissive parsing of spaces/tabs preceding the colon in HTTP header names, or around the header values.
+**Learning:** Permitting whitespace before a header name's colon violates RFC 7230 §3.2.4 and can lead to severe request smuggling or caching issues when chained with strict downstream or upstream proxies that process the whitespace differently.
+**Prevention:** Explicitly reject any HTTP request headers containing whitespace between the header name and the colon, and trim both leading and trailing optional whitespace (OWS) on the header value to ensure parsing consistency.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -386,7 +386,9 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let name_raw = &line[..colon];
         // RFC 7230 §3.2.4: Reject if whitespace exists between header-name and colon
         if name_raw.ends_with(' ') || name_raw.ends_with('\t') {
-            return Err(ForwardError::HeadParse("whitespace before colon in header name"));
+            return Err(ForwardError::HeadParse(
+                "whitespace before colon in header name",
+            ));
         }
         let name = name_raw.trim();
         if name.is_empty() {

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name_raw = &line[..colon];
+        // RFC 7230 §3.2.4: Reject if whitespace exists between header-name and colon
+        if name_raw.ends_with(' ') || name_raw.ends_with('\t') {
+            return Err(ForwardError::HeadParse("whitespace before colon in header name"));
+        }
+        let name = name_raw.trim();
+        if name.is_empty() {
+            return Err(ForwardError::HeadParse("empty header name"));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        // Trim both ends to robustly handle OWS at both ends of the header value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +791,24 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_before_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example.com\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows_from_both_ends_of_header_value() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example.com\t \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
### 🛡️ Sentinel: Fix HTTP Request Smuggling via RFC 7230 Compliance

🚨 **Severity:** HIGH
💡 **Vulnerability:** HTTP Request Smuggling via permissive whitespace parsing preceding a header name's colon.
🎯 **Impact:** Permitting trailing whitespace before a header colon violates RFC 7230 §3.2.4 and can allow an attacker to bypass upstream controls or trigger request smuggling attacks when openhostd is coupled with strict downstream/upstream proxies.
🔧 **Fix:** Explicitly reject any HTTP requests containing whitespace before the colon in header names, and securely trim both ends of the header values to handle OWS robustly.
✅ **Verification:** Expanded the unit test suite in `crates/openhost-daemon/src/forward.rs` with `parse_request_head_rejects_whitespace_before_colon` and `parse_request_head_trims_ows_from_both_ends_of_header_value`. All tests pass successfully.


---
*PR created automatically by Jules for task [2861754212000082523](https://jules.google.com/task/2861754212000082523) started by @vamzi*