### PR TITLE
⚡ Bolt: optimize MailboxKey::seal buffer allocation

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,19 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Single allocation: reserve exact capacity for nonce (12 bytes) + plaintext + Poly1305 tag (16 bytes).
+        // This eliminates intermediate heap allocations and memcpy operations from `cipher.encrypt()`.
+        let total_len = MAILBOX_NONCE_LEN + plaintext.len() + 16;
+        let mut out = Vec::with_capacity(total_len);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
+
         Ok(out)
     }
 


### PR DESCRIPTION
⚡ Bolt: optimize MailboxKey::seal buffer allocation

💡 What:
Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to use `AeadInPlace::encrypt_in_place_detached` on a single pre-allocated `Vec<u8>` output buffer.

🎯 Why:
Previously, `MailboxKey::seal` called `cipher.encrypt()`, which allocated a separate `Vec<u8>` on the heap for the ciphertext + tag, followed by allocating a second vector `out` and copying both the nonce and ciphertext into it. This created redundant heap allocations and buffer copies during mailbox sealing operations.

📊 Impact:
Eliminates 1 intermediate heap allocation and 1 buffer copy on every `MailboxKey::seal` call, reducing memory allocation latency and pressure.

🔬 Measurement:
Verified via `cargo test -p openhost-peer` and workspace-wide `cargo test`. All AEAD roundtrip tests and tampered ciphertext/nonce unit tests pass cleanly.

---
*PR created automatically by Jules for task [7955860625367181479](https://jules.google.com/task/7955860625367181479) started by @vamzi*