### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP Request Smuggling via strict RFC 7230 header parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,8 @@
+# Sentinel Security Journal
+
+This is a record of critical security learnings for the openhost codebase.
+
+## 2026-07-28 - HTTP Request Smuggling via Lenient Header Parsing (RFC 7230 §3.2.4)
+**Vulnerability:** The localhost HTTP request forwarder parsed header field names leniently using `.trim()`, which allowed request headers to have trailing or leading whitespace around field names (e.g., `Host : example.com`). This violates RFC 7230 §3.2.4 and can lead to HTTP Request Smuggling where a downstream/upstream proxy parses headers differently.
+**Learning:** Permissive string-trimming during parsing hides malformed input and introduces parsing inconsistencies between hops, which is the root cause of request smuggling.
+**Prevention:** Never use a generic `.trim()` on header names during HTTP parsing. Explicitly validate that header names contain absolutely no leading or trailing whitespace (SP/HTAB) surrounding the name or before the colon, and reject invalid requests immediately.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,19 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
+        let name_raw = &line[..colon];
+        if name_raw.starts_with([' ', '\t']) || name_raw.ends_with([' ', '\t']) {
+            return Err(ForwardError::HeadParse(
+                "whitespace surrounding header name",
+            ));
+        }
+        let name = name_raw;
+        if name.is_empty() {
+            return Err(ForwardError::HeadParse("empty header name"));
+        }
         // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        // Trim both ends to robustly handle OWS at both ends of the header value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +771,28 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_around_colon() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example.com\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+
+        let raw3 = b"GET / HTTP/1.1\r\n Host: example.com\r\n\r\n";
+        let err3 = parse_request_head(raw3).unwrap_err();
+        assert!(matches!(err3, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows_from_both_ends_of_header_value() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example.com\t \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
The localhost HTTP forwarder in `openhost-daemon` parsed HTTP request head fields leniently using a generic `.trim()` on the extracted header field name part. This allowed request header field names containing surrounding whitespace (e.g., spaces or tabs) before the colon separator (such as `Host : example.com` or `Host\t: example.com`) to be accepted and forwarded. Additionally, only leading OWS was stripped from header values, leaving trailing OWS unhandled.

This parsing leniency violates RFC 7230 §3.2.4, which strictly prohibits any whitespace between the header field name and the colon, and specifies that optional whitespace (OWS) must be trimmed from both ends of field values.

🎯 Impact:
If downstream or upstream proxies/servers handle field-name surrounding whitespace differently (e.g., by rejecting or ignoring them, or interpreting them as different headers), an attacker can exploit this discrepancy to mount HTTP Request Smuggling (HRS) attacks. This can lead to cache poisoning, request hijacking, or bypassing security controls on the forwarded path.

🔧 Fix:
- Modified `parse_request_head` in `crates/openhost-daemon/src/forward.rs` to explicitly check and reject any header line where the field name contains leading or trailing spaces or tabs before the colon.
- Replaced the `.trim()` on the header name with strict checking and zero leniency.
- Changed header value trimming to use `.trim_matches([' ', '\t'])` so that optional whitespace (OWS) is correctly and robustly stripped from both ends of the header value, fully satisfying RFC 7230 §3.2.4 requirements.

✅ Verification:
- Added `parse_request_head_rejects_whitespace_around_colon` unit test to verify that request heads with spaces/tabs surrounding/before the colon are successfully caught and rejected.
- Added `parse_request_head_trims_ows_from_both_ends_of_header_value` unit test to verify correct OWS trimming of both ends of values.
- Verified that all unit and workspace tests pass successfully (`cargo test --workspace`).
- Verified formatting and linting are perfectly clean (`cargo fmt --all --check` & `cargo clippy --workspace -- -D warnings`).

---
*PR created automatically by Jules for task [4929982432204911036](https://jules.google.com/task/4929982432204911036) started by @vamzi*