### PR TITLE
🛡️ Sentinel: Fix RFC 7230 §3.2.4 header whitespace rejection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Strict Compliance with RFC 7230 §3.2.4 Header Whitespace
+**Vulnerability:** Accepting HTTP requests with whitespace surrounding header names (e.g. `Host : example`) can lead to HTTP Request Smuggling or header smuggling if proxy and upstream parsers handle whitespace differently.
+**Learning:** Hand-rolled HTTP request line/header parsers must explicitly validate that no whitespace exists before the header name or between the header name and colon, as `trim()` silently accepts non-compliant whitespace.
+**Prevention:** Reject any header line where the slice before the colon contains whitespace, and trim only OWS (`[' ', '\t']`) from the header value.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,16 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name_raw = &line[..colon];
+        // RFC 7230 §3.2.4: No whitespace is allowed between the header field name and colon, or before the header field name.
+        if name_raw.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+            return Err(ForwardError::HeadParse(
+                "whitespace surrounding header name is forbidden",
+            ));
+        }
+        let name = name_raw;
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value and trailing value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +768,17 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_whitespace_surrounding_header_name() {
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw_leading = b"GET / HTTP/1.1\r\n Host: example.com\r\n\r\n";
+        let err_leading = parse_request_head(raw_leading).unwrap_err();
+        assert!(matches!(err_leading, ForwardError::HeadParse(_)));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Hand-rolled HTTP request header parser allowed whitespace surrounding header field names (e.g., `Host : example.com`).
🎯 Impact: HTTP Request Smuggling or proxy desynchronization attacks when openhostd parses headers differently than upstream HTTP servers.
🔧 Fix: Enforced RFC 7230 §3.2.4 compliance by explicitly rejecting header lines containing whitespace surrounding or preceding the header name before the colon.
✅ Verification: Added unit test `parse_request_head_rejects_whitespace_surrounding_header_name` and verified all tests pass.

---
*PR created automatically by Jules for task [15657181645648072230](https://jules.google.com/task/15657181645648072230) started by @vamzi*