### PR TITLE
⚡ Bolt: O(N) single-pass bucket-sort fragment reassembly optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-07-20 - O(N) single-pass bucket-sort fragment reassembly optimization
+**Learning:** Walking the resource record list O(N²) times is highly inefficient in the pathological case of MAX_FRAGMENT_TOTAL=255. By using `packet.all_resource_records()` and bucket-sorting the fragments into a stack-allocated array (of size 256) by their numeric index suffix in a single O(N) pass, we completely eliminate duplicate lookup walks and minimize memory allocation overhead.
+**Action:** Always prefer a single-pass scan with a bounded stack-allocated index array/bucket list when reassembling indexed packet structures rather than doing N repeated lookups.

--- a/crates/openhost-pkarr/src/offer.rs
+++ b/crates/openhost-pkarr/src/offer.rs
@@ -1098,37 +1098,68 @@ pub fn decode_answer_fragments_from_packet(
         zbase32::encode_full_bytes(&client_hash)
     );
 
-    // TODO(perf): replace the per-fragment `collect_single_txt` probes
-    // with a single pass over `packet.all_resource_records()` that
-    // bucket-sorts matching names by their numeric `-<idx>` suffix.
-    // Today this walks the packet's RR list `chunk_total` times — fine
-    // for the 1–3 fragments we see in practice, O(N²) in the
-    // pathological MAX_FRAGMENT_TOTAL=255 case. Not a hotpath (one
-    // reassembly per dial attempt) so the refactor is deferred.
-
-    // Probe idx = 0 first. Missing zero-fragment ⇒ no answer for us.
-    let first_name = format!("{base}-0");
-    let Some(first_text) = collect_single_txt(packet, &first_name)? else {
-        return Ok(None);
+    // O(N) single-pass bucket-sort fragment reassembly optimization.
+    // We walk packet.all_resource_records() once and bucket-sort any matching
+    // answer fragments by their numeric -<idx> suffix.
+    let mut buckets: [Option<DecodedFragment>; 256] = {
+        const NONE: Option<DecodedFragment> = None;
+        [NONE; 256]
     };
-    let first_bytes = URL_SAFE_NO_PAD.decode(first_text.as_bytes())?;
-    let first = decode_fragment(&first_bytes)?;
-    if first.idx != 0 {
-        return Err(PkarrError::MalformedCanonical(
-            "answer fragment 0 carries non-zero idx",
-        ));
+
+    let prefix = format!("{base}-");
+
+    for rr in packet.all_resource_records() {
+        if let RData::TXT(txt) = &rr.rdata {
+            let labels = rr.name.get_labels();
+            let first_label = labels.first();
+            let label_opt = first_label.and_then(|l| core::str::from_utf8(l.as_ref()).ok());
+
+            if let Some(label_str) = label_opt {
+                if let Some(suffix) = label_str.strip_prefix(&prefix) {
+                    if let Ok(idx) = suffix.parse::<u8>() {
+                        if buckets[idx as usize].is_some() {
+                            return Err(PkarrError::MultipleOpenhostRecords);
+                        }
+                        let mut out = String::new();
+                        for (key, value) in txt.iter_raw() {
+                            out.push_str(
+                                core::str::from_utf8(key).map_err(|_| PkarrError::InvalidUtf8)?,
+                            );
+                            if let Some(v) = value {
+                                out.push('=');
+                                out.push_str(
+                                    core::str::from_utf8(v).map_err(|_| PkarrError::InvalidUtf8)?,
+                                );
+                            }
+                        }
+                        let bytes = URL_SAFE_NO_PAD.decode(out.as_bytes())?;
+                        let frag = decode_fragment(&bytes)?;
+                        if frag.idx != idx {
+                            return Err(PkarrError::MalformedCanonical(
+                                "answer fragment idx disagrees with its DNS label suffix",
+                            ));
+                        }
+                        buckets[idx as usize] = Some(frag);
+                    }
+                }
+            }
+        }
     }
+
+    if buckets[0].is_none() {
+        return Ok(None);
+    }
+
+    let first = buckets[0].as_ref().expect("already checked is_some");
     let total = first.total;
 
-    let mut fragments: Vec<DecodedFragment> = Vec::with_capacity(total as usize);
-    fragments.push(first);
-    for i in 1..total {
-        let name = format!("{base}-{i}");
-        let text = collect_single_txt(packet, &name)?.ok_or(PkarrError::MalformedCanonical(
-            "answer fragment set is missing an idx",
-        ))?;
-        let bytes = URL_SAFE_NO_PAD.decode(text.as_bytes())?;
-        let frag = decode_fragment(&bytes)?;
+    let mut fragments = Vec::with_capacity(total as usize);
+    for i in 0..total {
+        let frag = buckets[i as usize]
+            .take()
+            .ok_or(PkarrError::MalformedCanonical(
+                "answer fragment set is missing an idx",
+            ))?;
         if frag.total != total {
             return Err(PkarrError::MalformedCanonical(
                 "answer fragments disagree on chunk_total",


### PR DESCRIPTION
💡 What:
Replaced the O(N²) loop that probes for answer fragments via sequential `collect_single_txt` queries with an O(N) single-pass bucket-sort algorithm over `packet.all_resource_records()`. It identifies fragments matching `_answer-<client-hash>-` once, parses their indices, and places them into a stack-allocated lookup array of size 256.

🎯 Why:
The original approach performed repeated lookup walks over the packet's resource records list `chunk_total` times (once per index probe from `0..total`). In the pathological case where `MAX_FRAGMENT_TOTAL` can be up to 255, this resulted in an O(N²) walk with redundant allocations.

📊 Impact:
- Reduces time complexity of fragment reassembly from O(N²) to O(N).
- Eliminates repeated heap-allocated string formatting / construction for name probes.
- Completely avoids redundant cloning of the decrypted payload vectors when moving them from buckets to the final reassembly list.

🔬 Measurement:
- Run `cargo test -p openhost-pkarr` to verify the reassembly test cases (`small_answer_fragments_and_reassembles`, `multi_fragment_answer_reassembles`, and error handling/validation tests).
- Benchmark-tested locally to confirm O(N) complexity behavior under high fragment counts.

---
*PR created automatically by Jules for task [18389654649336638448](https://jules.google.com/task/18389654649336638448) started by @vamzi*