### PR TITLE
🛡️ Sentinel: Add X-Content-Type-Options nosniff header to CLI file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -321,5 +325,21 @@ mod tests {
         );
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
+    }
+
+    #[test]
+    fn ok_response_carries_nosniff_header() {
+        let blob = FileBlob {
+            bytes: Bytes::from_static(b"test"),
+            sha256: String::from("0"),
+            filename: "file.bin".to_owned(),
+            path: PathBuf::new(),
+        };
+        let resp = build_ok_response(&blob);
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
     }
 }


### PR DESCRIPTION
### 💡 Vulnerability / Security Concern
The ephemeral HTTP server spawned by `oh send` serves files with `Content-Type: application/octet-stream`, but lacked the `X-Content-Type-Options: nosniff` header. Downstream web clients or browsers receiving file streams without this header might attempt MIME-type sniffing, potentially executing binary or script content in sensitive contexts.

### 🔧 Security Fix
Added `X-Content-Type-Options: nosniff` to `build_ok_response` in `crates/openhost-cli/src/file_server.rs` to enforce strict MIME handling on served files.

### ✅ Verification
- Added unit test `ok_response_carries_nosniff_header` in `crates/openhost-cli/src/file_server.rs`.
- Ran `cargo test` across all workspace crates and confirmed all tests pass.
- Verified with `cargo clippy` and `cargo fmt`.

---
*PR created automatically by Jules for task [12460845321471485060](https://jules.google.com/task/12460845321471485060) started by @vamzi*