### PR TITLE
🛡️ Sentinel: add X-Content-Type-Options nosniff header to file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -323,7 +323,10 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
-        let nosniff = resp.headers().get(http::header::X_CONTENT_TYPE_OPTIONS).unwrap();
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
         assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");

--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -304,7 +308,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ok_response_carries_sha256_header() {
+    async fn ok_response_carries_security_headers() {
         let blob = FileBlob {
             bytes: Bytes::from_static(b"abc"),
             sha256: String::from(
@@ -319,6 +323,8 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
+        let nosniff = resp.headers().get(http::header::X_CONTENT_TYPE_OPTIONS).unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
     }


### PR DESCRIPTION
### 🛡️ Sentinel Security Enhancement

- **Severity:** ENHANCEMENT / LOW
- **💡 Vulnerability / Enhancement:** The ephemeral file server spawned by `oh send` serves file responses as `application/octet-stream` without setting `X-Content-Type-Options: nosniff`.
- **🎯 Impact:** Browsers or clients that perform MIME-type sniffing could potentially execute HTML/JS embedded within transferred files if loaded in a browser context.
- **🔧 Fix:** Added `X-Content-Type-Options: nosniff` header to `build_ok_response()` in `crates/openhost-cli/src/file_server.rs`.
- **✅ Verification:** Updated `file_server` unit tests (`ok_response_carries_security_headers`) to assert that `X-Content-Type-Options: nosniff` is included in all successful file responses. All workspace tests passed.

---
*PR created automatically by Jules for task [12388125708193880710](https://jules.google.com/task/12388125708193880710) started by @vamzi*