### PR TITLE
🛡️ Sentinel: add X-Content-Type-Options nosniff header to CLI file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -319,6 +323,11 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
     }


### PR DESCRIPTION
### 🛡️ Sentinel Security Enhancement

**Vulnerability:** Absence of `X-Content-Type-Options: nosniff` header on responses served by the CLI file server.
**Impact:** Browsers downloading file streams served by `oh send` could perform MIME-type sniffing, potentially interpreting binary/untrusted content as executable code or HTML.
**Fix:** Explicitly set `X-Content-Type-Options: nosniff` in `build_ok_response` within `crates/openhost-cli/src/file_server.rs`.
**Verification:** Added unit test `ok_response_carries_sha256_header` assertion for `X-Content-Type-Options` and verified with `cargo test -p openhost-cli`.

---
*PR created automatically by Jules for task [3927429069090006926](https://jules.google.com/task/3927429069090006926) started by @vamzi*