### PR TITLE
🛡️ Sentinel: Fix local TOCTOU file creation permission race condition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Atomic Mode-0600 Creation for Sensitive Files
+**Vulnerability:** Opening or creating files (seeds, DTLS certificates, identity keys, allowlists) with default `File::create` or `fs::write` prior to calling `set_permissions` leaves a TOCTOU window where local unprivileged users can read sensitive material before permissions are tightened.
+**Learning:** Functions like `std::fs::write` or `File::create` apply the process umask, which typically results in `0644` or `0666` modes until a subsequent `set_permissions` async or sync call completes.
+**Prevention:** Use `OpenOptions` with `OpenOptionsExt::mode(0o600)` under `#[cfg(unix)]` at file creation time so the file descriptor is opened with restricted mode atomically upon creation.

--- a/crates/openhost-cli/src/send.rs
+++ b/crates/openhost-cli/src/send.rs
@@ -228,18 +228,20 @@ pub async fn run(file: PathBuf) -> Result<()> {
 
 async fn write_seed(path: &Path, seed: &[u8; 32]) -> Result<()> {
     use tokio::io::AsyncWriteExt;
-    let mut f = tokio::fs::File::create(path)
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut f = options
+        .open(path)
         .await
         .with_context(|| format!("create identity file: {}", path.display()))?;
     f.write_all(seed).await?;
     f.flush().await?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(path, perms).await?;
-    }
     Ok(())
 }
 

--- a/crates/openhost-daemon/src/dtls_cert.rs
+++ b/crates/openhost-daemon/src/dtls_cert.rs
@@ -144,13 +144,20 @@ async fn write_pem_bundle(path: &Path, pem: &str) -> std::io::Result<()> {
         }
     }
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, pem).await?;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    let mut f = options.open(&tmp).await?;
+    use tokio::io::AsyncWriteExt;
+    f.write_all(pem.as_bytes()).await?;
+    f.flush().await?;
+
     tokio::fs::rename(&tmp, path).await
 }
 

--- a/crates/openhost-daemon/src/identity_store.rs
+++ b/crates/openhost-daemon/src/identity_store.rs
@@ -106,14 +106,19 @@ pub async fn load_or_create(store: &dyn KeyStore) -> DaemonResult<SigningKey> {
 /// grants.
 async fn write_mode_0600(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     let tmp = path.with_extension("tmp");
-    tokio::fs::write(&tmp, bytes).await?;
 
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        tokio::fs::set_permissions(&tmp, perms).await?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    let mut f = options.open(&tmp).await?;
+    use tokio::io::AsyncWriteExt;
+    f.write_all(bytes).await?;
+    f.flush().await?;
 
     tokio::fs::rename(&tmp, path).await
 }

--- a/crates/openhost-daemon/src/pairing.rs
+++ b/crates/openhost-daemon/src/pairing.rs
@@ -168,14 +168,19 @@ pub fn save_atomic(path: &Path, db: &PairingDb) -> Result<(), PairingError> {
     }
     let body = toml::to_string_pretty(db)?;
     let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, body.as_bytes())?;
 
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        std::fs::set_permissions(&tmp, perms)?;
+        #[allow(unused_imports)]
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
     }
+    let mut f = options.open(&tmp)?;
+    use std::io::Write;
+    f.write_all(body.as_bytes())?;
+    f.flush()?;
 
     std::fs::rename(&tmp, path)?;
     Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Creating sensitive files (seeds, DTLS certificates, identity keys, allowlists) using default `File::create` or `fs::write` prior to `set_permissions` opens files with permissive default umask modes (e.g. 0644/0666) before tightening them to 0600. Local unprivileged users can read sensitive keys during this window.
🎯 Impact: Local process/user eavesdropping or secret extraction on shared Unix host environments during file creation.
🔧 Fix: Updated `write_seed`, `save_atomic`, `write_pem_bundle`, and `write_mode_0600` to configure `options.mode(0o600)` at creation time under `#[cfg(unix)]`.
✅ Verification: Ran `cargo test --package openhost-cli --package openhost-daemon` and confirmed all file creation permission tests pass.

---
*PR created automatically by Jules for task [4249678676747936425](https://jules.google.com/task/4249678676747936425) started by @vamzi*