### PR TITLE
🛡️ Sentinel: Fix file creation permission race condition

### DIFF
--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -228,18 +228,20 @@ pub async fn run(file: PathBuf) -> Result<()> {
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
     use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut f = options
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
     f.write_all(seed).await?;
     f.flush().await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -138,19 +138,24 @@ pub async fn force_rotate(path: &Path) -> Result<DtlsCertificate, CertError> {
 }
 
 async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             tokio::fs::create_dir_all(parent).await?;
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    let mut f = options.open(&tmp).await?;
+    f.write_all(pem.as_bytes()).await?;
+    f.flush().await?;
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -105,16 +105,19 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// atomic on POSIX; on Windows the final mode is whatever the parent ACL
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use tokio::io::AsyncWriteExt;
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
-
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
-
+    let mut f = options.open(&tmp).await?;
+    f.write_all(bytes).await?;
+    f.flush().await?;
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -161,6 +161,7 @@ pub fn load(path: &Path) -> Result<PairingDb, PairingError> {
 /// Atomically overwrite the DB at `path`. On Unix the final file mode
 /// is 0600; on Windows the parent directory's ACL applies.
 pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
+    use std::io::Write;
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent)?;
@@ -168,14 +169,17 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
-
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    let mut f = options.open(&tmp)?;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
### 🚨 Severity
MEDIUM / HIGH

### 💡 Vulnerability
Previously, sensitive files (Ed25519 identity key seeds, DTLS certificates, and pairing allowlists) were created with default umask file creation modes and subsequently restricted to mode `0600` via `set_permissions`. This left a brief Time-Of-Check To Time-Of-Use (TOCTOU) window during file creation where another local user could potentially open or inspect sensitive key material or client allowlists before permissions were tightened.

### 🎯 Impact
Local attackers sharing the host system could briefly read sensitive ephemeral key material or configuration data during file creation.

### 🔧 Fix
Refactored file creation routines across `openhost-cli` and `openhost-daemon` to set mode `0o600` atomically at `open()` creation time on Unix platforms using `OpenOptionsExt::mode(0o600)`.

### ✅ Verification
All workspace unit and integration tests (`cargo test --workspace`) as well as format (`cargo fmt --check`) and clippy (`cargo clippy --workspace --all-targets -- -D warnings`) pass cleanly.

---
*PR created automatically by Jules for task [14682636921075120421](https://jules.google.com/task/14682636921075120421) started by @vamzi*