### PR TITLE
🛡️ Sentinel: Fix HTTP Request Smuggling via RFC 7230 compliance

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,9 @@
+## 2026-07-28 - Preventing Unix File Creation Permission Race Condition
+**Vulnerability:** Creating sensitive files (such as identities, seeds, certs, or allowlists) and then tightening permissions (e.g. via chmod) creates a brief Time-of-Check to Time-of-Use (TOCTOU) timing window during which other local users could potentially read or write to the file.
+**Learning:** This existed because file permissions were set post-creation via chmod.
+**Prevention:** Ensure highly sensitive files are atomically created with strict permissions using `OpenOptionsExt::mode(0o600)` on Unix platforms at creation time.
+
+## 2026-07-28 - Strict Compliance with RFC 7230 §3.2.4 to Prevent HTTP Request Smuggling
+**Vulnerability:** Accepting requests where leading or trailing whitespace surrounds a header name violates RFC 7230 §3.2.4 and can lead to HTTP Request Smuggling or Header Injection attacks when requests are forwarded upstream.
+**Learning:** This existed because header parsers or forwarders may trim whitespace around header names, allowing malicious clients to craft requests that are parsed differently by our forwarder and the upstream proxy.
+**Prevention:** Explicitly reject any request containing whitespace (space or horizontal tab) surrounding a header name, and strictly trim optional whitespace (OWS) at both ends of header values.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,18 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        if name.starts_with(' ')
+            || name.starts_with('\t')
+            || name.ends_with(' ')
+            || name.ends_with('\t')
+        {
+            return Err(ForwardError::HeadParse(
+                "whitespace surrounding header name is forbidden by RFC 7230",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` at both ends of the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -782,6 +791,36 @@ mod tests {
         let raw = b"GET / HTTP/1.1\r\nNoColonHere\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_surrounding_whitespace_in_header_name() {
+        // Space before the colon
+        let raw1 = b"GET / HTTP/1.1\r\nHost : example\r\n\r\n";
+        let err1 = parse_request_head(raw1).unwrap_err();
+        assert!(matches!(err1, ForwardError::HeadParse(_)));
+
+        // Tab before the colon
+        let raw2 = b"GET / HTTP/1.1\r\nHost\t: example\r\n\r\n";
+        let err2 = parse_request_head(raw2).unwrap_err();
+        assert!(matches!(err2, ForwardError::HeadParse(_)));
+
+        // Space at the start of header name
+        let raw3 = b"GET / HTTP/1.1\r\n Host: example\r\n\r\n";
+        let err3 = parse_request_head(raw3).unwrap_err();
+        assert!(matches!(err3, ForwardError::HeadParse(_)));
+
+        // Tab at the start of header name
+        let raw4 = b"GET / HTTP/1.1\r\n\tHost: example\r\n\r\n";
+        let err4 = parse_request_head(raw4).unwrap_err();
+        assert!(matches!(err4, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_trims_ows_at_both_ends_of_value() {
+        let raw = b"GET / HTTP/1.1\r\nHost:  example.com\t \r\n\r\n";
+        let (_, _, headers) = parse_request_head(raw).unwrap();
+        assert_eq!(headers.get("host").unwrap(), "example.com");
     }
 
     // --- Response head encoder --------------------------------------


### PR DESCRIPTION
### 🛡️ Sentinel: Strict compliance with RFC 7230 §3.2.4

🚨 Severity: HIGH
💡 Vulnerability: HTTP Request Smuggling
🎯 Impact: An attacker could bypass security filters, hijack sessions, or access unauthorized data by crafting requests with spaces surrounding header names that are parsed differently by the forwarder and the upstream.
🔧 Fix: Explicitly reject headers containing leading or trailing whitespace around header names, and trim OWS at both ends of header values.
✅ Verification: Added robust unit tests verifying both header name validation and header value trimming. All tests pass successfully.

---
*PR created automatically by Jules for task [2762797620982666838](https://jules.google.com/task/2762797620982666838) started by @vamzi*