### PR TITLE
🛡️ Sentinel: Add X-Content-Type-Options nosniff header to file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -304,7 +308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ok_response_carries_sha256_header() {
+    async fn ok_response_carries_sha256_and_nosniff_headers() {
         let blob = FileBlob {
             bytes: Bytes::from_static(b"abc"),
             sha256: String::from(
@@ -319,6 +323,11 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
     }


### PR DESCRIPTION
## 🛡️ Sentinel Security Enhancement

### 💡 Enhancement
Added `X-Content-Type-Options: nosniff` header to successful file responses served by `FileServer` in `crates/openhost-cli/src/file_server.rs`.

### 🎯 Impact
Prevents browsers and HTTP clients from performing MIME-type sniffing on served binary content, mitigating drive-by download and content interpretation risks.

### 🛠️ Fix
Instructs clients to strictly respect the `application/octet-stream` Content-Type header by setting `X-Content-Type-Options: nosniff`.

### ✅ Verification
- Unit test added in `crates/openhost-cli/src/file_server.rs` (`ok_response_carries_sha256_and_nosniff_headers`)
- Verified passing unit test suite with `cargo test -p openhost-cli`
- Passed `cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings`

---
*PR created automatically by Jules for task [14440077943315042013](https://jules.google.com/task/14440077943315042013) started by @vamzi*