### PR TITLE
🛡️ Sentinel: add X-Content-Type-Options: nosniff header to file server

### DIFF
--- a/crates/openhost-cli/src/file_server.rs
+++ b/crates/openhost-cli/src/file_server.rs
@@ -188,6 +188,10 @@ fn build_ok_response(blob: &FileBlob) -> Response<Full<Bytes>> {
         HeaderValue::from_str(&blob.bytes.len().to_string())
             .expect("numeric length is a valid header value"),
     );
+    headers.insert(
+        http::header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
     // RFC 6266 filename parameter. We ASCII-sanitise aggressively —
     // the filename is attacker-controlled in principle, and most
     // receivers will sniff Content-Disposition before writing to
@@ -319,6 +323,11 @@ mod tests {
             sha.to_str().unwrap(),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
         );
+        let nosniff = resp
+            .headers()
+            .get(http::header::X_CONTENT_TYPE_OPTIONS)
+            .unwrap();
+        assert_eq!(nosniff.to_str().unwrap(), "nosniff");
         let body = collect_body(resp).await;
         assert_eq!(body.as_ref(), b"abc");
     }


### PR DESCRIPTION
🛡️ Sentinel: add X-Content-Type-Options: nosniff header to CLI file server

- 💡 Security Enhancement: Set `X-Content-Type-Options: nosniff` header on successful file responses from `file_server.rs`.
- 🎯 Impact: Prevents browsers from performing MIME-type sniffing on served binary streams (`application/octet-stream`), mitigating potential MIME-confusion / XSS vectors.
- 🔧 Fix: Added `http::header::X_CONTENT_TYPE_OPTIONS` header set to `"nosniff"` in `build_ok_response`.
- ✅ Verification: Added unit test assertion in `ok_response_carries_sha256_header` test. Ran `cargo test --package openhost-cli`.

---
*PR created automatically by Jules for task [9419834353498224606](https://jules.google.com/task/9419834353498224606) started by @vamzi*