### PR TITLE
⚡ Bolt: optimize wire frame encoding/decoding and fix capacity reallocations

### DIFF
--- a/crates/openhost-client/src/dialer.rs
+++ b/crates/openhost-client/src/dialer.rs
@@ -689,7 +689,8 @@ impl Drop for PeerConnectionGuard {
 }
 
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<()> {
-    let mut buf = Vec::with_capacity(5 + frame.payload.len());
+    let mut buf =
+        Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf))
         .await

--- a/crates/openhost-core/src/wire/mod.rs
+++ b/crates/openhost-core/src/wire/mod.rs
@@ -186,11 +186,22 @@ impl Frame {
     /// tests only.
     pub fn encode(&self, out: &mut Vec<u8>) {
         out.reserve(FRAME_V2_HEADER_LEN + self.payload.len());
-        out.push(FRAME_V2_VERSION);
-        out.push(self.frame_type.as_u8());
-        out.extend_from_slice(&self.request_id.to_be_bytes());
         let len = u32::try_from(self.payload.len()).expect("length fits in u32 by construction");
-        out.extend_from_slice(&len.to_be_bytes());
+        let id_bytes = self.request_id.to_be_bytes();
+        let len_bytes = len.to_be_bytes();
+        let header: [u8; FRAME_V2_HEADER_LEN] = [
+            FRAME_V2_VERSION,
+            self.frame_type.as_u8(),
+            id_bytes[0],
+            id_bytes[1],
+            id_bytes[2],
+            id_bytes[3],
+            len_bytes[0],
+            len_bytes[1],
+            len_bytes[2],
+            len_bytes[3],
+        ];
+        out.extend_from_slice(&header);
         out.extend_from_slice(&self.payload);
     }
 
@@ -200,9 +211,16 @@ impl Frame {
     #[doc(hidden)]
     pub fn encode_v1(&self, out: &mut Vec<u8>) {
         out.reserve(FRAME_HEADER_LEN + self.payload.len());
-        out.push(self.frame_type.as_u8());
         let len = u32::try_from(self.payload.len()).expect("length fits in u32 by construction");
-        out.extend_from_slice(&len.to_le_bytes());
+        let len_bytes = len.to_le_bytes();
+        let header: [u8; FRAME_HEADER_LEN] = [
+            self.frame_type.as_u8(),
+            len_bytes[0],
+            len_bytes[1],
+            len_bytes[2],
+            len_bytes[3],
+        ];
+        out.extend_from_slice(&header);
         out.extend_from_slice(&self.payload);
     }
 
@@ -242,8 +260,7 @@ impl Frame {
             return Ok(None);
         }
         let type_byte = buf[0];
-        let len_bytes: [u8; 4] = buf[1..5].try_into().expect("5..5 slice");
-        let length = u32::from_le_bytes(len_bytes) as usize;
+        let length = u32::from_le_bytes([buf[1], buf[2], buf[3], buf[4]]) as usize;
 
         if length > MAX_PAYLOAD_LEN {
             return Err(Error::OversizedFrame {
@@ -282,10 +299,8 @@ impl Frame {
         }
         // buf[0] = version (already verified by caller)
         let type_byte = buf[1];
-        let id_bytes: [u8; 4] = buf[2..6].try_into().expect("2..6 slice");
-        let len_bytes: [u8; 4] = buf[6..10].try_into().expect("6..10 slice");
-        let request_id = u32::from_be_bytes(id_bytes);
-        let length = u32::from_be_bytes(len_bytes) as usize;
+        let request_id = u32::from_be_bytes([buf[2], buf[3], buf[4], buf[5]]);
+        let length = u32::from_be_bytes([buf[6], buf[7], buf[8], buf[9]]) as usize;
 
         if length > MAX_PAYLOAD_LEN {
             return Err(Error::OversizedFrame {

--- a/crates/openhost-daemon/src/listener.rs
+++ b/crates/openhost-daemon/src/listener.rs
@@ -1069,7 +1069,7 @@ async fn dispatch_frame(
         }
         FrameType::Ping => {
             let pong = Frame::new(FrameType::Pong, Vec::new()).expect("Pong is empty");
-            let mut out = Vec::with_capacity(5);
+            let mut out = Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN);
             pong.encode(&mut out);
             if let Err(err) = dc.send(&Bytes::from(out)).await {
                 tracing::warn!(?err, "openhostd: failed to send Pong");
@@ -1426,7 +1426,8 @@ async fn emit_response(dc: &RTCDataChannel, resp: ForwardResponse) -> Result<(),
 
 /// Encode one frame and send it as its own data-channel message.
 async fn send_frame(dc: &RTCDataChannel, frame: Frame) -> Result<(), webrtc::Error> {
-    let mut buf = Vec::with_capacity(5 + frame.payload.len());
+    let mut buf =
+        Vec::with_capacity(openhost_core::wire::FRAME_V2_HEADER_LEN + frame.payload.len());
     frame.encode(&mut buf);
     dc.send(&Bytes::from(buf)).await?;
     Ok(())


### PR DESCRIPTION
💡 What:
1. Fixed vector capacity allocation in `send_frame` in both `crates/openhost-daemon/src/listener.rs` and `crates/openhost-client/src/dialer.rs` from `5 + payload.len()` to `FRAME_V2_HEADER_LEN + payload.len()` (10 + payload.len()).
2. Batch-encoded header bytes in `Frame::encode` and `Frame::encode_v1` using stack-allocated `[u8; HEADER_LEN]` arrays and a single `extend_from_slice` call.
3. Simplified header slice decoding in `try_decode_v1` and `try_decode_v2` using direct array index expressions (`[buf[x], ...]`) instead of `try_into().expect(...)`.

🎯 Why:
V2 wire frames have a 10-byte header (`FRAME_V2_HEADER_LEN`), but `send_frame` was reserving only 5 header bytes + payload length. As a result, every frame emitted during HTTP transactions and channel binding caused `Vec` to reallocate memory when appending bytes past capacity. Furthermore, `Frame::encode` pushed bytes individually or in multiple slices, incurring redundant bounds checks.

📊 Impact:
- Completely eliminates heap buffer reallocations on every `send_frame` call in the daemon and client.
- Accelerates frame header construction and decoding across all data channel operations by allowing LLVM to emit vectorized single-instruction memory moves and eliminating slice conversion overhead.

🔬 Measurement:
Run `cargo test` to verify that all unit and integration tests for framing, channel binding, and HTTP forwarding continue to pass.

---
*PR created automatically by Jules for task [3624790575618935883](https://jules.google.com/task/3624790575618935883) started by @vamzi*