### PR TITLE
⚡ Bolt: optimize MailboxKey::seal in-place encryption

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,17 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Performance optimization: pre-allocate output buffer for nonce + ciphertext + tag
+        // and encrypt in-place to avoid intermediate heap allocations and extra memory copies.
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(&tag);
         Ok(out)
     }
 


### PR DESCRIPTION
⚡ Bolt: optimize MailboxKey::seal in-place encryption

💡 What:
Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to use `encrypt_in_place_detached` from `chacha20poly1305::aead::AeadInPlace` into a pre-allocated output vector (`MAILBOX_NONCE_LEN + plaintext.len() + 16`).

🎯 Why:
Previously, `cipher.encrypt()` allocated a separate heap vector for the ciphertext and authentication tag, which was then copied into another output buffer alongside the 12-byte nonce. This resulted in unnecessary heap allocations and redundant memory copying per sealed envelope.

📊 Impact:
Eliminates 1 heap allocation and 1 redundant memcpy per sealed envelope operation, reducing memory overhead and CPU cycles during peer envelope sealing.

🔬 Measurement:
Verified through `cargo test -p openhost-peer` and `cargo test --workspace` that all unit and integration tests for envelope sealing, opening, and tampering detection pass as expected.

---
*PR created automatically by Jules for task [1051430351701282883](https://jules.google.com/task/1051430351701282883) started by @vamzi*