### PR TITLE
🛡️ Sentinel: add X-Content-Type-Options nosniff header

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -301,6 +305,22 @@ mod tests {
         assert!(!filename_val.contains('/'));
         assert!(!filename_val.contains(';'));
         assert!(!filename_val.contains(' '));
+    }
+
+    #[test]
+    fn ok_response_carries_nosniff_header() {
+        let blob = FileBlob {
+            bytes: Bytes::from_static(b"abc"),
+            sha256: String::from("0"),
+            filename: "abc.txt".to_owned(),
+            path: PathBuf::new(),
+        };
+        let resp = build_ok_response(&blob);
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .expect("nosniff header should be present");
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
     }
 
     #[tokio::test]


### PR DESCRIPTION
🛡️ Sentinel: add X-Content-Type-Options nosniff header

Add X-Content-Type-Options: nosniff header to responses in openhost-cli file_server to prevent MIME sniffing of binary streams by browsers/clients.

---
*PR created automatically by Jules for task [4876333526062646641](https://jules.google.com/task/4876333526062646641) started by @vamzi*