### PR TITLE
🛡️ Sentinel: Add X-Content-Type-Options: nosniff header to CLI file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -212,6 +212,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         FILE_SHA256_HEADER,
         HeaderValue::from_str(&blob.sha256).expect("hex is a valid header value"),
     );
+    headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
     resp
 }
 
@@ -304,7 +308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ok_response_carries_sha256_header() {
+    async fn ok_response_carries_sha256_and_nosniff_headers() {
         let blob = FileBlob {
             bytes: Bytes::from_static(b"abc"),
             sha256: String::from(
@@ -319,6 +323,8 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
+        let nosniff = resp.headers().get(http::header::X_CONTENT_TYPE_OPTIONS).unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
     }

--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -323,7 +323,10 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
-        let nosniff = resp.headers().get(http::header::X_CONTENT_TYPE_OPTIONS).unwrap();
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
         assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");


### PR DESCRIPTION
### Security Context
- **Vulnerability / Security Goal:** Defense-in-depth against MIME-type sniffing attacks when files are served by the local CLI file server.
- **Fix:** Sets `X-Content-Type-Options: nosniff` in `build_ok_response` in `crates/openhost-cli/src/file_server.rs`.
- **Verification:** Unit test `ok_response_carries_sha256_and_nosniff_headers` verifies that the `nosniff` header is present on responses.

---
*PR created automatically by Jules for task [13586311569579299928](https://jules.google.com/task/13586311569579299928) started by @vamzi*