### PR TITLE
🛡️ Sentinel: set X-Content-Type-Options nosniff in file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -301,6 +305,22 @@ mod tests {
         assert!(!filename_val.contains('/'));
         assert!(!filename_val.contains(';'));
         assert!(!filename_val.contains(' '));
+    }
+
+    #[tokio::test]
+    async fn ok_response_carries_x_content_type_options_header() {
+        let blob = FileBlob {
+            bytes: Bytes::from_static(b"abc"),
+            sha256: String::from("0"),
+            filename: "abc.txt".to_owned(),
+            path: PathBuf::new(),
+        };
+        let resp = build_ok_response(&blob);
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Context
Sets the `X-Content-Type-Options: nosniff` HTTP security header on successful file responses served by the `oh send` CLI file server in `crates/openhost-cli/src/file_server.rs`.

### Changes
1. Added `X-Content-Type-Options: nosniff` header insertion in `build_ok_response`.
2. Added unit test `ok_response_carries_x_content_type_options_header` in `file_server.rs`.

### Verification
- `cargo test -p openhost-cli` passed cleanly.
- `cargo fmt --check` passed cleanly.

---
*PR created automatically by Jules for task [16952873180743314010](https://jules.google.com/task/16952873180743314010) started by @vamzi*