### PR TITLE
⚡ Bolt: optimize MailboxKey::seal to eliminate intermediate heap allocation

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,17 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Single-buffer allocation: reserve space for nonce(12) + plaintext + Poly1305 tag(16)
+        // to encrypt directly in-place, avoiding an intermediate ciphertext Vec allocation.
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, &[], &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
         Ok(out)
     }
 


### PR DESCRIPTION
💡 What: Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` by utilizing `chacha20poly1305::aead::AeadInPlace::encrypt_in_place_detached` directly on a pre-allocated single `Vec<u8>` output buffer (`Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16)`).

🎯 Why: Previously, `cipher.encrypt` allocated a separate `Vec<u8>` for ciphertext before copying those bytes into the combined envelope buffer `out`, causing unnecessary heap allocation and redundant byte copying during envelope sealing for pkarr rendezvous records.

📊 Impact: Eliminates an intermediate heap allocation and memory copy for every sealed envelope, reducing allocator contention during pairing/rendezvous record publishing.

🔬 Measurement: Verified with `cargo test --workspace` across all crates to ensure encrypt/decrypt roundtrips and envelope framing remain completely intact.

---
*PR created automatically by Jules for task [7878578227455508370](https://jules.google.com/task/7878578227455508370) started by @vamzi*