### PR TITLE
⚡ Bolt: optimize MailboxKey::seal with in-place encryption

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,18 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Single buffer pre-allocation for nonce || ciphertext || tag (16 bytes),
+        // encrypting plaintext in place to avoid intermediate heap allocations.
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(&tag);
+
         Ok(out)
     }
 


### PR DESCRIPTION
### 💡 What
Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to use `AeadInPlace::encrypt_in_place_detached` on a single pre-allocated output vector (`Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16)`).

### 🎯 Why
Previously, calling `cipher.encrypt(nonce, plaintext)` allocated an intermediate `Vec<u8>` for the ciphertext + tag, and then copied those bytes into a second newly allocated `out` vector. This resulted in two separate heap allocations per sealed mailbox envelope.

### 📊 Impact
Reduces heap allocations during mailbox record sealing from 2 allocations to 1 allocation per call, eliminating unnecessary allocation overhead during peer rendezvous.

### 🔬 Measurement
All unit tests in `openhost-peer` pass and verify that sealed envelopes produce identical byte structure (`nonce || ciphertext || tag`) and successfully open under `MailboxKey::open`. Verified with `cargo test -p openhost-peer` and workspace clippy/fmt checks.

---
*PR created automatically by Jules for task [3539634747927825844](https://jules.google.com/task/3539634747927825844) started by @vamzi*