### PR TITLE
🛡️ Sentinel: Add X-Content-Type-Options nosniff header to CLI file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -184,6 +184,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_static("application/octet-stream"),
     );
     headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
         http::header::CONTENT_LENGTH,
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
@@ -318,6 +322,12 @@ mod tests {
         assert_eq!(
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        );
+        assert_eq!(
+            resp.headers()
+                .get(http::header::X_CONTENT_TYPE_OPTIONS)
+                .unwrap(),
+            "nosniff"
         );
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");


### PR DESCRIPTION
🛡️ Sentinel: Add X-Content-Type-Options nosniff header to CLI file server

🚨 Severity: MEDIUM
💡 Vulnerability: Binary streams served by CLI file server lacked explicit X-Content-Type-Options header.
🎯 Impact: Browsers receiving file responses could perform MIME-type sniffing, potentially executing unexpected content types.
🔧 Fix: Add X-Content-Type-Options: nosniff header in build_ok_response in file_server.rs.
✅ Verification: Verified via unit test ok_response_carries_sha256_header checking header presence, and cargo test --workspace.

---
*PR created automatically by Jules for task [16949652647645940382](https://jules.google.com/task/16949652647645940382) started by @vamzi*