### PR TITLE
⚡ Bolt: optimize MailboxKey::seal in openhost-peer with in-place AEAD encryption

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,17 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Pre-allocate a single output buffer for nonce (12B) + plaintext + Poly1305 tag (16B),
+        // avoiding secondary heap allocation and memory copy overhead from `encrypt`.
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
         Ok(out)
     }
 


### PR DESCRIPTION
### 💡 What
Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to perform in-place AEAD encryption using `AeadInPlace::encrypt_in_place_detached`.

### 🎯 Why
Previously, `MailboxKey::seal` called `cipher.encrypt()`, which allocated a temporary `Vec` for the ciphertext and Poly1305 authentication tag before copying those bytes into a second newly-allocated output buffer.

### 📊 Impact
- Reduces heap allocations per `seal` call from 2 down to 1.
- Eliminates intermediate memory copying overhead by encrypting directly into the pre-allocated output `Vec`.

### 🔬 Measurement
Run `cargo test -p openhost-peer` to verify that all unit tests and AEAD roundtrip tests pass.

---
*PR created automatically by Jules for task [15094454965298517655](https://jules.google.com/task/15094454965298517655) started by @vamzi*