### PR TITLE
🛡️ Sentinel: Add X-Content-Type-Options: nosniff header to CLI file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -321,5 +325,21 @@ mod tests {
         );
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
+    }
+
+    #[test]
+    fn ok_response_carries_nosniff_header() {
+        let blob = FileBlob {
+            bytes: Bytes::from_static(b"abc"),
+            sha256: String::from("0"),
+            filename: "abc.txt".to_owned(),
+            path: PathBuf::new(),
+        };
+        let resp = build_ok_response(&blob);
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
     }
 }


### PR DESCRIPTION
Adds the `X-Content-Type-Options: nosniff` header to successful HTTP responses returned by the ephemeral CLI file server (`crates/openhost-cli/src/file_server.rs`). This prevents browsers/receivers from performing MIME sniffing on served file streams.

---
*PR created automatically by Jules for task [4426898799799205640](https://jules.google.com/task/4426898799799205640) started by @vamzi*