### PR TITLE
⚡ Bolt: optimize MailboxKey::seal to avoid intermediate heap allocation

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,21 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // BOLT PERFORMANCE OPTIMIZATION:
+        // Allocate exact capacity for envelope: nonce (12B) + plaintext + Poly1305 tag (16B).
+        // Using in-place encryption directly in the output buffer avoids intermediate heap allocations
+        // and extra memory copying for ciphertext.
+        const TAG_LEN: usize = 16;
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + TAG_LEN);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
+
         Ok(out)
     }
 


### PR DESCRIPTION
💡 What: Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` by utilizing `chacha20poly1305::aead::AeadInPlace::encrypt_in_place_detached` on a single pre-allocated `Vec<u8>` output buffer.

🎯 Why: Previously, `MailboxKey::seal` called `cipher.encrypt()`, which allocated an intermediate `Vec<u8>` for ciphertext before copying it into the final output vector.

📊 Impact: Eliminates an intermediate heap allocation and memory copy on every rendezvous record sealing operation in `openhost-peer`.

🔬 Measurement: Verified with `cargo test -p openhost-peer` and workspace-wide `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [12572847829852064370](https://jules.google.com/task/12572847829852064370) started by @vamzi*