### PR TITLE
⚡ Bolt: eliminate string allocations in HTTP response head encoding

### DIFF
--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -462,7 +462,12 @@ fn encode_websocket_response_head(
     }
     let reason = status.canonical_reason().unwrap_or("Switching Protocols");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Construct response status line directly to avoid intermediate String allocations via format!.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.extend_from_slice(b" ");
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");
@@ -517,14 +522,20 @@ fn encode_response_head(
     // might have sent `Transfer-Encoding: chunked` (now stripped);
     // without an accurate Content-Length the openhost client can't
     // frame-split the response stream.
+    // Construct HeaderValue directly from u64 to avoid string parsing/allocations.
     headers.insert(
         http::header::CONTENT_LENGTH,
-        HeaderValue::from_str(&body_len.to_string()).expect("body_len is ASCII digits"),
+        HeaderValue::from(body_len as u64),
     );
 
     let reason = status.canonical_reason().unwrap_or("Unknown");
     let mut out = Vec::with_capacity(128 + headers.len() * 64);
-    out.extend_from_slice(format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason).as_bytes());
+    // Construct response status line directly to avoid intermediate String allocations via format!.
+    out.extend_from_slice(b"HTTP/1.1 ");
+    out.extend_from_slice(status.as_str().as_bytes());
+    out.extend_from_slice(b" ");
+    out.extend_from_slice(reason.as_bytes());
+    out.extend_from_slice(b"\r\n");
     for (name, value) in &headers {
         out.extend_from_slice(name.as_str().as_bytes());
         out.extend_from_slice(b": ");


### PR DESCRIPTION
💡 What: Replaced `format!("HTTP/1.1 {} {}\r\n", status.as_u16(), reason)` with sequential `extend_from_slice` calls using `status.as_str()` and `reason`, and replaced `HeaderValue::from_str(&body_len.to_string())` with `HeaderValue::from(body_len as u64)`.
🎯 Why: Constructing HTTP response status lines with `format!` and `Content-Length` headers via `.to_string()` created unnecessary heap-allocated strings on every forwarded HTTP and WebSocket response.
📊 Impact: Eliminates 2 intermediate heap allocations and string parsing per HTTP response head sent by the daemon forwarder.
🔬 Measurement: Verified with unit tests (`cargo test -p openhost-daemon`) and `cargo clippy`.

---
*PR created automatically by Jules for task [17483636155209234011](https://jules.google.com/task/17483636155209234011) started by @vamzi*