### PR TITLE
🛡️ Sentinel: [HIGH] Mitigate Unix file-creation permission race conditions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,11 @@
+# Sentinel Security Journal
+
+## 2026-07-28 - Preventing HTTP Request Smuggling via Header Name Whitespace Check (RFC 7230 §3.2.4)
+**Vulnerability:** HTTP Request Smuggling (HRS) is possible if upstreams and downstreams parse or handle header names with surrounding whitespace differently. RFC 7230 §3.2.4 explicitly mandates rejecting any request that contains whitespace (space or tab) surrounding a header name.
+**Learning:** Simply trimming whitespace from parsed header names is unsafe because an upstream proxy may interpret or route the request differently than the local forwarder, leading to security bypasses or cache poisoning.
+**Prevention:** Reject requests with an error (e.g., `ForwardError::HeadParse`) if whitespace is detected before the colon separator in a header line.
+
+## 2026-07-28 - Preventing Local File Permission Race Conditions via OpenOptions Atomic Creation
+**Vulnerability:** Local privilege escalation or sensitive data leakage (TOCTOU race condition) can occur if sensitive files (such as private keys, DTLS certificates, seeds, or pairing databases) are created with default permissive permissions and then subsequently restricted using `chmod` / `set_permissions`.
+**Learning:** During the tiny window between file creation and permission restriction, other local users could read the sensitive file.
+**Prevention:** Always use `OpenOptions` (`std::fs` or `tokio::fs`) with `.mode(0o600)` at creation time on Unix platforms so that the file is atomic and never exposed with permissive defaults.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -228,18 +228,24 @@ pub async fn run(file: PathBuf) -> Result<()> {
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
     use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut f = options
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
     f.write_all(seed).await?;
     f.flush().await?;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -138,19 +138,29 @@ pub async fn force_rotate(path: &Path) -> Result<DtlsCertificate, CertError> {
 }
 
 async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             tokio::fs::create_dir_all(parent).await?;
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut f = options.open(&tmp).await?;
+    f.write_all(pem.as_bytes()).await?;
+    f.flush().await?;
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -105,15 +105,23 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// atomic on POSIX; on Windows the final mode is whatever the parent ACL
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
+
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut f = options.open(&tmp).await?;
+    f.write_all(bytes).await?;
+    f.flush().await?;
 
     tokio::fs::rename(&tmp, path).await
 }

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -161,6 +161,8 @@ pub fn load(path: &Path) -> Result<PairingDb, PairingError> {
 /// Atomically overwrite the DB at `path`. On Unix the final file mode
 /// is 0600; on Windows the parent directory's ACL applies.
 pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
+    use std::io::Write;
+
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)?;
@@ -168,14 +170,20 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+
+    let mut f = options.open(&tmp)?;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
Local privilege escalation or sensitive data leakage (TOCTOU race condition) was possible if sensitive files (such as Ed25519 seeds, DTLS certificates, identity stores, or pairing databases) were created with default system permissions and subsequently restricted using `chmod` / `set_permissions` after creation. During the tiny window between file creation and permission restriction, other local users could read the sensitive files.

🎯 Impact:
A malicious local user could read sensitive cryptographic private seeds, DTLS certificates, or host/client allowlists before their permissions were restricted, bypassing protocol defenses and potentially compromising private keys.

🔧 Fix:
Replaced standard file writing or creation operations with `OpenOptions` (both `std::fs` and `tokio::fs`) with `.mode(0o600)` configured at creation time on Unix platforms. This ensures the files are atomically created with restricted permissions, closing the race condition completely.

✅ Verification:
1. Ran all tests using `cargo test --workspace` and verified all tests pass.
2. Verified code compilation and clippy lints run cleanly with `cargo clippy --workspace --all-targets -- -D warnings`.
3. Verified format with `cargo fmt --all --check`.

---
*PR created automatically by Jules for task [10452269942720141618](https://jules.google.com/task/10452269942720141618) started by @vamzi*