### PR TITLE
🛡️ Sentinel: [HIGH] Fix HTTP request smuggling via header whitespace (RFC 7230 §3.2.4)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-28 - Strict Compliance with RFC 7230 §3.2.4 Header Name Parsing
+**Vulnerability:** Header field names containing whitespace (e.g. space before colon `Host : example` or leading space ` Host: example`) were silently trimmed during request parsing. This tolerance could allow HTTP Request Smuggling or Header Injection when proxying requests upstream.
+**Learning:** Silently trimming header field names instead of strictly rejecting whitespace before or around header names creates a desynchronization gap between front-end and back-end parsers.
+**Prevention:** Strictly reject any HTTP request header field name that contains space or tab characters before parsing or forwarding.

--- a/crates/openhost-daemon/src/forward.rs
+++ b/crates/openhost-daemon/src/forward.rs
@@ -383,9 +383,15 @@ fn parse_request_head(bytes: &[u8]) -> Result<(Method, String, HeaderMap), Forwa
         let colon = line
             .find(':')
             .ok_or(ForwardError::HeadParse("header line missing ':'"))?;
-        let name = line[..colon].trim();
-        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` between `:` and the value.
-        let value = line[colon + 1..].trim_start_matches([' ', '\t']);
+        let name = &line[..colon];
+        // RFC 7230 §3.2.4: Reject whitespace in/around header name to prevent smuggling.
+        if name.bytes().any(|b| b == b' ' || b == b'\t') {
+            return Err(ForwardError::HeadParse(
+                "header field name contains whitespace",
+            ));
+        }
+        // RFC 7230 §3.2.4: `OWS = *( SP / HTAB )` surrounding the value.
+        let value = line[colon + 1..].trim_matches([' ', '\t']);
         let header_name = HeaderName::from_bytes(name.as_bytes())
             .map_err(|_| ForwardError::HeadParse("invalid header name"))?;
         let header_value = HeaderValue::from_str(value)
@@ -761,6 +767,18 @@ mod tests {
         let raw = b"GET / HTTP/1.0\r\n\r\n";
         let err = parse_request_head(raw).unwrap_err();
         assert!(matches!(err, ForwardError::HeadParse(_)));
+    }
+
+    #[test]
+    fn parse_request_head_rejects_header_name_with_whitespace() {
+        // RFC 7230 §3.2.4: Reject space before colon or leading space in header name
+        let raw = b"GET / HTTP/1.1\r\nHost : example.com\r\n\r\n";
+        let err = parse_request_head(raw).unwrap_err();
+        assert!(matches!(err, ForwardError::HeadParse(_)));
+
+        let raw_leading = b"GET / HTTP/1.1\r\n Host: example.com\r\n\r\n";
+        let err_leading = parse_request_head(raw_leading).unwrap_err();
+        assert!(matches!(err_leading, ForwardError::HeadParse(_)));
     }
 
     #[test]


### PR DESCRIPTION
### 🛡️ Sentinel Security Fix

* **🚨 Severity:** HIGH
* **💡 Vulnerability:** The HTTP request head parser previously trimmed whitespace around header names (e.g. accepting `Host : example` or ` Host: example`), violating RFC 7230 §3.2.4.
* **🎯 Impact:** Silently permitting whitespace in header field names can lead to HTTP Request Smuggling / desynchronization vulnerabilities when proxying requests between intermediaries and upstreams.
* **🔧 Fix:** Reject any header line where the field name contains space or tab characters in `crates/openhost-daemon/src/forward.rs` and trim OWS from values using `.trim_matches([' ', '\t'])`.
* **✅ Verification:** Added unit test `parse_request_head_rejects_header_name_with_whitespace` and ran `cargo test --workspace`.

---
*PR created automatically by Jules for task [3836847702042638001](https://jules.google.com/task/3836847702042638001) started by @vamzi*