### PR TITLE
⚡ Bolt: optimize MailboxKey::seal with in-place AEAD encryption

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -123,15 +123,19 @@ impl MailboxKey {
     /// does not fail under normal use.
     pub fn seal(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
         let cipher = ChaCha20Poly1305::new(Key::from_slice(&self.aead_key));
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
-        let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        // Performance: encrypt in place over `out[MAILBOX_NONCE_LEN..]` buffer directly
+        // to avoid intermediate `Vec<u8>` allocation and slice copying.
+        let nonce = Nonce::from_slice(&nonce_bytes);
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
         Ok(out)
     }
 


### PR DESCRIPTION
💡 What: Refactored `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to use `encrypt_in_place_detached` on a single pre-allocated `Vec<u8>` output buffer containing `nonce || plaintext`.

🎯 Why: Previously, `MailboxKey::seal` called `cipher.encrypt()`, which allocated an internal `Vec<u8>` for ciphertext before copying it into `out`. This caused 2 heap allocations and an extra byte slice copy per sealed envelope.

📊 Impact: Reduces heap allocations per sealed mailbox envelope from 2 to 1 and eliminates intermediate slice copying during ChaCha20-Poly1305 encryption.

🔬 Measurement: Ran `cargo test -p openhost-peer` and `cargo test --workspace` to verify that all envelope seal/open unit tests and end-to-end tests pass.

---
*PR created automatically by Jules for task [10078566533872496062](https://jules.google.com/task/10078566533872496062) started by @vamzi*