### PR TITLE
⚡ Bolt: Optimize MailboxKey::seal with in-place AEAD encryption

### DIFF
--- a/crates/openhost-peer/src/mailbox.rs
+++ b/crates/openhost-peer/src/mailbox.rs
@@ -36,7 +36,7 @@
 
 use crate::code::PairingCode;
 use crate::error::{PeerError, Result};
-use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::aead::{Aead, AeadInPlace, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
 use hkdf::Hkdf;
@@ -126,12 +126,18 @@ impl MailboxKey {
         let mut nonce_bytes = [0u8; MAILBOX_NONCE_LEN];
         rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, plaintext)
-            .map_err(|_| PeerError::Crypto("seal"))?;
-        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + ciphertext.len());
+
+        // Pre-allocate exact buffer layout: nonce (12 bytes) || ciphertext (N bytes) || tag (16 bytes).
+        // Using in-place encryption avoids allocating an intermediate Vec for ciphertext and tag.
+        let mut out = Vec::with_capacity(MAILBOX_NONCE_LEN + plaintext.len() + 16);
         out.extend_from_slice(&nonce_bytes);
-        out.extend_from_slice(&ciphertext);
+        out.extend_from_slice(plaintext);
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[MAILBOX_NONCE_LEN..])
+            .map_err(|_| PeerError::Crypto("seal"))?;
+        out.extend_from_slice(tag.as_slice());
+
         Ok(out)
     }
 


### PR DESCRIPTION
### 💡 What
Optimized `MailboxKey::seal` in `crates/openhost-peer/src/mailbox.rs` to use `AeadInPlace::encrypt_in_place_detached` on a single pre-allocated `Vec<u8>` buffer (`12 + plaintext.len() + 16` bytes).

### 🎯 Why
Previously, `cipher.encrypt(...)` created an intermediate `Vec<u8>` allocation for the ciphertext and auth tag, which was then appended to the final envelope `Vec<u8>`, resulting in 2 heap allocations and redundant data copying per sealed mailbox message.

### 📊 Impact
Reduces heap allocations per `MailboxKey::seal` call from 2 down to 1 and eliminates redundant copying of encrypted bytes.

### 🔬 Measurement
All unit tests in `openhost-peer` (`cargo test --package openhost-peer`) pass without issue, confirming exact behavioral and cryptographic compatibility.

---
*PR created automatically by Jules for task [11220252730950914056](https://jules.google.com/task/11220252730950914056) started by @vamzi*