### PR TITLE
🛡️ Sentinel: Zeroize sensitive channel-binding exporter secrets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,13 @@
+# Sentinel Security Journal
+
+This is a record of critical security learnings for the openhost codebase.
+
+## 2026-07-28 - Preventing Unix File Permission Race Conditions
+**Vulnerability:** Weak default file-creation permissions allowed sensitive files (e.g., Ed25519 seeds) to be temporarily readable by other local users before explicit `chmod` was called, creating a TOCTOU (time-of-check to time-of-use) race condition window.
+**Learning:** Operating system file creation defaults (umask) can be overly permissive, and setting permissions post-creation leaves a race window open.
+**Prevention:** Use platform-specific `OpenOptionsExt::mode(0o600)` at the exact moment of file creation so the file is never readable by other users.
+
+## 2026-07-28 - Zeroizing Sensitive Handshake Keying Material
+**Vulnerability:** The DTLS exporter secret (sensitive keying material used for channel binding) was returned as a raw heap-allocated `Vec<u8>` on both client and daemon sides. When deallocated at the end of the handshake, the plaintext bytes lingered in heap memory.
+**Learning:** Raw vectors do not automatically zeroize their contents on drop.
+**Prevention:** Wrap raw sensitive buffers in `zeroize::Zeroizing` to ensure the memory is cleared immediately when it goes out of scope.

--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -615,6 +615,7 @@ async fn complete_binding(
             ClientBindingError::ExporterLength(exporter.len()),
         ));
     }
+    let exporter = Zeroizing::new(exporter);
 
     // Wait for AuthNonce.
     let nonce_frame = inbound.next_frame(timeout).await?;

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -44,6 +44,7 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::peer_connection::RTCPeerConnection;
+use zeroize::Zeroizing;
 
 /// Ensures the rustls CryptoProvider is installed exactly once per
 /// process. Required in rustls 0.23+ because the crate no longer picks
@@ -1154,7 +1155,7 @@ async fn handle_auth_client(
 ) -> FrameOutcome {
     let binding_secret =
         match derive_binding_secret(dtls_transport, binding_mode, local_dtls_fp).await {
-            Ok(bytes) => bytes,
+            Ok(bytes) => Zeroizing::new(bytes),
             Err(reason) => {
                 tracing::warn!(
                     ?binding_mode,


### PR DESCRIPTION
🛡️ Sentinel: Zeroize sensitive channel-binding exporter secrets

🚨 Severity: MEDIUM (Security Hardening / Defense in Depth)

💡 Vulnerability:
The DTLS exporter secret (the master keying material used for channel binding) was returned as a raw heap-allocated `Vec<u8>`. After the channel-binding verification process completes or fails, these vectors are deallocated without clearing their underlying buffer, leaving sensitive session-derived keying material lingering in heap memory.

🎯 Impact:
A malicious local user or another process with capability to read daemon memory could potentially extract active session-derived keying material from memory, compromising the confidentiality and isolation of past DTLS connections.

🛠️ Fix:
Wrapped the returned DTLS exporter secret (`exporter` in `crates/openhost-client/src/dialer.rs` and `binding_secret` in `crates/openhost-daemon/src/listener.rs`) in a `zeroize::Zeroizing` wrapper. This ensures the underlying heap-allocated keying material is explicitly zeroized on drop immediately after the channel-binding step finishes.

✅ Verification:
1. Ran all tests across the workspace using `cargo test --workspace` and verified that they compile and pass perfectly.
2. Verified correct memory zeroization semantics via Rust's strong compile-time types for `zeroize::Zeroizing`.
3. Validated code style and formatting using `cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings`.

---
*PR created automatically by Jules for task [2377739493441013002](https://jules.google.com/task/2377739493441013002) started by @vamzi*